### PR TITLE
IK-CCA Issue

### DIFF
--- a/pyClient/README.md
+++ b/pyClient/README.md
@@ -20,6 +20,12 @@ python -m venv zeth-devenv
 source zeth-devenv/bin/activate
 ```
 
+### Update pip to the latest verstion
+
+```
+pip install --upgrade pip
+```
+
 ### Install the dependencies
 
 ```

--- a/pyClient/README.md
+++ b/pyClient/README.md
@@ -20,7 +20,7 @@ python -m venv zeth-devenv
 source zeth-devenv/bin/activate
 ```
 
-### Update pip to the latest verstion
+### Update pip to the latest version
 
 ```
 pip install --upgrade pip

--- a/pyClient/requirements.txt
+++ b/pyClient/requirements.txt
@@ -17,6 +17,7 @@ idna==2.8
 lru-dict==1.1.6
 parsimonious==0.8.1
 protobuf==3.6.1
+py_ecc==1.7.1
 py-solc-x==0.1.1
 pycryptodome==3.7.3
 pynacl==1.3.0
@@ -28,5 +29,3 @@ toolz==0.9.0
 urllib3==1.24.2
 web3==4.8.2
 websockets==6.0
-py_ecc==1.7.1
-wheel==0.33.4

--- a/pyClient/requirements.txt
+++ b/pyClient/requirements.txt
@@ -8,7 +8,7 @@ eth-hash==0.2.0
 eth-keyfile==0.5.1
 eth-keys==0.2.1
 eth-rlp==0.1.2
-eth-typing==2.0.0
+eth-typing==2.1.0
 eth-utils==1.4.1
 grpcio==1.18.0
 grpcio-tools==1.18.0

--- a/pyClient/requirements.txt
+++ b/pyClient/requirements.txt
@@ -19,6 +19,7 @@ parsimonious==0.8.1
 protobuf==3.6.1
 py-solc-x==0.1.1
 pycryptodome==3.7.3
+pynacl==1.3.0
 requests==2.21.0
 rlp==1.1.0
 semantic-version==2.6.0
@@ -28,3 +29,4 @@ urllib3==1.24.2
 web3==4.8.2
 websockets==6.0
 py_ecc==1.7.1
+wheel==0.33.4

--- a/pyClient/testERCTokenMixing.py
+++ b/pyClient/testERCTokenMixing.py
@@ -164,8 +164,9 @@ if __name__ == '__main__':
 
     # Alice sees a deposit and tries to decrypt the ciphertexts to see if she was the recipient
     # But she wasn't the recipient (Bob was), so she fails to decrypt
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, pk_sender_bob_to_bob, keystore["Alice"]["AddrSk"]["encSK"], "alice")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, pk_sender_bob_to_bob, keystore["Alice"]["AddrSk"]["encSK"], "alice")
+    alice_sk = zethUtils.get_private_key_from_bytes(keystore["Alice"]["AddrSk"]["encSK"])
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, pk_sender_bob_to_bob, alice_sk, "alice")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, pk_sender_bob_to_bob, alice_sk, "alice")
     assert (recovered_plaintext1 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
     assert (recovered_plaintext2 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
 
@@ -175,7 +176,8 @@ if __name__ == '__main__':
     mk_byte_tree = get_merkle_tree(mixer_instance)
     mk_path = zethUtils.compute_merkle_path(cm_address_bob_to_bob1, mk_tree_depth, mk_byte_tree)
     # Bob decrypts one of the note he previously received (useless here but useful if the payment came from someone else)
-    input_note_json = json.loads(zethUtils.decrypt(ciphertext_bob_to_bob1, keystore["Bob"]["AddrPk"]["encPK"], keystore["Bob"]["AddrSk"]["encSK"]))
+    bob_sk = zethUtils.get_private_key_from_bytes(keystore["Bob"]["AddrSk"]["encSK"])
+    input_note_json = json.loads(zethUtils.decrypt(ciphertext_bob_to_bob1, pk_sender_bob_to_bob, bob_sk))
     input_note_bob_to_charlie = zethGRPC.zethNoteObjFromParsed(input_note_json)
     # Execution of the transfer
     result_transfer_bob_to_charlie = zethTest.bob_to_charlie(
@@ -225,8 +227,9 @@ if __name__ == '__main__':
     )
 
     # Charlie tries to decrypt the ciphertexts from Bob's previous transaction
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, pk_sender_bob_to_charlie, keystore["Charlie"]["AddrSk"]["encSK"], "charlie")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, pk_sender_bob_to_charlie, keystore["Charlie"]["AddrSk"]["encSK"], "charlie")
+    charlie_sk = zethUtils.get_private_key_from_bytes(keystore["Charlie"]["AddrSk"]["encSK"])
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, pk_sender_bob_to_charlie, charlie_sk, "charlie")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, pk_sender_bob_to_charlie, charlie_sk, "charlie")
     assert (recovered_plaintext1 == ""),"Charlie managed to decrypt a ciphertext that was not encrypted with his key!"
     assert (recovered_plaintext2 != ""),"Charlie should have been able to decrypt the ciphertext that was obtained with his key!"
 

--- a/pyClient/testERCTokenMixing.py
+++ b/pyClient/testERCTokenMixing.py
@@ -163,8 +163,8 @@ if __name__ == '__main__':
 
     # Alice sees a deposit and tries to decrypt the ciphertexts to see if she was the recipient
     # But she wasn't the recipient (Bob was), so she fails to decrypt
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, keystore["Alice"]["AddrSk"]["dk"], "alice")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, keystore["Alice"]["AddrSk"]["dk"], "alice")
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Alice"]["AddrSk"]["privkey"], "alice")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Alice"]["AddrSk"]["privkey"], "alice")
     assert (recovered_plaintext1 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
     assert (recovered_plaintext2 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
 
@@ -174,7 +174,7 @@ if __name__ == '__main__':
     mk_byte_tree = get_merkle_tree(mixer_instance)
     mk_path = zethUtils.compute_merkle_path(cm_address_bob_to_bob1, mk_tree_depth, mk_byte_tree)
     # Bob decrypts one of the note he previously received (useless here but useful if the payment came from someone else)
-    input_note_json = json.loads(zethUtils.decrypt(ciphertext_bob_to_bob1, keystore["Bob"]["AddrSk"]["dk"]))
+    input_note_json = json.loads(zethUtils.decrypt(ciphertext_bob_to_bob1, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Bob"]["AddrSk"]["privkey"]))
     input_note_bob_to_charlie = zethGRPC.zethNoteObjFromParsed(input_note_json)
     # Execution of the transfer
     result_transfer_bob_to_charlie = zethTest.bob_to_charlie(
@@ -223,8 +223,8 @@ if __name__ == '__main__':
     )
 
     # Charlie tries to decrypt the ciphertexts from Bob's previous transaction
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, keystore["Charlie"]["AddrSk"]["dk"], "charlie")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, keystore["Charlie"]["AddrSk"]["dk"], "charlie")
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Charlie"]["AddrSk"]["privkey"], "charlie")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Charlie"]["AddrSk"]["privkey"], "charlie")
     assert (recovered_plaintext1 == ""),"Charlie managed to decrypt a ciphertext that was not encrypted with his key!"
     assert (recovered_plaintext2 != ""),"Charlie should have been able to decrypt the ciphertext that was obtained with his key!"
 

--- a/pyClient/testERCTokenMixing.py
+++ b/pyClient/testERCTokenMixing.py
@@ -163,8 +163,8 @@ if __name__ == '__main__':
 
     # Alice sees a deposit and tries to decrypt the ciphertexts to see if she was the recipient
     # But she wasn't the recipient (Bob was), so she fails to decrypt
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Alice"]["AddrSk"]["privkey"], "alice")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Alice"]["AddrSk"]["privkey"], "alice")
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, keystore["Bob"]["AddrPk"]["encPK"], keystore["Alice"]["AddrSk"]["encSK"], "alice")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, keystore["Bob"]["AddrPk"]["encPK"], keystore["Alice"]["AddrSk"]["encSK"], "alice")
     assert (recovered_plaintext1 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
     assert (recovered_plaintext2 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
 
@@ -174,7 +174,7 @@ if __name__ == '__main__':
     mk_byte_tree = get_merkle_tree(mixer_instance)
     mk_path = zethUtils.compute_merkle_path(cm_address_bob_to_bob1, mk_tree_depth, mk_byte_tree)
     # Bob decrypts one of the note he previously received (useless here but useful if the payment came from someone else)
-    input_note_json = json.loads(zethUtils.decrypt(ciphertext_bob_to_bob1, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Bob"]["AddrSk"]["privkey"]))
+    input_note_json = json.loads(zethUtils.decrypt(ciphertext_bob_to_bob1, keystore["Bob"]["AddrPk"]["encPK"], keystore["Bob"]["AddrSk"]["encSK"]))
     input_note_bob_to_charlie = zethGRPC.zethNoteObjFromParsed(input_note_json)
     # Execution of the transfer
     result_transfer_bob_to_charlie = zethTest.bob_to_charlie(
@@ -194,7 +194,7 @@ if __name__ == '__main__':
     new_merkle_root_bob_to_charlie = result_transfer_bob_to_charlie[2]
     ciphertext_bob_to_charlie1 = result_transfer_bob_to_charlie[3]
     ciphertext_bob_to_charlie2 = result_transfer_bob_to_charlie[4]
-    
+
     # Bob tries to spend `input_note_bob_to_charlie` twice
     result_double_spending = ""
     try:
@@ -223,8 +223,8 @@ if __name__ == '__main__':
     )
 
     # Charlie tries to decrypt the ciphertexts from Bob's previous transaction
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Charlie"]["AddrSk"]["privkey"], "charlie")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Charlie"]["AddrSk"]["privkey"], "charlie")
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, keystore["Bob"]["AddrPk"]["encPK"], keystore["Charlie"]["AddrSk"]["encSK"], "charlie")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, keystore["Bob"]["AddrPk"]["encPK"], keystore["Charlie"]["AddrSk"]["encSK"], "charlie")
     assert (recovered_plaintext1 == ""),"Charlie managed to decrypt a ciphertext that was not encrypted with his key!"
     assert (recovered_plaintext2 != ""),"Charlie should have been able to decrypt the ciphertext that was obtained with his key!"
 

--- a/pyClient/testERCTokenMixing.py
+++ b/pyClient/testERCTokenMixing.py
@@ -162,11 +162,14 @@ if __name__ == '__main__':
         mixer_instance.address
     )
 
+    # Construct sk and pk objects from bytes
+    alice_sk = zethUtils.get_private_key_from_bytes(keystore["Alice"]["AddrSk"]["encSK"])
+    pk_sender = zethUtils.get_public_key_from_bytes(pk_sender_bob_to_bob)
+
     # Alice sees a deposit and tries to decrypt the ciphertexts to see if she was the recipient
     # But she wasn't the recipient (Bob was), so she fails to decrypt
-    alice_sk = zethUtils.get_private_key_from_bytes(keystore["Alice"]["AddrSk"]["encSK"])
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, pk_sender_bob_to_bob, alice_sk, "alice")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, pk_sender_bob_to_bob, alice_sk, "alice")
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, pk_sender, alice_sk, "alice")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, pk_sender, alice_sk, "alice")
     assert (recovered_plaintext1 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
     assert (recovered_plaintext2 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
 
@@ -177,7 +180,7 @@ if __name__ == '__main__':
     mk_path = zethUtils.compute_merkle_path(cm_address_bob_to_bob1, mk_tree_depth, mk_byte_tree)
     # Bob decrypts one of the note he previously received (useless here but useful if the payment came from someone else)
     bob_sk = zethUtils.get_private_key_from_bytes(keystore["Bob"]["AddrSk"]["encSK"])
-    input_note_json = json.loads(zethUtils.decrypt(ciphertext_bob_to_bob1, pk_sender_bob_to_bob, bob_sk))
+    input_note_json = json.loads(zethUtils.decrypt(ciphertext_bob_to_bob1, pk_sender, bob_sk))
     input_note_bob_to_charlie = zethGRPC.zethNoteObjFromParsed(input_note_json)
     # Execution of the transfer
     result_transfer_bob_to_charlie = zethTest.bob_to_charlie(
@@ -226,10 +229,13 @@ if __name__ == '__main__':
         mixer_instance.address
     )
 
-    # Charlie tries to decrypt the ciphertexts from Bob's previous transaction
+    # Construct sk and pk objects from bytes
     charlie_sk = zethUtils.get_private_key_from_bytes(keystore["Charlie"]["AddrSk"]["encSK"])
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, pk_sender_bob_to_charlie, charlie_sk, "charlie")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, pk_sender_bob_to_charlie, charlie_sk, "charlie")
+    pk_sender = zethUtils.get_public_key_from_bytes(pk_sender_bob_to_charlie)
+
+    # Charlie tries to decrypt the ciphertexts from Bob's previous transaction
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, pk_sender, charlie_sk, "charlie")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, pk_sender, charlie_sk, "charlie")
     assert (recovered_plaintext1 == ""),"Charlie managed to decrypt a ciphertext that was not encrypted with his key!"
     assert (recovered_plaintext2 != ""),"Charlie should have been able to decrypt the ciphertext that was obtained with his key!"
 

--- a/pyClient/testERCTokenMixing.py
+++ b/pyClient/testERCTokenMixing.py
@@ -150,8 +150,9 @@ if __name__ == '__main__':
     cm_address_bob_to_bob1 = result_deposit_bob_to_bob[0]
     cm_address_bob_to_bob2 = result_deposit_bob_to_bob[1]
     new_merkle_root_bob_to_bob = result_deposit_bob_to_bob[2]
