### PR TITLE
Switch to public docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ git clone git@gitlab.clearmatics.net:ar/zeth.git
 cd zeth
 git submodule update --init --recursive
 
-docker build -t zeth-dev .
-docker run -ti -p 50051:50051 --name zeth zeth-dev
+docker pull clearmatics/zeth-dev:latest 
+docker run -ti -p 50051:50051 --name zeth clearmatics/zeth-dev:latest
 
 ## All the commands below are ran in the docker container
 # Configure your environment


### PR DESCRIPTION
Update the docker instructions to use pre-built image available at Docker Hub. 