### PR TITLE
Removed google duplicated dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "depends/libsnark"]
     path = depends/libsnark
     url = https://github.com/clearmatics/libsnark.git 
-[submodule "depends/googletest"]
-    path = depends/googletest
-    url = https://github.com/google/googletest.git
 [submodule "depends/libsodium"]
 	path = depends/libsodium
 	url = https://github.com/jedisct1/libsodium.git


### PR DESCRIPTION
Fixing #10
In case the dependency has been initialized the user will see a `depends/googletest untracked` folder that has to delete manually.

https://gist.github.com/myusuf3/7f645819ded92bda6677