-    ciphertext_bob_to_bob1 = result_deposit_bob_to_bob[3]
-    ciphertext_bob_to_bob2 = result_deposit_bob_to_bob[4]
+    pk_sender_bob_to_bob = result_deposit_bob_to_bob[3]
+    ciphertext_bob_to_bob1 = result_deposit_bob_to_bob[4]
+    ciphertext_bob_to_bob2 = result_deposit_bob_to_bob[5]
 
     print("- Balances after Bob's deposit: ")
     print_token_balances(
@@ -163,8 +164,8 @@ if __name__ == '__main__':
 
     # Alice sees a deposit and tries to decrypt the ciphertexts to see if she was the recipient
     # But she wasn't the recipient (Bob was), so she fails to decrypt
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, keystore["Bob"]["AddrPk"]["encPK"], keystore["Alice"]["AddrSk"]["encSK"], "alice")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, keystore["Bob"]["AddrPk"]["encPK"], keystore["Alice"]["AddrSk"]["encSK"], "alice")
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, pk_sender_bob_to_bob, keystore["Alice"]["AddrSk"]["encSK"], "alice")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, pk_sender_bob_to_bob, keystore["Alice"]["AddrSk"]["encSK"], "alice")
     assert (recovered_plaintext1 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
     assert (recovered_plaintext2 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
 
@@ -192,8 +193,9 @@ if __name__ == '__main__':
     cm_address_bob_to_charlie1 = result_transfer_bob_to_charlie[0] # Bob -> Bob (Change)
     cm_address_bob_to_charlie2 = result_transfer_bob_to_charlie[1] # Bob -> Charlie (payment to Charlie)
     new_merkle_root_bob_to_charlie = result_transfer_bob_to_charlie[2]
-    ciphertext_bob_to_charlie1 = result_transfer_bob_to_charlie[3]
-    ciphertext_bob_to_charlie2 = result_transfer_bob_to_charlie[4]
+    pk_sender_bob_to_charlie = result_transfer_bob_to_charlie[3]
+    ciphertext_bob_to_charlie1 = result_transfer_bob_to_charlie[4]
+    ciphertext_bob_to_charlie2 = result_transfer_bob_to_charlie[5]
 
     # Bob tries to spend `input_note_bob_to_charlie` twice
     result_double_spending = ""
@@ -223,8 +225,8 @@ if __name__ == '__main__':
     )
 
     # Charlie tries to decrypt the ciphertexts from Bob's previous transaction
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, keystore["Bob"]["AddrPk"]["encPK"], keystore["Charlie"]["AddrSk"]["encSK"], "charlie")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, keystore["Bob"]["AddrPk"]["encPK"], keystore["Charlie"]["AddrSk"]["encSK"], "charlie")
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, pk_sender_bob_to_charlie, keystore["Charlie"]["AddrSk"]["encSK"], "charlie")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, pk_sender_bob_to_charlie, keystore["Charlie"]["AddrSk"]["encSK"], "charlie")
     assert (recovered_plaintext1 == ""),"Charlie managed to decrypt a ciphertext that was not encrypted with his key!"
     assert (recovered_plaintext2 != ""),"Charlie should have been able to decrypt the ciphertext that was obtained with his key!"
 

--- a/pyClient/testEtherMixing.py
+++ b/pyClient/testEtherMixing.py
@@ -103,8 +103,8 @@ if __name__ == '__main__':
 
     # Alice sees a deposit and tries to decrypt the ciphertexts to see if she was the recipient
     # But she wasn't the recipient (Bob was), so she fails to decrypt
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Alice"]["AddrSk"]["privkey"], "alice")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Alice"]["AddrSk"]["privkey"], "alice")
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, keystore["Bob"]["AddrPk"]["encPK"], keystore["Alice"]["AddrSk"]["encSK"], "alice")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, keystore["Bob"]["AddrPk"]["encPK"], keystore["Alice"]["AddrSk"]["encSK"], "alice")
     assert (recovered_plaintext1 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
     assert (recovered_plaintext2 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
 
@@ -115,7 +115,7 @@ if __name__ == '__main__':
     mk_path = zethUtils.compute_merkle_path(cm_address_bob_to_bob1, mk_tree_depth, mk_byte_tree)
 
     # Bob decrypts one of the note he previously received (useless here but useful if the payment came from someone else)
-    input_note_json = json.loads(zethUtils.decrypt(ciphertext_bob_to_bob1, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Bob"]["AddrSk"]["privkey"]))
+    input_note_json = json.loads(zethUtils.decrypt(ciphertext_bob_to_bob1, keystore["Bob"]["AddrPk"]["encPK"], keystore["Bob"]["AddrSk"]["encSK"]))
     input_note_bob_to_charlie = zethGRPC.zethNoteObjFromParsed(input_note_json)
     # Execution of the transfer
     result_transfer_bob_to_charlie = zethTest.bob_to_charlie(
@@ -135,7 +135,7 @@ if __name__ == '__main__':
     new_merkle_root_bob_to_charlie = result_transfer_bob_to_charlie[2]
     ciphertext_bob_to_charlie1 = result_transfer_bob_to_charlie[3]
     ciphertext_bob_to_charlie2 = result_transfer_bob_to_charlie[4]
-    
+
     # Bob tries to spend `input_note_bob_to_charlie` twice
     result_double_spending = ""
     try:
@@ -164,8 +164,8 @@ if __name__ == '__main__':
     )
 
     # Charlie tries to decrypt the ciphertexts from Bob's previous transaction
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Charlie"]["AddrSk"]["privkey"], "charlie")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Charlie"]["AddrSk"]["privkey"], "charlie")
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, keystore["Bob"]["AddrPk"]["encPK"], keystore["Charlie"]["AddrSk"]["encSK"], "charlie")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, keystore["Bob"]["AddrPk"]["encPK"], keystore["Charlie"]["AddrSk"]["encSK"], "charlie")
     assert (recovered_plaintext1 == ""),"Charlie managed to decrypt a ciphertext that was not encrypted with his key!"
     assert (recovered_plaintext2 != ""),"Charlie should have been able to decrypt the ciphertext that was obtained with his key!"
 

--- a/pyClient/testEtherMixing.py
+++ b/pyClient/testEtherMixing.py
@@ -90,8 +90,9 @@ if __name__ == '__main__':
     cm_address_bob_to_bob1 = result_deposit_bob_to_bob[0]
     cm_address_bob_to_bob2 = result_deposit_bob_to_bob[1]
     new_merkle_root_bob_to_bob = result_deposit_bob_to_bob[2]
-    ciphertext_bob_to_bob1 = result_deposit_bob_to_bob[3]
-    ciphertext_bob_to_bob2 = result_deposit_bob_to_bob[4]
+    pk_sender_ciphertext_bob_to_bob = result_deposit_bob_to_bob[3]
+    ciphertext_bob_to_bob1 = result_deposit_bob_to_bob[4]
+    ciphertext_bob_to_bob2 = result_deposit_bob_to_bob[5]
 
     print("- Balances after Bob's deposit: ")
     print_balances(
@@ -103,8 +104,8 @@ if __name__ == '__main__':
 
     # Alice sees a deposit and tries to decrypt the ciphertexts to see if she was the recipient
     # But she wasn't the recipient (Bob was), so she fails to decrypt
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, keystore["Bob"]["AddrPk"]["encPK"], keystore["Alice"]["AddrSk"]["encSK"], "alice")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, keystore["Bob"]["AddrPk"]["encPK"], keystore["Alice"]["AddrSk"]["encSK"], "alice")
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, pk_sender_ciphertext_bob_to_bob, keystore["Alice"]["AddrSk"]["encSK"], "alice")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, pk_sender_ciphertext_bob_to_bob, keystore["Alice"]["AddrSk"]["encSK"], "alice")
     assert (recovered_plaintext1 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
     assert (recovered_plaintext2 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
 
@@ -133,8 +134,9 @@ if __name__ == '__main__':
     cm_address_bob_to_charlie1 = result_transfer_bob_to_charlie[0] # Bob -> Bob (Change)
     cm_address_bob_to_charlie2 = result_transfer_bob_to_charlie[1] # Bob -> Charlie (payment to Charlie)
     new_merkle_root_bob_to_charlie = result_transfer_bob_to_charlie[2]
-    ciphertext_bob_to_charlie1 = result_transfer_bob_to_charlie[3]
-    ciphertext_bob_to_charlie2 = result_transfer_bob_to_charlie[4]
+    pk_sender_ciphertext_bob_to_charlie = result_transfer_bob_to_charlie[3]
+    ciphertext_bob_to_charlie1 = result_transfer_bob_to_charlie[4]
+    ciphertext_bob_to_charlie2 = result_transfer_bob_to_charlie[5]
 
     # Bob tries to spend `input_note_bob_to_charlie` twice
     result_double_spending = ""
@@ -164,8 +166,8 @@ if __name__ == '__main__':
     )
 
     # Charlie tries to decrypt the ciphertexts from Bob's previous transaction
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, keystore["Bob"]["AddrPk"]["encPK"], keystore["Charlie"]["AddrSk"]["encSK"], "charlie")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, keystore["Bob"]["AddrPk"]["encPK"], keystore["Charlie"]["AddrSk"]["encSK"], "charlie")
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, pk_sender_ciphertext_bob_to_charlie, keystore["Charlie"]["AddrSk"]["encSK"], "charlie")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, pk_sender_ciphertext_bob_to_charlie, keystore["Charlie"]["AddrSk"]["encSK"], "charlie")
     assert (recovered_plaintext1 == ""),"Charlie managed to decrypt a ciphertext that was not encrypted with his key!"
     assert (recovered_plaintext2 != ""),"Charlie should have been able to decrypt the ciphertext that was obtained with his key!"
 

--- a/pyClient/testEtherMixing.py
+++ b/pyClient/testEtherMixing.py
@@ -102,11 +102,14 @@ if __name__ == '__main__':
         mixer_instance.address
     )
 
+    # Construct sk and pk objects from bytes
+    sk_alice = zethUtils.get_private_key_from_bytes(keystore["Alice"]["AddrSk"]["encSK"])
+    pk_sender = zethUtils.get_public_key_from_bytes(pk_sender_ciphertext_bob_to_bob)
+
     # Alice sees a deposit and tries to decrypt the ciphertexts to see if she was the recipient
     # But she wasn't the recipient (Bob was), so she fails to decrypt
-    alice_sk = zethUtils.get_private_key_from_bytes(keystore["Alice"]["AddrSk"]["encSK"])
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, pk_sender_ciphertext_bob_to_bob, alice_sk, "alice")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, pk_sender_ciphertext_bob_to_bob, alice_sk, "alice")
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, pk_sender, sk_alice, "alice")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, pk_sender, sk_alice, "alice")
     assert (recovered_plaintext1 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
     assert (recovered_plaintext2 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
 
@@ -117,8 +120,8 @@ if __name__ == '__main__':
     mk_path = zethUtils.compute_merkle_path(cm_address_bob_to_bob1, mk_tree_depth, mk_byte_tree)
 
     # Bob decrypts one of the note he previously received (useless here but useful if the payment came from someone else)
-    bob_sk = zethUtils.get_private_key_from_bytes(keystore["Bob"]["AddrSk"]["encSK"])
-    input_note_json = json.loads(zethUtils.decrypt(ciphertext_bob_to_bob1, pk_sender_ciphertext_bob_to_bob, bob_sk))
+    sk_bob = zethUtils.get_private_key_from_bytes(keystore["Bob"]["AddrSk"]["encSK"])
+    input_note_json = json.loads(zethUtils.decrypt(ciphertext_bob_to_bob1, pk_sender, sk_bob))
     input_note_bob_to_charlie = zethGRPC.zethNoteObjFromParsed(input_note_json)
     # Execution of the transfer
     result_transfer_bob_to_charlie = zethTest.bob_to_charlie(
@@ -167,10 +170,13 @@ if __name__ == '__main__':
         mixer_instance.address
     )
 
+    # Construct sk and pk objects from bytes
+    sk_charlie = zethUtils.get_private_key_from_bytes(keystore["Charlie"]["AddrSk"]["encSK"])
+    pk_sender = zethUtils.get_public_key_from_bytes(pk_sender_ciphertext_bob_to_charlie)
+
     # Charlie tries to decrypt the ciphertexts from Bob's previous transaction
-    charlie_sk = zethUtils.get_private_key_from_bytes(keystore["Charlie"]["AddrSk"]["encSK"])
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, pk_sender_ciphertext_bob_to_charlie, charlie_sk, "charlie")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, pk_sender_ciphertext_bob_to_charlie, charlie_sk, "charlie")
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, pk_sender, sk_charlie, "charlie")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, pk_sender, sk_charlie, "charlie")
     assert (recovered_plaintext1 == ""),"Charlie managed to decrypt a ciphertext that was not encrypted with his key!"
     assert (recovered_plaintext2 != ""),"Charlie should have been able to decrypt the ciphertext that was obtained with his key!"
 

