### PR TITLE
Fix for Wheezy and Jessie being removed for mirrors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.7-slim-jessie
+FROM python:3.6.8-slim-jessie
 
 RUN apt-get update && apt-get install -y \
         git \


### PR DESCRIPTION
Build fails because of
https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html