--- a/pyClient/testEtherMixing.py
+++ b/pyClient/testEtherMixing.py
@@ -104,8 +104,9 @@ if __name__ == '__main__':
 
     # Alice sees a deposit and tries to decrypt the ciphertexts to see if she was the recipient
     # But she wasn't the recipient (Bob was), so she fails to decrypt
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, pk_sender_ciphertext_bob_to_bob, keystore["Alice"]["AddrSk"]["encSK"], "alice")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, pk_sender_ciphertext_bob_to_bob, keystore["Alice"]["AddrSk"]["encSK"], "alice")
+    alice_sk = zethUtils.get_private_key_from_bytes(keystore["Alice"]["AddrSk"]["encSK"])
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, pk_sender_ciphertext_bob_to_bob, alice_sk, "alice")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, pk_sender_ciphertext_bob_to_bob, alice_sk, "alice")
     assert (recovered_plaintext1 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
     assert (recovered_plaintext2 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
 
@@ -116,7 +117,8 @@ if __name__ == '__main__':
     mk_path = zethUtils.compute_merkle_path(cm_address_bob_to_bob1, mk_tree_depth, mk_byte_tree)
 
     # Bob decrypts one of the note he previously received (useless here but useful if the payment came from someone else)
-    input_note_json = json.loads(zethUtils.decrypt(ciphertext_bob_to_bob1, keystore["Bob"]["AddrPk"]["encPK"], keystore["Bob"]["AddrSk"]["encSK"]))
+    bob_sk = zethUtils.get_private_key_from_bytes(keystore["Bob"]["AddrSk"]["encSK"])
+    input_note_json = json.loads(zethUtils.decrypt(ciphertext_bob_to_bob1, pk_sender_ciphertext_bob_to_bob, bob_sk))
     input_note_bob_to_charlie = zethGRPC.zethNoteObjFromParsed(input_note_json)
     # Execution of the transfer
     result_transfer_bob_to_charlie = zethTest.bob_to_charlie(
@@ -166,8 +168,9 @@ if __name__ == '__main__':
     )
 
     # Charlie tries to decrypt the ciphertexts from Bob's previous transaction
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, pk_sender_ciphertext_bob_to_charlie, keystore["Charlie"]["AddrSk"]["encSK"], "charlie")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, pk_sender_ciphertext_bob_to_charlie, keystore["Charlie"]["AddrSk"]["encSK"], "charlie")
+    charlie_sk = zethUtils.get_private_key_from_bytes(keystore["Charlie"]["AddrSk"]["encSK"])
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, pk_sender_ciphertext_bob_to_charlie, charlie_sk, "charlie")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, pk_sender_ciphertext_bob_to_charlie, charlie_sk, "charlie")
     assert (recovered_plaintext1 == ""),"Charlie managed to decrypt a ciphertext that was not encrypted with his key!"
     assert (recovered_plaintext2 != ""),"Charlie should have been able to decrypt the ciphertext that was obtained with his key!"
 

--- a/pyClient/testEtherMixing.py
+++ b/pyClient/testEtherMixing.py
@@ -103,8 +103,8 @@ if __name__ == '__main__':
 
     # Alice sees a deposit and tries to decrypt the ciphertexts to see if she was the recipient
     # But she wasn't the recipient (Bob was), so she fails to decrypt
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, keystore["Alice"]["AddrSk"]["dk"], "alice")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, keystore["Alice"]["AddrSk"]["dk"], "alice")
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_bob1, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Alice"]["AddrSk"]["privkey"], "alice")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_bob2, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Alice"]["AddrSk"]["privkey"], "alice")
     assert (recovered_plaintext1 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
     assert (recovered_plaintext2 == ""),"Alice managed to decrypt a ciphertext that was not encrypted with her key!"
 
@@ -115,7 +115,7 @@ if __name__ == '__main__':
     mk_path = zethUtils.compute_merkle_path(cm_address_bob_to_bob1, mk_tree_depth, mk_byte_tree)
 
     # Bob decrypts one of the note he previously received (useless here but useful if the payment came from someone else)
-    input_note_json = json.loads(zethUtils.decrypt(ciphertext_bob_to_bob1, keystore["Bob"]["AddrSk"]["dk"]))
+    input_note_json = json.loads(zethUtils.decrypt(ciphertext_bob_to_bob1, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Bob"]["AddrSk"]["privkey"]))
     input_note_bob_to_charlie = zethGRPC.zethNoteObjFromParsed(input_note_json)
     # Execution of the transfer
     result_transfer_bob_to_charlie = zethTest.bob_to_charlie(
@@ -164,8 +164,8 @@ if __name__ == '__main__':
     )
 
     # Charlie tries to decrypt the ciphertexts from Bob's previous transaction
-    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, keystore["Charlie"]["AddrSk"]["dk"], "charlie")
-    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, keystore["Charlie"]["AddrSk"]["dk"], "charlie")
+    recovered_plaintext1 = zethUtils.receive(ciphertext_bob_to_charlie1, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Charlie"]["AddrSk"]["privkey"], "charlie")
+    recovered_plaintext2 = zethUtils.receive(ciphertext_bob_to_charlie2, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Charlie"]["AddrSk"]["privkey"], "charlie")
     assert (recovered_plaintext1 == ""),"Charlie managed to decrypt a ciphertext that was not encrypted with his key!"
     assert (recovered_plaintext2 != ""),"Charlie should have been able to decrypt the ciphertext that was obtained with his key!"
 

--- a/pyClient/testZethUtils.py
+++ b/pyClient/testZethUtils.py
@@ -5,30 +5,30 @@ from nacl.public import PrivateKey, PublicKey
 # Tests the correct encrypt-decrypt flow: decrypt(encrypt(m)) == m
 def test_encrypt_decrypt():
 
-  message = "Kill all humans"
+  message = "Join Clearmatics, we are hiring!"
 
-  alice_keys_bytes, bob_keys_bytes, _ = zethUtils.gen_keys_utility()
+  keypair_alice_bytes, keypair_bob_bytes, _ = zethUtils.gen_keys_utility()
 
-  pkalice_bytes = alice_keys_bytes[0]
-  skalice = zethUtils.get_private_key_from_bytes(alice_keys_bytes[1])
+  pk_alice = zethUtils.get_public_key_from_bytes(keypair_alice_bytes[0])
+  sk_alice = zethUtils.get_private_key_from_bytes(keypair_alice_bytes[1])
 
-  pkbob_bytes = bob_keys_bytes[0]
-  skbob = zethUtils.get_private_key_from_bytes(bob_keys_bytes[1])
+  pk_bob = zethUtils.get_public_key_from_bytes(keypair_bob_bytes[0])
+  sk_bob = zethUtils.get_private_key_from_bytes(keypair_bob_bytes[1])
 
   # Subtest 1: Alice to Alice
-  ciphertext_alice_alice = zethUtils.encrypt(message, pkalice_bytes, skalice)
+  ciphertext_alice_alice = zethUtils.encrypt(message, pk_alice, sk_alice)
 
-  plaintext_alice_alice = zethUtils.decrypt(ciphertext_alice_alice, pkalice_bytes, skalice)
+  plaintext_alice_alice = zethUtils.decrypt(ciphertext_alice_alice, pk_alice, sk_alice)
   assert plaintext_alice_alice == message, "error in Alice to Alice test"
 
   # Subest 2: Bob to Alice
-  ciphertext_bob_alice = zethUtils.encrypt(message, pkalice_bytes, skbob)
+  ciphertext_bob_alice = zethUtils.encrypt(message, pk_alice, sk_bob)
 
-  plaintext_bob_alice = zethUtils.decrypt(ciphertext_bob_alice, pkalice_bytes, skbob)
-  assert plaintext_bob_alice == message, "error in Bob to Alice test: pkalice,skbob"
+  plaintext_bob_alice = zethUtils.decrypt(ciphertext_bob_alice, pk_alice, sk_bob)
+  assert plaintext_bob_alice == message, "error in Bob to Alice test: pk_alice,sk_bob"
 
-  plaintext_bob_alice = zethUtils.decrypt(ciphertext_bob_alice, pkbob_bytes, skalice)
-  assert plaintext_bob_alice == message, "error in Bob to Alice test: pkbob,skalice"
+  plaintext_bob_alice = zethUtils.decrypt(ciphertext_bob_alice, pk_bob, sk_alice)
+  assert plaintext_bob_alice == message, "error in Bob to Alice test: pk_bob,sk_alice"
 
   print("Tests encrypt_decrypt passed")
 

--- a/pyClient/testZethUtils.py
+++ b/pyClient/testZethUtils.py
@@ -10,24 +10,24 @@ def test_encrypt_decrypt():
   alice_keys_bytes, bob_keys_bytes, _ = zethUtils.gen_keys_utility()
 
   pkalice_bytes = alice_keys_bytes[0]
-  skalice_bytes = alice_keys_bytes[1]
+  skalice = zethUtils.get_private_key_from_bytes(alice_keys_bytes[1])
 
   pkbob_bytes = bob_keys_bytes[0]
-  skbob_bytes = bob_keys_bytes[1]
+  skbob = zethUtils.get_private_key_from_bytes(bob_keys_bytes[1])
 
   # Subtest 1: Alice to Alice
-  ciphertext_alice_alice = zethUtils.encrypt(message, pkalice_bytes, skalice_bytes)
+  ciphertext_alice_alice = zethUtils.encrypt(message, pkalice_bytes, skalice)
 
-  plaintext_alice_alice = zethUtils.decrypt(ciphertext_alice_alice, pkalice_bytes, skalice_bytes)
+  plaintext_alice_alice = zethUtils.decrypt(ciphertext_alice_alice, pkalice_bytes, skalice)
   assert plaintext_alice_alice == message, "error in Alice to Alice test"
 
   # Subest 2: Bob to Alice
-  ciphertext_bob_alice = zethUtils.encrypt(message, pkalice_bytes, skbob_bytes)
+  ciphertext_bob_alice = zethUtils.encrypt(message, pkalice_bytes, skbob)
 
-  plaintext_bob_alice = zethUtils.decrypt(ciphertext_bob_alice, pkalice_bytes, skbob_bytes)
+  plaintext_bob_alice = zethUtils.decrypt(ciphertext_bob_alice, pkalice_bytes, skbob)
   assert plaintext_bob_alice == message, "error in Bob to Alice test: pkalice,skbob"
 
-  plaintext_bob_alice = zethUtils.decrypt(ciphertext_bob_alice, pkbob_bytes, skalice_bytes)
+  plaintext_bob_alice = zethUtils.decrypt(ciphertext_bob_alice, pkbob_bytes, skalice)
   assert plaintext_bob_alice == message, "error in Bob to Alice test: pkbob,skalice"
 
   print("Tests encrypt_decrypt passed")

--- a/pyClient/testZethUtils.py
+++ b/pyClient/testZethUtils.py
@@ -1,26 +1,7 @@
-import zethMock
 import zethUtils
 
 from nacl.public import PrivateKey, PublicKey
 from nacl.encoding import HexEncoder
-
-# Tests that we get the correct PrivateKey object from the hexadecimal encoding
-def test_get_private_key_from_hex():
-  private_key_obj = zethUtils.get_private_key_from_hex(keystore["Alice"]["AddrSk"]["privkey"])
-
-  private_key = PrivateKey(keystore["Alice"]["AddrSk"]["privkey"], encoder=HexEncoder)
-
-  assert private_key_obj == private_key, "private key not correct"
-  print("Test get_private_key_from_hex passed")
-
-# Tests that we get the correct PublicKey object from the hexadecimal encoding
-def test_get_public_key_from_hex():
-  public_key_obj = zethUtils.get_public_key_from_hex(keystore["Alice"]["AddrPk"]["pubkey"])
-
-  public_key = PublicKey(keystore["Alice"]["AddrPk"]["pubkey"], encoder=HexEncoder)
-
-  assert public_key_obj == public_key, "public key not correct"
-  print("Test get_public_key_from_hex passed")
 
 # Tests the correct encrypt-decrypt flow: decrypt(encrypt(m)) == m
 def test_encrypt_decrypt():
@@ -54,8 +35,4 @@ def test_encrypt_decrypt():
 
 if __name__ == "__main__":
 
-  keystore = zethMock.initTestKeystore()
-
-  test_get_private_key_from_hex()
-  test_get_public_key_from_hex()
   test_encrypt_decrypt()

--- a/pyClient/testZethUtils.py
+++ b/pyClient/testZethUtils.py
@@ -4,7 +4,6 @@ from nacl.public import PrivateKey, PublicKey
 
 # Tests the correct encrypt-decrypt flow: decrypt(encrypt(m)) == m
 def test_encrypt_decrypt():
-
   message = "Join Clearmatics, we are hiring!"
 
   keypair_alice_bytes, keypair_bob_bytes, _ = zethUtils.gen_keys_utility()
@@ -17,21 +16,17 @@ def test_encrypt_decrypt():
 
   # Subtest 1: Alice to Alice
   ciphertext_alice_alice = zethUtils.encrypt(message, pk_alice, sk_alice)
-
   plaintext_alice_alice = zethUtils.decrypt(ciphertext_alice_alice, pk_alice, sk_alice)
-  assert plaintext_alice_alice == message, "error in Alice to Alice test"
+  assert plaintext_alice_alice == message, "Error in Alice to Alice test"
 
   # Subest 2: Bob to Alice
   ciphertext_bob_alice = zethUtils.encrypt(message, pk_alice, sk_bob)
-
   plaintext_bob_alice = zethUtils.decrypt(ciphertext_bob_alice, pk_alice, sk_bob)
-  assert plaintext_bob_alice == message, "error in Bob to Alice test: pk_alice,sk_bob"
-
+  assert plaintext_bob_alice == message, "Error in Bob to Alice test: pk_alice, sk_bob"
   plaintext_bob_alice = zethUtils.decrypt(ciphertext_bob_alice, pk_bob, sk_alice)
-  assert plaintext_bob_alice == message, "error in Bob to Alice test: pk_bob,sk_alice"
+  assert plaintext_bob_alice == message, "Error in Bob to Alice test: pk_bob, sk_alice"
 
   print("Tests encrypt_decrypt passed")
 
 if __name__ == "__main__":
-
   test_encrypt_decrypt()

--- a/pyClient/testZethUtils.py
+++ b/pyClient/testZethUtils.py
@@ -1,11 +1,10 @@
-# Set of tests for zethUtils.py
-
 import zethMock
 import zethUtils
 
 from nacl.public import PrivateKey, PublicKey
 from nacl.encoding import HexEncoder
 
+# Test we get the correct PrivateKey object from the hexadecimal encoding
 def test_get_private_key_from_hex():
   private_key_obj = zethUtils.get_private_key_from_hex(keystore["Alice"]["AddrSk"]["privkey"])
 
@@ -14,6 +13,7 @@ def test_get_private_key_from_hex():
   assert private_key_obj == private_key, "private key not correct"
   print("Test get_private_key_from_hex passed")
 
+# Test we get the correct PublicKey object from the hexadecimal encoding
 def test_get_public_key_from_hex():
   public_key_obj = zethUtils.get_public_key_from_hex(keystore["Alice"]["AddrPk"]["pubkey"])
 
@@ -22,9 +22,10 @@ def test_get_public_key_from_hex():
   assert public_key_obj == public_key, "public key not correct"
   print("Test get_public_key_from_hex passed")
 
+# Test correct encrypt-decrypt flow: decrypt(encrypt(m)) == m
 def test_encrypt_decrypt():
 
-  message = b"Kill all humans"
+  message = "Kill all humans"
 
   alice_keys_hex, bob_keys_hex, _ = zethUtils.gen_keys_utility()
 
@@ -36,17 +37,18 @@ def test_encrypt_decrypt():
 
   # Subtest 1: Alice to Alice
   ciphertext_alice_alice = zethUtils.encrypt(message, pkalice_hex, skalice_hex)
-  plaintext = zethUtils.decrypt(ciphertext_alice_alice, pkalice_hex, skalice_hex)
 
-  assert plaintext == str(message, encoding='utf-8'), "error in Alice to Alice test"
+  plaintext_alice_alice = zethUtils.decrypt(ciphertext_alice_alice, pkalice_hex, skalice_hex)
+  assert plaintext_alice_alice == message, "error in Alice to Alice test"
 
-  # Subest 2: Alice to Bob
-  ciphertext_alice_bob = zethUtils.encrypt(message, pkalice_hex, skbob_hex)
-  plaintext2 = zethUtils.decrypt(ciphertext_alice_bob, pkalice_hex, skbob_hex)
-  assert plaintext == str(message, encoding='utf-8'), "error in Bob to Alice test"
+  # Subest 2: Bob to Alice
+  ciphertext_bob_alice = zethUtils.encrypt(message, pkalice_hex, skbob_hex)
 
-  plaintext2 = zethUtils.decrypt(ciphertext_alice_bob, pkbob_hex, skalice_hex)
-  assert plaintext == str(message, encoding='utf-8'), "error in Bob to Alice test"
+  plaintext_bob_alice = zethUtils.decrypt(ciphertext_bob_alice, pkalice_hex, skbob_hex)
+  assert plaintext_bob_alice == message, "error in Bob to Alice test: pkalice,skbob"
+
+  plaintext_bob_alice = zethUtils.decrypt(ciphertext_bob_alice, pkbob_hex, skalice_hex)
+  assert plaintext_bob_alice == message, "error in Bob to Alice test: pkbob,skalice"
 
   print("Tests encrypt_decrypt passed")
 

--- a/pyClient/testZethUtils.py
+++ b/pyClient/testZethUtils.py
@@ -4,7 +4,7 @@ import zethUtils
 from nacl.public import PrivateKey, PublicKey
 from nacl.encoding import HexEncoder
 
-# Test we get the correct PrivateKey object from the hexadecimal encoding
+# Tests that we get the correct PrivateKey object from the hexadecimal encoding
 def test_get_private_key_from_hex():
   private_key_obj = zethUtils.get_private_key_from_hex(keystore["Alice"]["AddrSk"]["privkey"])
 
@@ -13,7 +13,7 @@ def test_get_private_key_from_hex():
   assert private_key_obj == private_key, "private key not correct"
   print("Test get_private_key_from_hex passed")
 
-# Test we get the correct PublicKey object from the hexadecimal encoding
+# Tests that we get the correct PublicKey object from the hexadecimal encoding
 def test_get_public_key_from_hex():
   public_key_obj = zethUtils.get_public_key_from_hex(keystore["Alice"]["AddrPk"]["pubkey"])
 
@@ -22,7 +22,7 @@ def test_get_public_key_from_hex():
   assert public_key_obj == public_key, "public key not correct"
   print("Test get_public_key_from_hex passed")
 
-# Test correct encrypt-decrypt flow: decrypt(encrypt(m)) == m
+# Tests the correct encrypt-decrypt flow: decrypt(encrypt(m)) == m
 def test_encrypt_decrypt():
 
   message = "Kill all humans"

--- a/pyClient/testZethUtils.py
+++ b/pyClient/testZethUtils.py
@@ -1,34 +1,33 @@
 import zethUtils
 
 from nacl.public import PrivateKey, PublicKey
-from nacl.encoding import HexEncoder
 
 # Tests the correct encrypt-decrypt flow: decrypt(encrypt(m)) == m
 def test_encrypt_decrypt():
 
   message = "Kill all humans"
 
-  alice_keys_hex, bob_keys_hex, _ = zethUtils.gen_keys_utility()
+  alice_keys_bytes, bob_keys_bytes, _ = zethUtils.gen_keys_utility()
 
-  pkalice_hex = alice_keys_hex[0]
-  skalice_hex = alice_keys_hex[1]
+  pkalice_bytes = alice_keys_bytes[0]
+  skalice_bytes = alice_keys_bytes[1]
 
-  pkbob_hex = bob_keys_hex[0]
-  skbob_hex = bob_keys_hex[1]
+  pkbob_bytes = bob_keys_bytes[0]
+  skbob_bytes = bob_keys_bytes[1]
 
   # Subtest 1: Alice to Alice
-  ciphertext_alice_alice = zethUtils.encrypt(message, pkalice_hex, skalice_hex)
+  ciphertext_alice_alice = zethUtils.encrypt(message, pkalice_bytes, skalice_bytes)
 
-  plaintext_alice_alice = zethUtils.decrypt(ciphertext_alice_alice, pkalice_hex, skalice_hex)
+  plaintext_alice_alice = zethUtils.decrypt(ciphertext_alice_alice, pkalice_bytes, skalice_bytes)
   assert plaintext_alice_alice == message, "error in Alice to Alice test"
 
   # Subest 2: Bob to Alice
-  ciphertext_bob_alice = zethUtils.encrypt(message, pkalice_hex, skbob_hex)
+  ciphertext_bob_alice = zethUtils.encrypt(message, pkalice_bytes, skbob_bytes)
 
-  plaintext_bob_alice = zethUtils.decrypt(ciphertext_bob_alice, pkalice_hex, skbob_hex)
+  plaintext_bob_alice = zethUtils.decrypt(ciphertext_bob_alice, pkalice_bytes, skbob_bytes)
   assert plaintext_bob_alice == message, "error in Bob to Alice test: pkalice,skbob"
 
-  plaintext_bob_alice = zethUtils.decrypt(ciphertext_bob_alice, pkbob_hex, skalice_hex)
+  plaintext_bob_alice = zethUtils.decrypt(ciphertext_bob_alice, pkbob_bytes, skalice_bytes)
   assert plaintext_bob_alice == message, "error in Bob to Alice test: pkbob,skalice"
 
   print("Tests encrypt_decrypt passed")

--- a/pyClient/test_zethUtils.py
+++ b/pyClient/test_zethUtils.py
@@ -1,0 +1,59 @@
+# Set of tests for zethUtils.py
+
+import zethMock
+import zethUtils
+
+from nacl.public import PrivateKey, PublicKey
+from nacl.encoding import HexEncoder
+
+def test_get_private_key_from_hex():
+  private_key_obj = zethUtils.get_private_key_from_hex(keystore["Alice"]["AddrSk"]["privkey"])
+
+  private_key = PrivateKey(keystore["Alice"]["AddrSk"]["privkey"], encoder=HexEncoder)
+
+  assert private_key_obj == private_key, "private key not correct"
+  print("Test get_private_key_from_hex passed")
+
+def test_get_public_key_from_hex():
+  public_key_obj = zethUtils.get_public_key_from_hex(keystore["Alice"]["AddrPk"]["pubkey"])
+
+  public_key = PublicKey(keystore["Alice"]["AddrPk"]["pubkey"], encoder=HexEncoder)
+
+  assert public_key_obj == public_key, "public key not correct"
+  print("Test get_public_key_from_hex passed")
+
+def test_encrypt_decrypt():
+
+  message = b"Kill all humans"
+
+  alice_keys_hex, bob_keys_hex, _ = zethUtils.gen_keys_utility()
+
+  pkalice_hex = alice_keys_hex[0]
+  skalice_hex = alice_keys_hex[1]
+
+  pkbob_hex = bob_keys_hex[0]
+  skbob_hex = bob_keys_hex[1]
+
+  # Subtest 1: Alice to Alice
+  ciphertext_alice_alice = zethUtils.encrypt(message, pkalice_hex, skalice_hex)
+  plaintext = zethUtils.decrypt(ciphertext_alice_alice, pkalice_hex, skalice_hex)
+
+  assert plaintext == str(message, encoding='utf-8'), "error in Alice to Alice test"
+
+  # Subest 2: Alice to Bob
+  ciphertext_alice_bob = zethUtils.encrypt(message, pkalice_hex, skbob_hex)
+  plaintext2 = zethUtils.decrypt(ciphertext_alice_bob, pkalice_hex, skbob_hex)
+  assert plaintext == str(message, encoding='utf-8'), "error in Bob to Alice test"
+
+  plaintext2 = zethUtils.decrypt(ciphertext_alice_bob, pkbob_hex, skalice_hex)
+  assert plaintext == str(message, encoding='utf-8'), "error in Bob to Alice test"
+
+  print("Tests encrypt_decrypt passed")
+
+if __name__ == "__main__":
+
+  keystore = zethMock.initTestKeystore()
+
+  test_get_private_key_from_hex()
+  test_get_public_key_from_hex()
+  test_encrypt_decrypt()

--- a/pyClient/zethContracts.py
+++ b/pyClient/zethContracts.py
@@ -228,6 +228,7 @@ def deploy_tree_contract(interface, depth, hasher_address):
 # Call to the mixer's mix function to do zero knowledge payments
 def mix_pghr13(
         mixer_instance,
+        pk_sender,
         ciphertext1,
         ciphertext2,
         parsed_proof,
@@ -238,6 +239,7 @@ def mix_pghr13(
         call_gas
     ):
     tx_hash = mixer_instance.functions.mix(
+        pk_sender,
         ciphertext1,
         ciphertext2,
         zethGRPC.hex2int(parsed_proof["a"]),
@@ -258,6 +260,7 @@ def mix_pghr13(
 
 def mix_groth16(
         mixer_instance,
+        pk_sender,
         ciphertext1,
         ciphertext2,
         parsed_proof,
@@ -268,6 +271,7 @@ def mix_groth16(
         call_gas
     ):
     tx_hash = mixer_instance.functions.mix(
+        pk_sender,
         ciphertext1,
         ciphertext2,
         zethGRPC.hex2int(parsed_proof["a"]),
@@ -283,6 +287,7 @@ def mix_groth16(
 
 def mix(
         mixer_instance,
+        pk_sender,
         ciphertext1,
         ciphertext2,
         parsed_proof,
@@ -296,6 +301,7 @@ def mix(
     if zksnark == constants.PGHR13_ZKSNARK:
         return mix_pghr13(
             mixer_instance,
+            pk_sender,
             ciphertext1,
             ciphertext2,
             parsed_proof,
@@ -308,6 +314,7 @@ def mix(
     elif zksnark == constants.GROTH16_ZKSNARK:
         return mix_groth16(
             mixer_instance,
+            pk_sender,
             ciphertext1,
             ciphertext2,
             parsed_proof,
@@ -338,7 +345,9 @@ def parse_mix_call(mixer_instance, tx_receipt):
     new_mk_root = w3.toHex(event_logs_logMerkleRoot[0].args.root)[2:] # [2:] to strip the '0x' prefix
     ciphertext1 = event_logs_logSecretCiphers[0].args.ciphertext
     ciphertext2 = event_logs_logSecretCiphers[1].args.ciphertext
-    return (commitment_address1, commitment_address2, new_mk_root, ciphertext1, ciphertext2)
+    pk_sender = event_logs_logSecretCiphers[0].args.pk_sender
+
+    return (commitment_address1, commitment_address2, new_mk_root, pk_sender, ciphertext1, ciphertext2)
 
 # Call the hash method of MiMC contract
 def mimcHash(instance, m, k, seed):

--- a/pyClient/zethContracts.py
+++ b/pyClient/zethContracts.py
@@ -95,6 +95,7 @@ def deploy_mixer(
     # Deploy the Mixer contract once the Verifier is successfully deployed
     mixer = w3.eth.contract(
             abi=mixer_interface['abi'], bytecode=mixer_interface['bin'])
+
     tx_hash = mixer.constructor(
         snark_ver = proof_verifier_address,
         sig_ver = otsig_verifier_address,
@@ -239,9 +240,6 @@ def mix_pghr13(
         call_gas
     ):
     tx_hash = mixer_instance.functions.mix(
-        pk_sender,
-        ciphertext1,
-        ciphertext2,
         zethGRPC.hex2int(parsed_proof["a"]),
         zethGRPC.hex2int(parsed_proof["a_p"]),
         [zethGRPC.hex2int(parsed_proof["b"][0]), zethGRPC.hex2int(parsed_proof["b"][1])],
@@ -252,7 +250,10 @@ def mix_pghr13(
         zethGRPC.hex2int(parsed_proof["k"]),
         [ [int(vk[0][0]), int(vk[0][1])], [int(vk[1][0]), int(vk[1][1])] ],
         int(sigma),
-        zethGRPC.hex2int(parsed_proof["inputs"])
+        zethGRPC.hex2int(parsed_proof["inputs"]),
+        pk_sender,
+        ciphertext1,
+        ciphertext2,
     ).transact({'from': sender_address, 'value': wei_pub_value, 'gas': call_gas})
 
     tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash, 10000)
@@ -271,15 +272,15 @@ def mix_groth16(
         call_gas
     ):
     tx_hash = mixer_instance.functions.mix(
-        pk_sender,
-        ciphertext1,
-        ciphertext2,
         zethGRPC.hex2int(parsed_proof["a"]),
         [zethGRPC.hex2int(parsed_proof["b"][0]), zethGRPC.hex2int(parsed_proof["b"][1])],
         zethGRPC.hex2int(parsed_proof["c"]),
         [ [int(vk[0][0]), int(vk[0][1])], [int(vk[1][0]), int(vk[1][1])] ],
         int(sigma),
-        zethGRPC.hex2int(parsed_proof["inputs"])
+        zethGRPC.hex2int(parsed_proof["inputs"]),
+        pk_sender,
+        ciphertext1,
+        ciphertext2,
     ).transact({'from': sender_address, 'value': wei_pub_value, 'gas': call_gas})
 
     tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash, 10000)

--- a/pyClient/zethGRPC.py
+++ b/pyClient/zethGRPC.py
@@ -308,7 +308,6 @@ def encodeToHash(messages):
 # The public values are encoded over one field element
 def encodeInputToHash(messages):
     input_sha = bytearray()
-    print(messages)
 
     # Flatten the input list
     if any(isinstance(el, list) for el in messages):

--- a/pyClient/zethMock.py
+++ b/pyClient/zethMock.py
@@ -4,104 +4,47 @@ import zethGRPC
 def initTestKeystore():
     # Alice credentials in the zeth abstraction
     AliceOwnershipKeys = zethGRPC.generateApkAskKeypair()
-    AliceEncKey = """-----BEGIN PUBLIC KEY-----
-MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDP34BAdxAX0p9yxhcoqkQtCKWc
-o/t/MEqLfjCP/dwkrN9MmML4CGYXqF0X9UKxv+2qxhtxkLLFtPnyT6PRTQDnPuHw
-+D8kQ4DOyn5fBVpIwvPVl/COIZYiSQgv2YaE8UI/9YtXLE9njJItsCJQbtcKY6TZ
-8JmIxk2E9fNah9V+SQIDAQAB
------END PUBLIC KEY-----"""
-    AliceDecKey = """-----BEGIN RSA PRIVATE KEY-----
-MIICWgIBAAKBgQDP34BAdxAX0p9yxhcoqkQtCKWco/t/MEqLfjCP/dwkrN9MmML4
-CGYXqF0X9UKxv+2qxhtxkLLFtPnyT6PRTQDnPuHw+D8kQ4DOyn5fBVpIwvPVl/CO
-IZYiSQgv2YaE8UI/9YtXLE9njJItsCJQbtcKY6TZ8JmIxk2E9fNah9V+SQIDAQAB
-An92hzpoMl86xHOmk3fLv0pnnCon5wOkF7NNVspoM+2hGGM7F/xM8Zl98hfNpr1Z
-q2TEEM6G+fPZZFEEfToPJSdzAf1GUPBNeIr/iJCERM1UzlRb1C09jil1Spne3NSa
-xYx3JVZs2WEhz/RAELuRzMBqntDNYmbUhhPEZ3S4WIBNAkEA3KvB1JvmJp5+S72S
-7JGsiH3iP0q/MsyLdZFyOtBiUlcmJ67iTDPR/sTF/o4jZrFQf8heGDRzvgLbqxbz
-NsIy1QJBAPEnOGUs8qo8JsIQv7khx3HDXO1pVA4WfL9i+G9AQKUtbN0pi8kErBCy
-KShUEsQQfx69r2BkUO/mxXuTKUKPT6UCQEQ8FBaTEmq0rabr+seOEASwsEoT6eVi
-XGlBTUokb5K4ggLZT/5yM6gM3pBlEUtK3vJ0WawwY+3IYnaYBSLUj/UCQFeK5Fce
-RQ11fqBukhrz30I2KJLq7J+cnDaiCAvi6FTOM7nprhwQPSJmerhwJMvWLT+MnpDA
-ef1M6h3dI1pNSh0CQQCjEQ/5Udy3YjQQfE1f+sW2CnosVGP7VZFhVyAT+KBxm8Sh
-YnR+rry8uG5XUjjkxOVoRDEZMx2uErlklDhYy4r0
------END RSA PRIVATE KEY-----"""
+    Alice25519PublicKey = b'97aa1d5ffc8322ea87c88de17440ed8feb1ea20e00e6d1a93cafcb2e83da5b0e'
+    Alice25519PrivateKey = b'82578283b14d7a3391139957e04aa16fcb498cabf4e8fb85d54a8b2526c28e42'
 
     # Bob credentials in the zeth abstraction
     BobOwnershipKeys = zethGRPC.generateApkAskKeypair()
-    BobEncKey = """-----BEGIN PUBLIC KEY-----
-MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC3Ba45mM+JhO9tNpHwldnnvAtA
-/j2XqiV4HNhkql39vt76oy6RV7Yl3KIW+dsT5EwZos8NmgvWo28pC4u+4nXbuNLH
-WVVt1jHQVhG9EQRlbkoCypDD4wOmrdlJplCjaRgCSeN8U7G+MTr2AtRT+0VozV04
-mIoKPDymx+pgH8KJVQIDAQAB
------END PUBLIC KEY-----"""
-    BobDecKey = """-----BEGIN RSA PRIVATE KEY-----
-MIICXAIBAAKBgQC3Ba45mM+JhO9tNpHwldnnvAtA/j2XqiV4HNhkql39vt76oy6R
-V7Yl3KIW+dsT5EwZos8NmgvWo28pC4u+4nXbuNLHWVVt1jHQVhG9EQRlbkoCypDD
-4wOmrdlJplCjaRgCSeN8U7G+MTr2AtRT+0VozV04mIoKPDymx+pgH8KJVQIDAQAB
-AoGBAJ7wNvHby3cgU5AjUK9+YuKEgb1qTHC2GJ3rZtxcuw0NwbQlG96qLgtJRBXx
-2xe2LYQhx++G9HrsKS+a0Dvvi+rQ7YK7cxFJuKNmwonoKI9LpIFDV7xvNJ1TPU1G
-QVskoU1OfwUabyDmYI5j7Lgf2xqu7Z2xNz1iQoMzFvI+ffItAkEA2GY+N3E3ZJWP
-+E6OuZHD08E0h9mPGoug5YQjhYEV0zyI9abGCzDZp90YKoLerTJefaD5NyErRVFn
-7jnFYGjxewJBANiDzSTMUeojGWboRhfHl/2FNSjg7ClgI8tjdH72Rn46EbLJHgno
-L3j5O1XwwgtbjTb/vRpc0V+gQp32qSlw728CQAhPnPIaKgt15wqdUcP0wjWexPq2
-s1VMqYhHE+ors//h4ky09AQ4AxP8XNI9Jno2ZgSjKw8f+f52iuxOUbNLNIMCQFfs
-vkQxTRqeAlTOApjpjwl/LOVa4cyzpBWWX9qnPF1KS6GlFrPDPHQOElCGIubl2OT6
-2dp40vXYaPUpE+0mVbUCQCxw7IvglwRKc142K7HfsSOdn0bQplS3ezEthriIzacP
-CCePPHuHI3A7+3ROFMKXmmjDauEMcpLhQen5f4/Corg=
------END RSA PRIVATE KEY-----"""
+    Bob25519PublicKey = b'2cb62682cb3f12bc320c7fa37caf14da344383bc980de3ac43c635237b725b2a'
+    Bob25519PrivateKey = b'ec6e45c26de33403c9e4059efdc940939b85f3b340dd95b7a9e32e24601960b6'
 
     # Charlie credentials in the zeth abstraction
     CharlieOwnershipKeys = zethGRPC.generateApkAskKeypair()
-    CharlieEncKey = """-----BEGIN PUBLIC KEY-----
-MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDz6F8PhRiHVCnfq5jxOx+N8Uso
-v35NJSWQ3R/iRmNK+BeNedXbqvunEbLPEdus5h9BE2RwR0wumDe7WJWIjjRLEU7C
-5dJGDEviWlJBC+yw0wbnWA5FV6Mrq0UJSLVe5Q5uiLuHuzI9Ag9UOqJZTXQ5yfG8
-9QRE8HumA1tzfxCrQwIDAQAB
------END PUBLIC KEY-----"""
-    CharlieDecKey = """-----BEGIN RSA PRIVATE KEY-----
-MIICWwIBAAKBgQDz6F8PhRiHVCnfq5jxOx+N8Usov35NJSWQ3R/iRmNK+BeNedXb
-qvunEbLPEdus5h9BE2RwR0wumDe7WJWIjjRLEU7C5dJGDEviWlJBC+yw0wbnWA5F
-V6Mrq0UJSLVe5Q5uiLuHuzI9Ag9UOqJZTXQ5yfG89QRE8HumA1tzfxCrQwIDAQAB
-AoGATQ6v4bZZ7n9Pj2OmOShFqtF9vkzpeTPwL1k89n7oZcoFnuPMBc96G+lChZsN
-vQ0i+KtIwxQzZFEg4mZ1L6RFrofOyveFxsdI3LdpAbIKZujfatnsIjvjfYuZtV71
-63oP9HAbQnatrx3vhzZgw+FoIp/0M14J3wmHC/GpdLGxABkCQQD32fzy0lSzqVTp
-elxw7U+Rkze9WPcUEQYyaFDiB4COTudFwVTxoBZd2vxfbxpfr03no59shslZxzcl
-GWPs2gbnAkEA++0wy+H7DSTSQaDFsciVId6qAvNfM9wEUpq1WepvZTvOhyULp9PI
-TrxCtvYKPjKqU/7rPsJ8eVbBoAlhDJXZRQJAeu3imKkbm7R7ygWHffcmBOUIu2A5
-w/khorS8kS75Yxvdd2qJcAJftZNcoxTe9uBi+mXcN56ulVnKjxsFxb7ptwJAWixi
-RPgURnYhlEAZwzMKvl7W98tpDkT4fyDFPPP+/3tSx2jpLR9PGW+laZvTusOj2ADs
-7z/qEfyNvdzdkgWpCQJAZyTN+aWuoqhR9h3fsCLy4NisJ3z5reViXZVMKW4J8jat
-aKtIj2rMlUbT+hLkAQmUb4YZwxtPibPTIUFTwrHmiw==
------END RSA PRIVATE KEY-----"""
+    Charlie25519PublicKey = b'a3058cdc22e4600de1b925ed02743a4310cb3011ec6a953abd9c9b859c9cec6d'
+    Charlie25519PrivateKey = b'bce6da6eda2bfe127dc1f3b7406d4f9f36d0747d04daa14b5a296fef54e0f56e'
 
     keystore = {
         "Alice": {
             "AddrPk": {
-                "ek": AliceEncKey,
+                "pubkey": Alice25519PublicKey,
                 "aPK": AliceOwnershipKeys["aPK"]
             },
             "AddrSk": {
-                "dk": AliceDecKey,
+                "privkey": Alice25519PrivateKey,
                 "aSK": AliceOwnershipKeys["aSK"]
             }
         },
         "Bob": {
             "AddrPk": {
-                "ek": BobEncKey,
+                "pubkey": Bob25519PublicKey,
                 "aPK": BobOwnershipKeys["aPK"]
             },
             "AddrSk": {
-                "dk": BobDecKey,
+                "privkey": Bob25519PrivateKey,
                 "aSK": BobOwnershipKeys["aSK"]
             }
         },
         "Charlie": {
             "AddrPk": {
-                "ek": CharlieEncKey,
+                "pubkey": Charlie25519PublicKey,
                 "aPK": CharlieOwnershipKeys["aPK"]
             },
             "AddrSk": {
-                "dk": CharlieDecKey,
+                "privkey": Charlie25519PrivateKey,
                 "aSK": CharlieOwnershipKeys["aSK"]
             }
         }

--- a/pyClient/zethMock.py
+++ b/pyClient/zethMock.py
@@ -4,18 +4,18 @@ import zethGRPC
 def initTestKeystore():
     # Alice credentials in the zeth abstraction
     AliceOwnershipKeys = zethGRPC.generateApkAskKeypair()
-    Alice25519EncPublicKey = b'97aa1d5ffc8322ea87c88de17440ed8feb1ea20e00e6d1a93cafcb2e83da5b0e'
-    Alice25519EncPrivateKey = b'82578283b14d7a3391139957e04aa16fcb498cabf4e8fb85d54a8b2526c28e42'
+    Alice25519EncPublicKey = b'\x1eO"\n\xdaWnU+\xf5\xaa\x8a#\xd2*\xd3\x11\x9fc\xe52 \xd8^\xbc-\xb6\xf1\xeej\xf41'
+    Alice25519EncPrivateKey = b'\xde\xa2\xc1\x0b\xd1\xf7\x13\xf8J\xa4:\xa4\xb6\xfa\xbd\xd5\xc9\x8a\xd9\xb6\xb4\xc4\xc4I\x88\xa4\xd9\xe2\xee\x9e\x9a\xff'
 
     # Bob credentials in the zeth abstraction
     BobOwnershipKeys = zethGRPC.generateApkAskKeypair()
-    Bob25519EncPublicKey = b'2cb62682cb3f12bc320c7fa37caf14da344383bc980de3ac43c635237b725b2a'
-    Bob25519EncPrivateKey = b'ec6e45c26de33403c9e4059efdc940939b85f3b340dd95b7a9e32e24601960b6'
+    Bob25519EncPublicKey = b't\xc5{5j\xb5\x8a\xd3n\xb3\xab9\xe8s^13\xba\xa2\x91x\xb01(\xf9\xbb\xf9@r_\x91}'
+    Bob25519EncPrivateKey = b'\xd3\xf0\x8f ,\x1d#\xdc\xac,\x93\xbd\xd0\xd9\xed\x8c\x92\x822\xef\xd6\x97^\x86\xf7\xe4/\x85\xb6\x10\xe6o'
 
     # Charlie credentials in the zeth abstraction
     CharlieOwnershipKeys = zethGRPC.generateApkAskKeypair()
-    Charlie25519EncPublicKey = b'a3058cdc22e4600de1b925ed02743a4310cb3011ec6a953abd9c9b859c9cec6d'
-    Charlie25519EncPrivateKey = b'bce6da6eda2bfe127dc1f3b7406d4f9f36d0747d04daa14b5a296fef54e0f56e'
+    Charlie25519EncPublicKey = b'u\xe7\x88\x9c\xbfE(\xf8\x99\xca<\xa8[<\xa2\x88m\xad\rN"\xf0}\xec\xfcB\x89\xe6\x96\xcf\x19U'
+    Charlie25519EncPrivateKey = b'zH\xb66q\x97\x0bO\xcb\xb9q\x9b\xbd-1`I\xae\x00-\x11\xb9\xed}\x18\x9f\xf6\x8dr\xaa\xd4R'
 
     keystore = {
         "Alice": {

--- a/pyClient/zethMock.py
+++ b/pyClient/zethMock.py
@@ -4,47 +4,47 @@ import zethGRPC
 def initTestKeystore():
     # Alice credentials in the zeth abstraction
     AliceOwnershipKeys = zethGRPC.generateApkAskKeypair()
-    Alice25519PublicKey = b'97aa1d5ffc8322ea87c88de17440ed8feb1ea20e00e6d1a93cafcb2e83da5b0e'
-    Alice25519PrivateKey = b'82578283b14d7a3391139957e04aa16fcb498cabf4e8fb85d54a8b2526c28e42'
+    Alice25519EncPublicKey = b'97aa1d5ffc8322ea87c88de17440ed8feb1ea20e00e6d1a93cafcb2e83da5b0e'
+    Alice25519EncPrivateKey = b'82578283b14d7a3391139957e04aa16fcb498cabf4e8fb85d54a8b2526c28e42'
 
     # Bob credentials in the zeth abstraction
     BobOwnershipKeys = zethGRPC.generateApkAskKeypair()
-    Bob25519PublicKey = b'2cb62682cb3f12bc320c7fa37caf14da344383bc980de3ac43c635237b725b2a'
-    Bob25519PrivateKey = b'ec6e45c26de33403c9e4059efdc940939b85f3b340dd95b7a9e32e24601960b6'
+    Bob25519EncPublicKey = b'2cb62682cb3f12bc320c7fa37caf14da344383bc980de3ac43c635237b725b2a'
+    Bob25519EncPrivateKey = b'ec6e45c26de33403c9e4059efdc940939b85f3b340dd95b7a9e32e24601960b6'
 
     # Charlie credentials in the zeth abstraction
     CharlieOwnershipKeys = zethGRPC.generateApkAskKeypair()
-    Charlie25519PublicKey = b'a3058cdc22e4600de1b925ed02743a4310cb3011ec6a953abd9c9b859c9cec6d'
-    Charlie25519PrivateKey = b'bce6da6eda2bfe127dc1f3b7406d4f9f36d0747d04daa14b5a296fef54e0f56e'
+    Charlie25519EncPublicKey = b'a3058cdc22e4600de1b925ed02743a4310cb3011ec6a953abd9c9b859c9cec6d'
+    Charlie25519EncPrivateKey = b'bce6da6eda2bfe127dc1f3b7406d4f9f36d0747d04daa14b5a296fef54e0f56e'
 
     keystore = {
         "Alice": {
             "AddrPk": {
-                "pubkey": Alice25519PublicKey,
+                "encPK": Alice25519EncPublicKey,
                 "aPK": AliceOwnershipKeys["aPK"]
             },
             "AddrSk": {
-                "privkey": Alice25519PrivateKey,
+                "encSK": Alice25519EncPrivateKey,
                 "aSK": AliceOwnershipKeys["aSK"]
             }
         },
         "Bob": {
             "AddrPk": {
-                "pubkey": Bob25519PublicKey,
+                "encPK": Bob25519EncPublicKey,
                 "aPK": BobOwnershipKeys["aPK"]
             },
             "AddrSk": {
-                "privkey": Bob25519PrivateKey,
+                "encSK": Bob25519EncPrivateKey,
                 "aSK": BobOwnershipKeys["aSK"]
             }
         },
         "Charlie": {
             "AddrPk": {
-                "pubkey": Charlie25519PublicKey,
+                "encPK": Charlie25519EncPublicKey,
                 "aPK": CharlieOwnershipKeys["aPK"]
             },
             "AddrSk": {
-                "privkey": Charlie25519PrivateKey,
+                "encSK": Charlie25519EncPrivateKey,
                 "aSK": CharlieOwnershipKeys["aSK"]
             }
         }

--- a/pyClient/zethTestScenario.py
+++ b/pyClient/zethTestScenario.py
@@ -41,8 +41,8 @@ def bob_deposit(test_grpc_endpoint, mixer_instance, mk_root, bob_eth_address, ke
 
     output_note1_str = json.dumps(zethGRPC.parseZethNote(output_note1))
     output_note2_str = json.dumps(zethGRPC.parseZethNote(output_note2))
-    ciphertext1 = zethUtils.encrypt(output_note1_str, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Bob"]["AddrSk"]["privkey"])
-    ciphertext2 = zethUtils.encrypt(output_note2_str, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Bob"]["AddrSk"]["privkey"])
+    ciphertext1 = zethUtils.encrypt(output_note1_str, keystore["Bob"]["AddrPk"]["encPK"], keystore["Bob"]["AddrSk"]["encSK"])
+    ciphertext2 = zethUtils.encrypt(output_note2_str, keystore["Bob"]["AddrPk"]["encPK"], keystore["Bob"]["AddrSk"]["encSK"])
 
     # Hash the cipher-texts
     ciphers = ciphertext1 + ciphertext2
@@ -107,8 +107,8 @@ def bob_to_charlie(test_grpc_endpoint, mixer_instance, mk_root, mk_path1, input_
 
     output_note1_str = json.dumps(zethGRPC.parseZethNote(output_note1))
     output_note2_str = json.dumps(zethGRPC.parseZethNote(output_note2))
-    ciphertext1 = zethUtils.encrypt(output_note1_str, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Bob"]["AddrSk"]["privkey"]) # Bob is the recipient
-    ciphertext2 = zethUtils.encrypt(output_note2_str, keystore["Charlie"]["AddrPk"]["pubkey"], keystore["Bob"]["AddrSk"]["privkey"]) # Charlie is the recipient
+    ciphertext1 = zethUtils.encrypt(output_note1_str, keystore["Bob"]["AddrPk"]["encPK"], keystore["Bob"]["AddrSk"]["encSK"]) # Bob is the recipient
+    ciphertext2 = zethUtils.encrypt(output_note2_str, keystore["Charlie"]["AddrPk"]["encPK"], keystore["Bob"]["AddrSk"]["encSK"]) # Charlie is the recipient
 
     # Hash the cipher-texts
     ciphers = ciphertext1 + ciphertext2
@@ -172,8 +172,8 @@ def charlie_withdraw(test_grpc_endpoint, mixer_instance, mk_root, mk_path1, inpu
 
     output_note1_str = json.dumps(zethGRPC.parseZethNote(output_note1))
     output_note2_str = json.dumps(zethGRPC.parseZethNote(output_note2))
-    ciphertext1 = zethUtils.encrypt(output_note1_str, keystore["Charlie"]["AddrPk"]["pubkey"], keystore["Charlie"]["AddrSk"]["privkey"]) # Charlie is the recipient
-    ciphertext2 = zethUtils.encrypt(output_note2_str, keystore["Charlie"]["AddrPk"]["pubkey"], keystore["Charlie"]["AddrSk"]["privkey"]) # Charlie is the recipient
+    ciphertext1 = zethUtils.encrypt(output_note1_str, keystore["Charlie"]["AddrPk"]["encPK"], keystore["Charlie"]["AddrSk"]["encSK"]) # Charlie is the recipient
+    ciphertext2 = zethUtils.encrypt(output_note2_str, keystore["Charlie"]["AddrPk"]["encPK"], keystore["Charlie"]["AddrSk"]["encSK"]) # Charlie is the recipient
     ciphers = [ciphertext1, ciphertext2]
 
     # Hash the cipher-texts

--- a/pyClient/zethTestScenario.py
+++ b/pyClient/zethTestScenario.py
@@ -7,6 +7,7 @@ import json
 from hashlib import sha256
 
 from web3 import Web3, HTTPProvider, IPCProvider, WebsocketProvider
+
 w3 = Web3(HTTPProvider("http://localhost:8545"))
 
 zero_wei_hex = "0000000000000000"
@@ -43,9 +44,10 @@ def bob_deposit(test_grpc_endpoint, mixer_instance, mk_root, bob_eth_address, ke
     output_note2_str = json.dumps(zethGRPC.parseZethNote(output_note2))
     ciphertext1 = zethUtils.encrypt(output_note1_str, keystore["Bob"]["AddrPk"]["encPK"], keystore["Bob"]["AddrSk"]["encSK"])
     ciphertext2 = zethUtils.encrypt(output_note2_str, keystore["Bob"]["AddrPk"]["encPK"], keystore["Bob"]["AddrSk"]["encSK"])
+    pk_sender = keystore["Bob"]["AddrPk"]["encPK"]
 
-    # Hash the cipher-texts
-    ciphers = ciphertext1 + ciphertext2
+    # Hash the pk_sender and cipher-texts
+    ciphers = pk_sender + ciphertext1 + ciphertext2
     hash_ciphers = sha256(ciphers).hexdigest()
 
     # Hash the proof
@@ -64,6 +66,7 @@ def bob_deposit(test_grpc_endpoint, mixer_instance, mk_root, bob_eth_address, ke
 
     return zethContracts.mix(
         mixer_instance,
+        pk_sender,
         ciphertext1,
         ciphertext2,
         proof_json,
@@ -109,9 +112,10 @@ def bob_to_charlie(test_grpc_endpoint, mixer_instance, mk_root, mk_path1, input_
     output_note2_str = json.dumps(zethGRPC.parseZethNote(output_note2))
     ciphertext1 = zethUtils.encrypt(output_note1_str, keystore["Bob"]["AddrPk"]["encPK"], keystore["Bob"]["AddrSk"]["encSK"]) # Bob is the recipient
     ciphertext2 = zethUtils.encrypt(output_note2_str, keystore["Charlie"]["AddrPk"]["encPK"], keystore["Bob"]["AddrSk"]["encSK"]) # Charlie is the recipient
+    pk_sender = keystore["Bob"]["AddrPk"]["encPK"]
 
-    # Hash the cipher-texts
-    ciphers = ciphertext1 + ciphertext2
+    # Hash the pk_sender and cipher-texts
+    ciphers = pk_sender + ciphertext1 + ciphertext2
     hash_ciphers = sha256(ciphers).hexdigest()
 
     # Hash the proof
@@ -130,6 +134,7 @@ def bob_to_charlie(test_grpc_endpoint, mixer_instance, mk_root, mk_path1, input_
 
     return zethContracts.mix(
         mixer_instance,
+        pk_sender,
         ciphertext1,
         ciphertext2,
         proof_json,
@@ -174,10 +179,10 @@ def charlie_withdraw(test_grpc_endpoint, mixer_instance, mk_root, mk_path1, inpu
     output_note2_str = json.dumps(zethGRPC.parseZethNote(output_note2))
     ciphertext1 = zethUtils.encrypt(output_note1_str, keystore["Charlie"]["AddrPk"]["encPK"], keystore["Charlie"]["AddrSk"]["encSK"]) # Charlie is the recipient
     ciphertext2 = zethUtils.encrypt(output_note2_str, keystore["Charlie"]["AddrPk"]["encPK"], keystore["Charlie"]["AddrSk"]["encSK"]) # Charlie is the recipient
-    ciphers = [ciphertext1, ciphertext2]
+    pk_sender = keystore["Charlie"]["AddrPk"]["encPK"]
 
-    # Hash the cipher-texts
-    ciphers = ciphertext1 + ciphertext2
+    # Hash the pk_sender and cipher-texts
+    ciphers = pk_sender + ciphertext1 + ciphertext2
     hash_ciphers = sha256(ciphers).hexdigest()
 
     # Hash the proof
@@ -196,6 +201,7 @@ def charlie_withdraw(test_grpc_endpoint, mixer_instance, mk_root, mk_path1, inpu
 
     return zethContracts.mix(
         mixer_instance,
+        pk_sender,
         ciphertext1,
         ciphertext2,
         proof_json,

--- a/pyClient/zethTestScenario.py
+++ b/pyClient/zethTestScenario.py
@@ -41,8 +41,8 @@ def bob_deposit(test_grpc_endpoint, mixer_instance, mk_root, bob_eth_address, ke
 
     output_note1_str = json.dumps(zethGRPC.parseZethNote(output_note1))
     output_note2_str = json.dumps(zethGRPC.parseZethNote(output_note2))
-    ciphertext1 = zethUtils.encrypt(output_note1_str, keystore["Bob"]["AddrPk"]["ek"])
-    ciphertext2 = zethUtils.encrypt(output_note2_str, keystore["Bob"]["AddrPk"]["ek"])
+    ciphertext1 = zethUtils.encrypt(output_note1_str, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Bob"]["AddrSk"]["privkey"])
+    ciphertext2 = zethUtils.encrypt(output_note2_str, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Bob"]["AddrSk"]["privkey"])
 
     # Hash the cipher-texts
     ciphers = ciphertext1 + ciphertext2
@@ -107,8 +107,8 @@ def bob_to_charlie(test_grpc_endpoint, mixer_instance, mk_root, mk_path1, input_
 
     output_note1_str = json.dumps(zethGRPC.parseZethNote(output_note1))
     output_note2_str = json.dumps(zethGRPC.parseZethNote(output_note2))
-    ciphertext1 = zethUtils.encrypt(output_note1_str.encode('utf-8'), keystore["Bob"]["AddrPk"]["pubkey"], keystore["Bob"]["AddrSk"]["privkey"]) # Bob is the recipient
-    ciphertext2 = zethUtils.encrypt(output_note2_str.encode('utf-8'), keystore["Charlie"]["AddrPk"]["pubkey"], keystore["Bob"]["AddrSk"]["privkey"]) # Charlie is the recipient
+    ciphertext1 = zethUtils.encrypt(output_note1_str, keystore["Bob"]["AddrPk"]["pubkey"], keystore["Bob"]["AddrSk"]["privkey"]) # Bob is the recipient
+    ciphertext2 = zethUtils.encrypt(output_note2_str, keystore["Charlie"]["AddrPk"]["pubkey"], keystore["Bob"]["AddrSk"]["privkey"]) # Charlie is the recipient
 
     # Hash the cipher-texts
     ciphers = ciphertext1 + ciphertext2
@@ -172,8 +172,8 @@ def charlie_withdraw(test_grpc_endpoint, mixer_instance, mk_root, mk_path1, inpu
 
     output_note1_str = json.dumps(zethGRPC.parseZethNote(output_note1))
     output_note2_str = json.dumps(zethGRPC.parseZethNote(output_note2))
-    ciphertext1 = zethUtils.encrypt(output_note1_str, keystore["Charlie"]["AddrPk"]["ek"]) # Charlie is the recipient
-    ciphertext2 = zethUtils.encrypt(output_note2_str, keystore["Charlie"]["AddrPk"]["ek"]) # Charlie is the recipient
+    ciphertext1 = zethUtils.encrypt(output_note1_str, keystore["Charlie"]["AddrPk"]["pubkey"], keystore["Charlie"]["AddrSk"]["privkey"]) # Charlie is the recipient
+    ciphertext2 = zethUtils.encrypt(output_note2_str, keystore["Charlie"]["AddrPk"]["pubkey"], keystore["Charlie"]["AddrSk"]["privkey"]) # Charlie is the recipient
     ciphers = [ciphertext1, ciphertext2]
 
     # Hash the cipher-texts

--- a/pyClient/zethTestScenario.py
+++ b/pyClient/zethTestScenario.py
@@ -107,8 +107,8 @@ def bob_to_charlie(test_grpc_endpoint, mixer_instance, mk_root, mk_path1, input_
 
     output_note1_str = json.dumps(zethGRPC.parseZethNote(output_note1))
     output_note2_str = json.dumps(zethGRPC.parseZethNote(output_note2))
-    ciphertext1 = zethUtils.encrypt(output_note1_str, keystore["Bob"]["AddrPk"]["ek"]) # Bob is the recipient
-    ciphertext2 = zethUtils.encrypt(output_note2_str, keystore["Charlie"]["AddrPk"]["ek"]) # Charlie is the recipient
+    ciphertext1 = zethUtils.encrypt(output_note1_str.encode('utf-8'), keystore["Bob"]["AddrPk"]["pubkey"], keystore["Bob"]["AddrSk"]["privkey"]) # Bob is the recipient
+    ciphertext2 = zethUtils.encrypt(output_note2_str.encode('utf-8'), keystore["Charlie"]["AddrPk"]["pubkey"], keystore["Bob"]["AddrSk"]["privkey"]) # Charlie is the recipient
 
     # Hash the cipher-texts
     ciphers = ciphertext1 + ciphertext2

--- a/pyClient/zethTestScenario.py
+++ b/pyClient/zethTestScenario.py
@@ -49,8 +49,12 @@ def bob_deposit(test_grpc_endpoint, mixer_instance, mk_root, bob_eth_address, ke
     # generate ephemeral ec25519 key
     eph_sk_bob = PrivateKey.generate()
 
-    ciphertext1 = zethUtils.encrypt(output_note1_str, keystore["Bob"]["AddrPk"]["encPK"], eph_sk_bob)
-    ciphertext2 = zethUtils.encrypt(output_note2_str, keystore["Bob"]["AddrPk"]["encPK"], eph_sk_bob)
+    # construct pk object from bytes
+    pk_bob = zethUtils.get_public_key_from_bytes(keystore["Bob"]["AddrPk"]["encPK"])
+
+    # encrypt the coins
+    ciphertext1 = zethUtils.encrypt(output_note1_str, pk_bob, eph_sk_bob)
+    ciphertext2 = zethUtils.encrypt(output_note2_str, pk_bob, eph_sk_bob)
 
     # get the ephemeral public key of the sender in bytes
     eph_pk_sender_bytes = eph_sk_bob.public_key.encode(encoder=nacl.encoding.RawEncoder)
@@ -123,8 +127,13 @@ def bob_to_charlie(test_grpc_endpoint, mixer_instance, mk_root, mk_path1, input_
     # generate ephemeral ec25519 key
     eph_sk_bob = PrivateKey.generate()
 
-    ciphertext1 = zethUtils.encrypt(output_note1_str, keystore["Bob"]["AddrPk"]["encPK"], eph_sk_bob) # Bob is the recipient
-    ciphertext2 = zethUtils.encrypt(output_note2_str, keystore["Charlie"]["AddrPk"]["encPK"], eph_sk_bob) # Charlie is the recipient
+    # construct pk objects from bytes
+    pk_bob = zethUtils.get_public_key_from_bytes(keystore["Bob"]["AddrPk"]["encPK"])
+    pk_charlie = zethUtils.get_public_key_from_bytes(keystore["Charlie"]["AddrPk"]["encPK"])
+
+    # encrypt the coins
+    ciphertext1 = zethUtils.encrypt(output_note1_str, pk_bob, eph_sk_bob) # Bob is the recipient
+    ciphertext2 = zethUtils.encrypt(output_note2_str, pk_charlie, eph_sk_bob) # Charlie is the recipient
     pk_sender = eph_sk_bob.public_key.encode(encoder=nacl.encoding.RawEncoder)
 
     # Hash the pk_sender and cipher-texts
@@ -194,8 +203,12 @@ def charlie_withdraw(test_grpc_endpoint, mixer_instance, mk_root, mk_path1, inpu
     # generate ephemeral ec25519 key
     eph_sk_charlie = PrivateKey.generate()
 
-    ciphertext1 = zethUtils.encrypt(output_note1_str, keystore["Charlie"]["AddrPk"]["encPK"], eph_sk_charlie) # Charlie is the recipient
-    ciphertext2 = zethUtils.encrypt(output_note2_str, keystore["Charlie"]["AddrPk"]["encPK"], eph_sk_charlie) # Charlie is the recipient
+    # construct pk object from bytes
+    pk_charlie = zethUtils.get_public_key_from_bytes(keystore["Charlie"]["AddrPk"]["encPK"])
+
+    # encrypt the coins
+    ciphertext1 = zethUtils.encrypt(output_note1_str, pk_charlie, eph_sk_charlie) # Charlie is the recipient
+    ciphertext2 = zethUtils.encrypt(output_note2_str, pk_charlie, eph_sk_charlie) # Charlie is the recipient
     pk_sender = eph_sk_charlie.public_key.encode(encoder=nacl.encoding.RawEncoder)
 
     # Hash the pk_sender and cipher-texts

--- a/pyClient/zethUtils.py
+++ b/pyClient/zethUtils.py
@@ -26,10 +26,9 @@ def get_private_key_from_bytes(private_key_bytes):
 def get_public_key_from_bytes(public_key_bytes):
   return PublicKey(public_key_bytes, encoder=nacl.encoding.RawEncoder)
 
-# Encrypts a string message by using valid hexadecimal ec25519 public and private keys. See: https://pynacl.readthedocs.io/en/stable/public/
-def encrypt(message, public_key_bytes, private_key_bytes):
+# Encrypts a string message by using valid ec25519 public key (bytes) and a private key object. See: https://pynacl.readthedocs.io/en/stable/public/
+def encrypt(message, public_key_bytes, private_key):
   # Decodes hex representation to keys objects
-  private_key = get_private_key_from_bytes(private_key_bytes)
   public_key = get_public_key_from_bytes(public_key_bytes)
 
   # Inits encryption box instance
@@ -44,10 +43,9 @@ def encrypt(message, public_key_bytes, private_key_bytes):
   # Need to cast to the parent class Bytes of nacl.utils.EncryptedMessage to make it accepted from mix solidity function
   return bytes(encrypted)
 
-# Decrypts a string ciphertext by using valid hexadecimal ec25519 public and private keys. See: https://pynacl.readthedocs.io/en/stable/public/
-def decrypt(encrypted_message, public_key_bytes, private_key_bytes):
+# Decrypts a string ciphertext by using valid ec25519 public key (bytes) and a private key object. See: https://pynacl.readthedocs.io/en/stable/public/
+def decrypt(encrypted_message, public_key_bytes, private_key):
   # Decode hex to keys objects
-  private_key = get_private_key_from_bytes(private_key_bytes)
   public_key = get_public_key_from_bytes(public_key_bytes)
 
   # Inits encryption box instance

--- a/pyClient/zethUtils.py
+++ b/pyClient/zethUtils.py
@@ -81,7 +81,7 @@ def compute_merkle_path(address_commitment, tree_depth, byte_tree):
 def receive(ciphertext, public_key_hex, private_key_hex, username):
     recovered_plaintext = ""
     try:
-        recovered_plaintext = decrypt(ciphertext, decryption_key)
+        recovered_plaintext = decrypt(ciphertext, public_key_hex, private_key_hex)
         print("[INFO] {} recovered one plaintext".format(username.capitalize()))
         print("[INFO] {} received a payment!".format(username.capitalize()))
         # Just as an example we write the received coin in the coinstore

--- a/pyClient/zethUtils.py
+++ b/pyClient/zethUtils.py
@@ -14,44 +14,45 @@ import zethGRPC
 # Import the constants and standard errors defined for zeth
 import zethConstants as constants
 import zethErrors as errors
-import zethMock
 
 from web3 import Web3, HTTPProvider, IPCProvider, WebsocketProvider
 w3 = Web3(HTTPProvider(constants.WEB3_HTTP_PROVIDER))
 
-# get PrivateKey object from hexadecimal representation (see: https://pynacl.readthedocs.io/en/stable/public/#nacl.public.PrivateKey)
+# Gets PrivateKey object from hexadecimal representation (see: https://pynacl.readthedocs.io/en/stable/public/#nacl.public.PrivateKey)
 def get_private_key_from_hex(private_key_hex):
   return PrivateKey(private_key_hex, encoder=nacl.encoding.HexEncoder)
 
-# get PublicKey object from hexadecimal representation (see: https://pynacl.readthedocs.io/en/stable/public/#nacl.public.PublicKey)
+# Gets PublicKey object from hexadecimal representation (see: https://pynacl.readthedocs.io/en/stable/public/#nacl.public.PublicKey)
 def get_public_key_from_hex(public_key_hex):
   return PublicKey(public_key_hex, encoder=nacl.encoding.HexEncoder)
 
+# Encrypts a string message by using valid hexadecimal ec25519 public and private keys. See: https://pynacl.readthedocs.io/en/stable/public/
 def encrypt(message, public_key_hex, private_key_hex):
-  # Decode hex representation to keys objects
+  # Decodes hex representation to keys objects
   private_key = get_private_key_from_hex(private_key_hex)
   public_key = get_public_key_from_hex(public_key_hex)
 
-  # Init encryption box instance
+  # Inits encryption box instance
   encryption_box = Box(private_key, public_key)
 
-  # str message encoding to bytes
+  # Encods str message to bytes
   message_bytes = message.encode('utf-8')
 
-  # Encrypt the message. The nonce is chosen randomly
+  # Encrypts the message. The nonce is chosen randomly.
   encrypted = encryption_box.encrypt(message_bytes, encoder=nacl.encoding.HexEncoder)
 
   return str(encrypted, encoding = 'utf-8')
 
+# Decrypts a string ciphertext by using valid hexadecimal ec25519 public and private keys. See: https://pynacl.readthedocs.io/en/stable/public/
 def decrypt(encrypted_message, public_key_hex, private_key_hex):
-
   # Decode hex to keys objects
   private_key = get_private_key_from_hex(private_key_hex)
   public_key = get_public_key_from_hex(public_key_hex)
 
-  # Init encryption box instance
+  # Inits encryption box instance
   decryption_box = Box(private_key, public_key)
 
+  # Checks integrity of the ciphertext and decrypts it
   message = decryption_box.decrypt(bytes(encrypted_message, encoding ='utf-8'), encoder=nacl.encoding.HexEncoder)
 
   return str(message, encoding = 'utf-8')
@@ -109,7 +110,7 @@ def parse_zksnark_arg():
         return sys.exit(errors.SNARK_NOT_SUPPORTED)
     return args.zksnark
 
-# Generate private/public keys (kP, k) over Curve25519 for Alice, Bob and Charlie
+# Generates private/public keys (kP, k) over Curve25519 for Alice, Bob and Charlie
 def gen_keys_utility(to_print=False):
   # Alice
   skalice = PrivateKey.generate()

--- a/pyClient/zethUtils.py
+++ b/pyClient/zethUtils.py
@@ -18,38 +18,40 @@ import zethErrors as errors
 from web3 import Web3, HTTPProvider, IPCProvider, WebsocketProvider
 w3 = Web3(HTTPProvider(constants.WEB3_HTTP_PROVIDER))
 
-# Gets PrivateKey object from hexadecimal representation (see: https://pynacl.readthedocs.io/en/stable/public/#nacl.public.PrivateKey)
+# Gets PrivateKey object from hexadecimal representation
+# (see: https://pynacl.readthedocs.io/en/stable/public/#nacl.public.PrivateKey)
 def get_private_key_from_bytes(sk_bytes):
   return PrivateKey(sk_bytes, encoder=nacl.encoding.RawEncoder)
 
-# Gets PublicKey object from hexadecimal representation (see: https://pynacl.readthedocs.io/en/stable/public/#nacl.public.PublicKey)
+# Gets PublicKey object from hexadecimal representation
+# (see: https://pynacl.readthedocs.io/en/stable/public/#nacl.public.PublicKey)
 def get_public_key_from_bytes(pk_bytes):
   return PublicKey(pk_bytes, encoder=nacl.encoding.RawEncoder)
 
-# Encrypts a string message by using valid ec25519 public key and private key objects. See: https://pynacl.readthedocs.io/en/stable/public/
+# Encrypts a string message by using valid ec25519 public key and
+# private key objects. See: https://pynacl.readthedocs.io/en/stable/public/
 def encrypt(message, pk_receiver, sk_sender):
-
-  # Inits encryption box instance
+  # Init encryption box instance
   encryption_box = Box(sk_sender, pk_receiver)
 
-  # Encods str message to bytes
+  # Encode str message to bytes
   message_bytes = message.encode('utf-8')
 
-  # Encrypts the message. The nonce is chosen randomly.
+  # Encrypt the message. The nonce is chosen randomly.
   encrypted = encryption_box.encrypt(message_bytes, encoder=nacl.encoding.RawEncoder)
 
-  # Need to cast to the parent class Bytes of nacl.utils.EncryptedMessage to make it accepted from mix solidity function
+  # Need to cast to the parent class Bytes of nacl.utils.EncryptedMessage
+  # to make it accepted from `Mix` Solidity function
   return bytes(encrypted)
 
-# Decrypts a string message by using valid ec25519 public key and private key objects. See: https://pynacl.readthedocs.io/en/stable/public/
+# Decrypts a string message by using valid ec25519 public key and private key objects.
+# See: https://pynacl.readthedocs.io/en/stable/public/
 def decrypt(encrypted_message, pk_sender, sk_receiver):
-
-  # Inits encryption box instance
+  # Init encryption box instance
   decryption_box = Box(sk_receiver, pk_sender)
 
-  # Checks integrity of the ciphertext and decrypts it
+  # Check integrity of the ciphertext and decrypt it
   message = decryption_box.decrypt(encrypted_message)
-
   return str(message, encoding = 'utf-8')
 
 # Converts the realtive address of a leaf to an absolute address in the tree
@@ -107,7 +109,6 @@ def parse_zksnark_arg():
 
 # Generates private/public keys (kP, k) over Curve25519 for Alice, Bob and Charlie
 def gen_keys_utility(to_print=False):
-
   # Encoder
   encoder = encoder=nacl.encoding.RawEncoder
 

--- a/pyClient/zethUtils.py
+++ b/pyClient/zethUtils.py
@@ -1,12 +1,13 @@
-import nacl.utils
-from nacl.public import PrivateKey, PublicKey, Box
-
 # Parse the arguments given to the script
 import argparse
 import sys
 
 import os
 import time
+
+# Import Pynacl required modules
+import nacl.utils
+from nacl.public import PrivateKey, PublicKey, Box
 
 import zethGRPC
 
@@ -34,8 +35,11 @@ def encrypt(message, public_key_hex, private_key_hex):
   # Init encryption box instance
   encryption_box = Box(private_key, public_key)
 
-  # Nonce is chosen randomly
-  encrypted = encryption_box.encrypt(message, encoder=nacl.encoding.HexEncoder)
+  # str message encoding to bytes
+  message_bytes = message.encode('utf-8')
+
+  # Encrypt the message. The nonce is chosen randomly
+  encrypted = encryption_box.encrypt(message_bytes, encoder=nacl.encoding.HexEncoder)
 
   return str(encrypted, encoding = 'utf-8')
 

--- a/zeth-contracts/contracts/BaseMixer.sol
+++ b/zeth-contracts/contracts/BaseMixer.sol
@@ -77,10 +77,10 @@ contract BaseMixer is MerkleTreeMiMC7, ERC223ReceivingContract {
     // Event to emit the root of a the merkle tree
     event LogMerkleRoot(bytes32 root);
 
-    // Event to emit the ciphertexts of the coins' data to be sent to the recipient of the payment
+    // Event to emit the encryption public key of the sender and ciphertexts of the coins' data to be sent to the recipient of the payment
     // This event is key to obfuscate the transaction graph while enabling on-chain storage of the coins' data
     // (useful to ease backup of user's wallets)
-    event LogSecretCiphers(string ciphertext);
+    event LogSecretCiphers(bytes32 pk_sender, bytes ciphertext);
 
     // Debug only
     event LogDebug(string message);
@@ -238,8 +238,8 @@ contract BaseMixer is MerkleTreeMiMC7, ERC223ReceivingContract {
         emit LogMerkleRoot(root);
     }
 
-    function emit_ciphertexts(string memory ciphertext0, string memory ciphertext1) internal {
-        emit LogSecretCiphers(ciphertext0);
-        emit LogSecretCiphers(ciphertext1);
+    function emit_ciphertexts(bytes32 pk_sender, bytes memory ciphertext0, bytes memory ciphertext1) internal {
+        emit LogSecretCiphers(pk_sender, ciphertext0);
+        emit LogSecretCiphers(pk_sender, ciphertext1);
     }
 }

--- a/zeth-contracts/contracts/BaseMixer.sol
+++ b/zeth-contracts/contracts/BaseMixer.sol
@@ -64,9 +64,6 @@ contract BaseMixer is MerkleTreeMiMC7, ERC223ReceivingContract {
     // If token = address(0) then the mixer works with ether
     address public token;
 
-    // Contract variable that indicates the address of the hasher contract
-    address public hasher;
-
     // Event to emit the address of a commitment in the merke tree
     // Allows for faster execution of the "Receive" functions on the receiver side.
     // The ciphertext of a note is emitted along the address of insertion in the tree

--- a/zeth-contracts/contracts/Groth16Mixer.sol
+++ b/zeth-contracts/contracts/Groth16Mixer.sol
@@ -18,15 +18,15 @@ contract Groth16Mixer is BaseMixer {
 
     // This function allows to mix coins and execute payments in zero knowledge
     function mix (
-        bytes32 pk_sender,
-        bytes memory ciphertext0,
-        bytes memory ciphertext1, // The nb of ciphertexts depends on the JS description (Here 2 inputs)
         uint[2] memory a,
         uint[2][2] memory b,
         uint[2] memory c,
         uint[2][2] memory vk,
         uint sigma,
-        uint[] memory input
+        uint[] memory input,
+        bytes32 pk_sender,
+        bytes memory ciphertext0,
+        bytes memory ciphertext1 // The nb of ciphertexts depends on the JS description (Here 2 inputs)
     ) public payable {
         // 1. Check the root and the nullifiers
         assemble_root_and_nullifiers_and_append_to_state(input);
@@ -39,7 +39,7 @@ contract Groth16Mixer is BaseMixer {
 
         // 2.b Verify the signature
         bytes32 hash_proof = sha256(abi.encodePacked(a, b, c));
-        bytes32 hash_ciphers = sha256(abi.encodePacked(ciphertext0, ciphertext1));
+        bytes32 hash_ciphers = sha256(abi.encodePacked(pk_sender,ciphertext0, ciphertext1));
         require(
             otsig_verifier.verify(
                 vk,

--- a/zeth-contracts/contracts/Groth16Mixer.sol
+++ b/zeth-contracts/contracts/Groth16Mixer.sol
@@ -39,7 +39,7 @@ contract Groth16Mixer is BaseMixer {
 
         // 2.b Verify the signature
         bytes32 hash_proof = sha256(abi.encodePacked(a, b, c));
-        bytes32 hash_ciphers = sha256(abi.encodePacked(pk_sender,ciphertext0, ciphertext1));
+        bytes32 hash_ciphers = sha256(abi.encodePacked(pk_sender, ciphertext0, ciphertext1));
         require(
             otsig_verifier.verify(
                 vk,

--- a/zeth-contracts/contracts/Groth16Mixer.sol
+++ b/zeth-contracts/contracts/Groth16Mixer.sol
@@ -18,8 +18,9 @@ contract Groth16Mixer is BaseMixer {
 
     // This function allows to mix coins and execute payments in zero knowledge
     function mix (
-        string memory ciphertext0,
-        string memory ciphertext1, // The nb of ciphertexts depends on the JS description (Here 2 inputs)
+        bytes32 pk_sender,
+        bytes memory ciphertext0,
+        bytes memory ciphertext1, // The nb of ciphertexts depends on the JS description (Here 2 inputs)
         uint[2] memory a,
         uint[2][2] memory b,
         uint[2] memory c,
@@ -60,6 +61,6 @@ contract Groth16Mixer is BaseMixer {
         add_and_emit_merkle_root(getRoot());
 
         // Emit the all the coins' secret data encrypted with the recipients' respective keys
-        emit_ciphertexts(ciphertext0, ciphertext1);
+        emit_ciphertexts(pk_sender, ciphertext0, ciphertext1);
     }
 }

--- a/zeth-contracts/contracts/Pghr13Mixer.sol
+++ b/zeth-contracts/contracts/Pghr13Mixer.sol
@@ -18,8 +18,9 @@ contract Pghr13Mixer is BaseMixer {
 
     // This function allows to mix coins and execute payments in zero knowledge
     function mix (
-        string memory ciphertext1,
-        string memory ciphertext2, // Nb of ciphertexts depends on the JS description (Here 2 inputs)
+        bytes32 pk_sender,
+        bytes memory ciphertext0,
+        bytes memory ciphertext1, // Nb of ciphertexts depends on the JS description (Here 2 inputs)
         uint[2] memory a,
         uint[2] memory a_p,
         uint[2][2] memory b,
@@ -43,7 +44,7 @@ contract Pghr13Mixer is BaseMixer {
 
         // 2.b Verify the signature
         bytes32 hash_proof = sha256(abi.encodePacked(a, a_p, b, b_p, c, c_p, h, k));
-        bytes32 hash_ciphers = sha256(abi.encodePacked(ciphertext1, ciphertext2));
+        bytes32 hash_ciphers = sha256(abi.encodePacked(ciphertext0, ciphertext1));
         require(
             otsig_verifier.verify(
                 vk,
@@ -65,6 +66,6 @@ contract Pghr13Mixer is BaseMixer {
         add_and_emit_merkle_root(getRoot());
 
         // Emit the all the coins' secret data encrypted with the recipients' respective keys
-        emit_ciphertexts(ciphertext1, ciphertext2);
+        emit_ciphertexts(pk_sender, ciphertext0, ciphertext1);
     }
 }

--- a/zeth-contracts/contracts/Pghr13Mixer.sol
+++ b/zeth-contracts/contracts/Pghr13Mixer.sol
@@ -18,9 +18,6 @@ contract Pghr13Mixer is BaseMixer {
 
     // This function allows to mix coins and execute payments in zero knowledge
     function mix (
-        bytes32 pk_sender,
-        bytes memory ciphertext0,
-        bytes memory ciphertext1, // Nb of ciphertexts depends on the JS description (Here 2 inputs)
         uint[2] memory a,
         uint[2] memory a_p,
         uint[2][2] memory b,
@@ -31,7 +28,10 @@ contract Pghr13Mixer is BaseMixer {
         uint[2] memory k,
         uint[2][2] memory vk,
         uint sigma,
-        uint[] memory input
+        uint[] memory input,
+        bytes32 pk_sender,
+        bytes memory ciphertext0,
+        bytes memory ciphertext1 // Nb of ciphertexts depends on the JS description (Here 2 inputs)
         ) public payable {
         // 1. Check the root and the nullifiers
         assemble_root_and_nullifiers_and_append_to_state(input);
@@ -44,7 +44,7 @@ contract Pghr13Mixer is BaseMixer {
 
         // 2.b Verify the signature
         bytes32 hash_proof = sha256(abi.encodePacked(a, a_p, b, b_p, c, c_p, h, k));
-        bytes32 hash_ciphers = sha256(abi.encodePacked(ciphertext0, ciphertext1));
+        bytes32 hash_ciphers = sha256(abi.encodePacked(pk_sender, ciphertext0, ciphertext1));
         require(
             otsig_verifier.verify(
                 vk,


### PR DESCRIPTION
This pull request covers issue #2 introducing a different encryption scheme to exchange coin data.

Each user now has a keypair of public/private keys over ec25519. By using diffie-hellmann key-exchange **X25519**, a shared secret is dynamically recovered and used as secret key for the symmetric authenticated encryption scheme **XSalsa20-Poly1305 MAC**. Although, the secret key is always the same, the security is ensured by the use a random nonce for each encryption.

### Algorithms details

- **X25519** diffie-helmann key exchange over 25519 curve generating 32 bytes long shared secret.
- **XSalsa20** is a stream cipher of 32 bytes key length. It uses nonce of 24 bytes.
- **Poly1305** is a message authentication code of 16 bytes size

See more: https://download.libsodium.org/doc/public-key_cryptography/authenticated_encryption

PyNacl python wrapper is used to call the underlying libsodium library. See: https://pynacl.readthedocs.io/en/stable/public/