### PR TITLE
Enable travis to check the build, tests and formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ addons:
     apt:
         packages:
             - docker.io
+            - clang-format
     homebrew:
         packages:
             - gmp
@@ -17,7 +18,7 @@ matrix:
         - env: CI_TASK=build_release CI_USE_DOCKER=1
           os: linux
           language: minimal
-        - env: CI_TASK=build_debug CI_USE_DOCKER=1
+        - env: CI_CHECK_FORMAT=1 CI_TASK=build_debug CI_USE_DOCKER=1
           os: linux
           language: minimal
         - env: CI_TASK=build_release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+addons:
+    apt:
+        packages:
+            - docker.io
+    homebrew:
+        packages:
+            - gmp
+            - grpc
+            - protobuf
+            - boost
+            - openssl
+            - cmake
+            # - llvm
+
+matrix:
+    include:
+        - env: CI_TASK=build_release CI_USE_DOCKER=1
+          os: linux
+          language: minimal
+        - env: CI_TASK=build_debug CI_USE_DOCKER=1
+          os: linux
+          language: minimal
+        - env: CI_TASK=build_release
+          os: osx
+          osx_image: xcode11
+        - env: CI_TASK=build_debug
+          os: osx
+          osx_image: xcode11
+
+script: CI_USE_DOCKER=${CI_USE_DOCKER} scripts/ci ${CI_TASK}

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ matrix:
           os: osx
           osx_image: xcode11
 
-script: CI_USE_DOCKER=${CI_USE_DOCKER} scripts/ci ${CI_TASK}
+script: CI_USE_DOCKER=${CI_USE_DOCKER} travis_wait 30 scripts/ci ${CI_TASK}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,13 @@ set(
   "Default snark: one of PGHR13, GROTH16"
 )
 
+# Run only fast test (e.g. on CI machine)
+option(
+  FAST_TESTS_ONLY
+  "Include only fast-running tests"
+  OFF
+)
+
 # Flags and compilation options for use with libsnark
 set(
   CURVE # Variable name

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ if(APPLE)
   set(WITH_SUPERCOP OFF CACHE BOOL "Build libff with supercop")
 
   # (Currently) OpenMP only available with custom llvm compilers
-  if(${CMAKE_C_COMPILER} MATCHES "/cc$")
+  if(${CMAKE_C_COMPILER} MATCHES ".*cc$")
     set(MULTICORE OFF)
   endif()
 endif()

--- a/scripts/ci
+++ b/scripts/ci
@@ -36,7 +36,7 @@ function build() {
         cxx_flags="${cxx_flags} -Wno-deprecated-declarations"
     fi
 
-    cmake_flags="-DFAST_TESTS_ONLY=ON -DCMAKE_BUILD_TYPE=${build_type}"
+    cmake_flags="-DCMAKE_BUILD_TYPE=${build_type}"
 
     . setup_env.sh
     mkdir -p build

--- a/scripts/ci
+++ b/scripts/ci
@@ -7,6 +7,17 @@ echo "running against commit: "`git log --oneline --no-decorate -n 1`
 set -x
 set -e
 
+function format_check() {
+    scripts/format
+    git diff --no-ext-diff | head -n 20 > format_errors
+    num_lines=`cat format_errors | wc -l`
+    if [ "0" != "${num_lines}" ] ; then
+        echo CODE FORMATTING ERRORS:
+        cat format_errors
+        exit 1
+    fi
+}
+
 function build() {
     dir_name=$1
     build_type=$2
@@ -49,6 +60,10 @@ function build_debug() {
 
 # The CI_EXECTUTE_IN_DOCKER variable determines whether we should
 # re-execute in the docker container.
+
+if [ "1" == "${CI_CHECK_FORMAT}" ] ; then
+    format_check
+fi
 
 if [ "1" == "${CI_USE_DOCKER}" ] ; then
     docker pull clearmatics/zeth-base:latest

--- a/scripts/ci
+++ b/scripts/ci
@@ -8,23 +8,34 @@ set -x
 set -e
 
 function build() {
+    dir_name=$1
+    build_type=$2
+
+    # Enable warnings-as-errors
+
+    cxx_flags="-Werror"
+
     if [ "Darwin" == "${platform}" ] ; then
         export PATH="/usr/local/opt/llvm/bin:/usr/local/bin:${PATH}"
         export PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig"
         export LIBRARY_PATH="/usr/local/opt/openssl/lib"
         export LDFLAGS="-L/usr/local/opt/llvm/lib -L-L/usr/local/lib"
         export CPPFLAGS="-I/usr/local/opt/llvm/include -I/usr/local/include"
+
+        cxx_flags="${cxx_flags} -Wno-deprecated-declarations"
     fi
 
-    dir_name=$1
-    build_type=$2
+    cmake_flags="-DFAST_TESTS_ONLY=ON -DCMAKE_BUILD_TYPE=${build_type}"
 
     . setup_env.sh
     mkdir -p build
     cd build
-    cmake -DFAST_TESTS_ONLY=ON -DCMAKE_BUILD_TYPE=${build_type} ..
+    cmake                                    \
+        ${cmake_flags}                       \
+        -DCMAKE_CXX_FLAGS="${cxx_flags}"     \
+        ..
 
-    make -j 2 all build_tests
+    make -j 2 VERBOSE=1 all build_tests
     make -j 2 check
 }
 

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+platform=`uname`
+echo platform=${platform}
+echo "running against commit: "`git log --oneline --no-decorate -n 1`
+
+set -x
+set -e
+
+function build() {
+    if [ "Darwin" == "${platform}" ] ; then
+        export PATH="/usr/local/opt/llvm/bin:/usr/local/bin:${PATH}"
+        export PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig"
+        export LIBRARY_PATH="/usr/local/opt/openssl/lib"
+        export LDFLAGS="-L/usr/local/opt/llvm/lib -L-L/usr/local/lib"
+        export CPPFLAGS="-I/usr/local/opt/llvm/include -I/usr/local/include"
+    fi
+
+    dir_name=$1
+    build_type=$2
+
+    . setup_env.sh
+    mkdir -p build
+    cd build
+    cmake -DFAST_TESTS_ONLY=ON -DCMAKE_BUILD_TYPE=${build_type} ..
+
+    make -j 2 all build_tests
+    make -j 2 check
+}
+
+function build_release() {
+    build build-release Release
+}
+
+function build_debug() {
+    build build-debug Debug
+}
+
+# The CI_EXECTUTE_IN_DOCKER variable determines whether we should
+# re-execute in the docker container.
+
+if [ "1" == "${CI_USE_DOCKER}" ] ; then
+    docker pull clearmatics/zeth-base:latest
+    docker build -f Dockerfile-zeth -t zeth-dev .
+    docker run -t -p 50051:50051 --name zeth zeth-dev:latest $0 $@
+else
+    eval $@
+fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,28 +116,35 @@ target_link_libraries(
 ## Tests
 include(CTest)
 
-function(zeth_test TEST_NAME TEST_SOURCE)
-  add_executable(
-    ${TEST_NAME}
-    EXCLUDE_FROM_ALL
-    ${TEST_SOURCE}
-  )
+# A target which builds all tests, even if they will not be run.
+add_custom_target(build_tests)
+
+function(zeth_test TEST_NAME TEST_SOURCE IS_FAST_TEST)
+  add_executable(${TEST_NAME} EXCLUDE_FROM_ALL ${TEST_SOURCE})
   target_link_libraries(${TEST_NAME} zeth gtest_main)
-  add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
-  add_dependencies(check ${TEST_NAME})
+
+  # Add all tests to the 'build_tests' target
+  add_dependencies(build_tests ${TEST_NAME})
+
+  if((NOT FAST_TESTS_ONLY) OR IS_FAST_TEST)
+    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+    add_dependencies(check ${TEST_NAME})
+  else()
+    message("Skipping slow test ${TEST_NAME}")
+  endif()
 endfunction(zeth_test)
 
-zeth_test(test_simple test/simple_test.cpp)
-zeth_test(test_addition test/packed_addition_test.cpp)
-zeth_test(test_hex_to_field test/hex_to_field_test.cpp)
-zeth_test(test_note test/note_test.cpp)
-zeth_test(test_prfs test/prfs_test.cpp)
-zeth_test(test_commitments test/commitments_test.cpp)
-zeth_test(test_round test/round_test.cpp)
-zeth_test(test_mimc test/mimc_test.cpp)
-zeth_test(test_mimc_mp test/mimc_mp_test.cpp)
-zeth_test(test_merkle_tree test/merkle_tree_test.cpp)
-zeth_test(test_prover test/prover_test.cpp)
+zeth_test(test_simple test/simple_test.cpp TRUE)
+zeth_test(test_addition test/packed_addition_test.cpp TRUE)
+zeth_test(test_hex_to_field test/hex_to_field_test.cpp TRUE)
+zeth_test(test_note test/note_test.cpp TRUE)
+zeth_test(test_prfs test/prfs_test.cpp TRUE)
+zeth_test(test_commitments test/commitments_test.cpp TRUE)
+zeth_test(test_round test/round_test.cpp TRUE)
+zeth_test(test_mimc test/mimc_test.cpp TRUE)
+zeth_test(test_mimc_mp test/mimc_mp_test.cpp TRUE)
+zeth_test(test_merkle_tree test/merkle_tree_test.cpp TRUE)
+zeth_test(test_prover test/prover_test.cpp FALSE)
 
 # prover test has extra dependencies
 target_link_libraries(

--- a/src/circuits/joinsplit.tcc
+++ b/src/circuits/joinsplit.tcc
@@ -619,6 +619,12 @@ public:
         // < FieldT::capacity()
         nb_elements += 1;
 
+        // We allocate 2 field elements to pack the value of h_sig
+        nb_elements += 2;
+
+        // We allocate 2 field elements to pack each malleability tags h_iS
+        nb_elements += NumInputs * 2;
+
         return nb_elements;
     }
 };

--- a/src/test/note_test.cpp
+++ b/src/test/note_test.cpp
@@ -115,8 +115,7 @@ TEST(TestNoteCircuits, TestInputNoteGadget)
         "Setup a local merkle tree and append our commitment to it", true);
 
     libff::enter_block(
-        "[BEGIN] Data conversion to generate a witness of the note gadget",
-        true);
+        "Data conversion to generate a witness of the note gadget", true);
 
     std::shared_ptr<libsnark::digest_variable<FieldT>> a_sk_digest;
     a_sk_digest.reset(new libsnark::digest_variable<FieldT>(
@@ -194,8 +193,7 @@ TEST(TestNoteCircuits, TestOutputNoteGadget)
         "Initialize the output coins' data (a_pk, cm, rho)", true);
 
     libff::enter_block(
-        "[BEGIN] Data conversion to generate a witness of the note gadget",
-        true);
+        "Data conversion to generate a witness of the note gadget", true);
 
     std::shared_ptr<libsnark::digest_variable<FieldT>> rho_digest;
     rho_digest.reset(new libsnark::digest_variable<FieldT>(

--- a/src/test/prover_test.cpp
+++ b/src/test/prover_test.cpp
@@ -41,7 +41,7 @@ bool TestValidJS2In2Case1(
         "0x0 || OUT => vpub_out = 0x1700000000000007, note0 = "
         "0x1800000000000008, note1 = 0x0");
 
-    libff::enter_block("[START] Instantiate merkle tree for the tests", true);
+    libff::enter_block("Instantiate merkle tree for the tests", true);
     // Create a merkle tree to run our tests
     // Note: `make_unique` should be C++14 compliant, but here we use c++11, so
     // we instantiate our unique_ptr manually
@@ -49,11 +49,11 @@ bool TestValidJS2In2Case1(
         std::unique_ptr<merkle_tree_field<FieldT, HashTreeT>>(
             new merkle_tree_field<FieldT, HashTreeT>(
                 ZETH_MERKLE_TREE_DEPTH_TEST));
-    libff::leave_block("[END] Instantiate merkle tree for the tests", true);
+    libff::leave_block("Instantiate merkle tree for the tests", true);
 
     // --- Test 1: Generate a valid proof for commitment inserted at address 1
     // -- //
-    libff::enter_block("[BEGIN] Create JSInput", true);
+    libff::enter_block("Create JSInput", true);
     // Create the zeth note data for the commitment we will insert in the tree
     // (commitment to spend in this test)
     bits384 trap_r_bits384 =
@@ -118,9 +118,9 @@ bool TestValidJS2In2Case1(
     std::array<JSInput<FieldT>, 2> inputs;
     inputs[0] = input;
     inputs[1] = input_dummy;
-    libff::leave_block("[END] Create JSInput", true);
+    libff::leave_block("Create JSInput", true);
 
-    libff::enter_block("[BEGIN] Create JSOutput/ZethNote", true);
+    libff::enter_block("Create JSOutput/ZethNote", true);
     bits64 value_out_bits64 = get_bits64_from_vector(
         hexadecimal_str_to_binary_vector("1800000000000008"));
     bits256 a_pk_out_bits256 = get_bits256_from_vector(
@@ -152,9 +152,9 @@ bool TestValidJS2In2Case1(
     std::array<ZethNote, 2> outputs;
     outputs[0] = note_output;
     outputs[1] = note_dummy_output;
-    libff::leave_block("[END] Create JSOutput/ZethNote", true);
+    libff::leave_block("Create JSOutput/ZethNote", true);
 
-    libff::enter_block("[BEGIN] Generate proof", true);
+    libff::enter_block("Generate proof", true);
     extended_proof<ppT> ext_proof = prover.prove(
         updated_root_value,
         inputs,
@@ -165,14 +165,14 @@ bool TestValidJS2In2Case1(
         h_sig,
         phi,
         keypair.pk);
-    libff::leave_block("[END] Generate proof", true);
+    libff::leave_block("Generate proof", true);
 
-    libff::enter_block("[BEGIN] Verify proof", true);
+    libff::enter_block("Verify proof", true);
     // Get the verification key
     libzeth::verificationKeyT<ppT> vk = keypair.vk;
     bool res = libzeth::verify(ext_proof, vk);
     std::cout << "Does the proof verify? " << res << std::endl;
-    libff::leave_block("[END] Verify proof", true);
+    libff::leave_block("Verify proof", true);
 
     std::cout << "[DEBUG] Displaying the extended proof" << std::endl;
     ext_proof.dump_proof();
@@ -190,7 +190,7 @@ bool TestValidJS2In2Case2(
         "0x0 || OUT => v_pub = 0x000000000000000B, note0 = 0x1A00000000000002, "
         "note1 = 0x1500000000000002");
 
-    libff::enter_block("[START] Instantiate merkle tree for the tests", true);
+    libff::enter_block("Instantiate merkle tree for the tests", true);
     // Create a merkle tree to run our tests
     // Note: `make_unique` should be C++14 compliant, but here we use c++11, so
     // we instantiate our unique_ptr manually
@@ -198,11 +198,11 @@ bool TestValidJS2In2Case2(
         std::unique_ptr<merkle_tree_field<FieldT, HashTreeT>>(
             new merkle_tree_field<FieldT, HashTreeT>(
                 ZETH_MERKLE_TREE_DEPTH_TEST));
-    libff::leave_block("[END] Instantiate merkle tree for the tests", true);
+    libff::leave_block("Instantiate merkle tree for the tests", true);
 
     // --- Test 1: Generate a valid proof for commitment inserted at address 1
     // -- //
-    libff::enter_block("[BEGIN] Create JSInput", true);
+    libff::enter_block("Create JSInput", true);
     // Create the zeth note data for the commitment we will insert in the tree
     // (commitment to spend in this test)
     bits384 trap_r_bits384 =
@@ -268,9 +268,9 @@ bool TestValidJS2In2Case2(
     std::array<JSInput<FieldT>, 2> inputs;
     inputs[0] = input0;
     inputs[1] = input1;
-    libff::leave_block("[END] Create JSInput", true);
+    libff::leave_block("Create JSInput", true);
 
-    libff::enter_block("[BEGIN] Create JSOutput/ZethNote", true);
+    libff::enter_block("Create JSOutput/ZethNote", true);
     bits256 a_pk_out_bits256 = get_bits256_from_vector(
         hexadecimal_digest_to_binary_vector("7777f753bfe21ba2219ced74875b8dbd8c"
                                             "114c3c79d7e41306dd82118de1895b"));
@@ -296,9 +296,9 @@ bool TestValidJS2In2Case2(
     std::array<ZethNote, 2> outputs;
     outputs[0] = note_output0;
     outputs[1] = note_output1;
-    libff::leave_block("[END] Create JSOutput/ZethNote", true);
+    libff::leave_block("Create JSOutput/ZethNote", true);
 
-    libff::enter_block("[BEGIN] Generate proof", true);
+    libff::enter_block("Generate proof", true);
     // RHS = 0x1A00000000000002 + 0x1500000000000002 + 0x000000000000000B =
     // 2F0000000000000F (LHS)
     extended_proof<ppT> ext_proof = prover.prove(
@@ -312,14 +312,14 @@ bool TestValidJS2In2Case2(
         h_sig,
         phi,
         keypair.pk);
-    libff::leave_block("[END] Generate proof", true);
+    libff::leave_block("Generate proof", true);
 
-    libff::enter_block("[BEGIN] Verify proof", true);
+    libff::enter_block("Verify proof", true);
     // Get the verification key
     libzeth::verificationKeyT<ppT> vk = keypair.vk;
     bool res = libzeth::verify(ext_proof, vk);
     std::cout << "Does the proof verify? " << res << std::endl;
-    libff::leave_block("[END] Verify proof", true);
+    libff::leave_block("Verify proof", true);
 
     return res;
 }
@@ -334,7 +334,7 @@ bool TestValidJS2In2Case3(
         "0x2F0000000000000F, note1 = 0x0 || OUT => v_pub = 0x000000000000000B, "
         "note0 = 0x1A00000000000012, note1 = 0x1500000000000002");
 
-    libff::enter_block("[START] Instantiate merkle tree for the tests", true);
+    libff::enter_block("Instantiate merkle tree for the tests", true);
     // Create a merkle tree to run our tests
     // Note: `make_unique` should be C++14 compliant, but here we use c++11, so
     // we instantiate our unique_ptr manually
@@ -342,11 +342,11 @@ bool TestValidJS2In2Case3(
         std::unique_ptr<merkle_tree_field<FieldT, HashTreeT>>(
             new merkle_tree_field<FieldT, HashTreeT>(
                 ZETH_MERKLE_TREE_DEPTH_TEST));
-    libff::leave_block("[END] Instantiate merkle tree for the tests", true);
+    libff::leave_block("Instantiate merkle tree for the tests", true);
 
     // --- Test 1: Generate a valid proof for commitment inserted at address 1
     // -- //
-    libff::enter_block("[BEGIN] Create JSInput", true);
+    libff::enter_block("Create JSInput", true);
     // Create the zeth note data for the commitment we will insert in the tree
     // (commitment to spend in this test)
     bits384 trap_r_bits384 =
@@ -412,9 +412,9 @@ bool TestValidJS2In2Case3(
     std::array<JSInput<FieldT>, 2> inputs;
     inputs[0] = input0;
     inputs[1] = input1;
-    libff::leave_block("[END] Create JSInput", true);
+    libff::leave_block("Create JSInput", true);
 
-    libff::enter_block("[BEGIN] Create JSOutput/ZethNote", true);
+    libff::enter_block("Create JSOutput/ZethNote", true);
     bits256 a_pk_out_bits256 = get_bits256_from_vector(
         hexadecimal_digest_to_binary_vector("7777f753bfe21ba2219ced74875b8dbd8c"
                                             "114c3c79d7e41306dd82118de1895b"));
@@ -440,9 +440,9 @@ bool TestValidJS2In2Case3(
     std::array<ZethNote, 2> outputs;
     outputs[0] = note_output0;
     outputs[1] = note_output1;
-    libff::leave_block("[END] Create JSOutput/ZethNote", true);
+    libff::leave_block("Create JSOutput/ZethNote", true);
 
-    libff::enter_block("[BEGIN] Generate proof", true);
+    libff::enter_block("Generate proof", true);
     // (RHS) 0x1A00000000000012 + 0x1500000000000002 + 0x000000000000000B =
     // 2F0000000000000F + 0x0000000000000010 + 0x0 (LHS)
     extended_proof<ppT> ext_proof = prover.prove(
@@ -456,14 +456,14 @@ bool TestValidJS2In2Case3(
         h_sig,
         phi,
         keypair.pk);
-    libff::leave_block("[END] Generate proof", true);
+    libff::leave_block("Generate proof", true);
 
-    libff::enter_block("[BEGIN] Verify proof", true);
+    libff::enter_block("Verify proof", true);
     // Get the verification key
     libzeth::verificationKeyT<ppT> vk = keypair.vk;
     bool res = libzeth::verify(ext_proof, vk);
     std::cout << "Does the proof verfy? " << res << std::endl;
-    libff::leave_block("[END] Verify proof", true);
+    libff::leave_block("Verify proof", true);
 
     return res;
 }
@@ -477,7 +477,7 @@ bool TestValidJS2In2Deposit(
                         "note0 = 0x0, note1 = 0x0 || OUT => v_pub = 0x0, note0 "
                         "= 0x3782DACE9D900000, note1 = 0x29A2241AF62C0000");
 
-    libff::enter_block("[START] Instantiate merkle tree for the tests", true);
+    libff::enter_block("Instantiate merkle tree for the tests", true);
     // Create a merkle tree to run our tests
     // Note: `make_unique` should be C++14 compliant, but here we use c++11, so
     // we instantiate our unique_ptr manually
@@ -485,11 +485,11 @@ bool TestValidJS2In2Deposit(
         std::unique_ptr<merkle_tree_field<FieldT, HashTreeT>>(
             new merkle_tree_field<FieldT, HashTreeT>(
                 ZETH_MERKLE_TREE_DEPTH_TEST));
-    libff::leave_block("[END] Instantiate merkle tree for the tests", true);
+    libff::leave_block("Instantiate merkle tree for the tests", true);
 
     // --- Test 1: Generate a valid proof for commitment inserted at address 1
     // -- //
-    libff::enter_block("[BEGIN] Create JSInput", true);
+    libff::enter_block("Create JSInput", true);
     // Create the zeth note data for the commitment we will insert in the tree
     // (commitment to spend in this test)
     bits384 trap_r_bits384 =
@@ -554,9 +554,9 @@ bool TestValidJS2In2Deposit(
     std::array<JSInput<FieldT>, 2> inputs;
     inputs[0] = input0;
     inputs[1] = input1;
-    libff::leave_block("[END] Create JSInput", true);
+    libff::leave_block("Create JSInput", true);
 
-    libff::enter_block("[BEGIN] Create JSOutput/ZethNote", true);
+    libff::enter_block("Create JSOutput/ZethNote", true);
     bits256 a_pk_out_bits256 = get_bits256_from_vector(
         hexadecimal_digest_to_binary_vector("7777f753bfe21ba2219ced74875b8dbd8c"
                                             "114c3c79d7e41306dd82118de1895b"));
@@ -582,9 +582,9 @@ bool TestValidJS2In2Deposit(
     std::array<ZethNote, 2> outputs;
     outputs[0] = note_output0;
     outputs[1] = note_output1;
-    libff::leave_block("[END] Create JSOutput/ZethNote", true);
+    libff::leave_block("Create JSOutput/ZethNote", true);
 
-    libff::enter_block("[BEGIN] Generate proof", true);
+    libff::enter_block("Generate proof", true);
     // RHS = 0x0 + 0x3782DACE9D900000 + 0x29A2241AF62C0000 = 0x6124FEE993BC0000
     // (LHS)
     extended_proof<ppT> ext_proof = prover.prove(
@@ -598,16 +598,16 @@ bool TestValidJS2In2Deposit(
         h_sig,
         phi,
         keypair.pk);
-    libff::leave_block("[END] Generate proof", true);
+    libff::leave_block("Generate proof", true);
 
-    libff::enter_block("[BEGIN] Verify proof", true);
+    libff::enter_block("Verify proof", true);
     // Get the verification key
     libzeth::verificationKeyT<ppT> vk = keypair.vk;
     bool res = libzeth::verify(ext_proof, vk);
 
     ext_proof.dump_primary_inputs();
     std::cout << "Does the proof verify? " << res << std::endl;
-    libff::leave_block("[END] Verify proof", true);
+    libff::leave_block("Verify proof", true);
 
     return res;
 }
@@ -621,7 +621,7 @@ bool TestInvalidJS2In2(
                         "note0 = 0x0, note1 = 0x0 || OUT => v_pub = 0x0, note0 "
                         "= 0x8530000A00000001, note1 = 0x7550000A00000000");
 
-    libff::enter_block("[START] Instantiate merkle tree for the tests", true);
+    libff::enter_block("Instantiate merkle tree for the tests", true);
     // Create a merkle tree to run our tests
     // Note: `make_unique` should be C++14 compliant, but here we use c++11, so
     // we instantiate our unique_ptr manually
@@ -629,11 +629,11 @@ bool TestInvalidJS2In2(
         std::unique_ptr<merkle_tree_field<FieldT, HashTreeT>>(
             new merkle_tree_field<FieldT, HashTreeT>(
                 ZETH_MERKLE_TREE_DEPTH_TEST));
-    libff::leave_block("[END] Instantiate merkle tree for the tests", true);
+    libff::leave_block("Instantiate merkle tree for the tests", true);
 
     // --- Test 1: Generate a valid proof for commitment inserted at address 1
     // -- //
-    libff::enter_block("[BEGIN] Create JSInput", true);
+    libff::enter_block("Create JSInput", true);
     // Create the zeth note data for the commitment we will insert in the tree
     // (commitment to spend in this test)
     bits384 trap_r_bits384 =
@@ -698,9 +698,9 @@ bool TestInvalidJS2In2(
     std::array<JSInput<FieldT>, 2> inputs;
     inputs[0] = input0;
     inputs[1] = input1;
-    libff::leave_block("[END] Create JSInput", true);
+    libff::leave_block("Create JSInput", true);
 
-    libff::enter_block("[BEGIN] Create JSOutput/ZethNote", true);
+    libff::enter_block("Create JSOutput/ZethNote", true);
     bits256 a_pk_out_bits256 = get_bits256_from_vector(
         hexadecimal_digest_to_binary_vector("7777f753bfe21ba2219ced74875b8dbd8c"
                                             "114c3c79d7e41306dd82118de1895b"));
@@ -728,9 +728,9 @@ bool TestInvalidJS2In2(
     std::array<ZethNote, 2> outputs;
     outputs[0] = note_output0;
     outputs[1] = note_output1;
-    libff::leave_block("[END] Create JSOutput/ZethNote", true);
+    libff::leave_block("Create JSOutput/ZethNote", true);
 
-    libff::enter_block("[BEGIN] Generate proof", true);
+    libff::enter_block("Generate proof", true);
     // LHS = 0xFA80001400000000 (18.050427392400293888 ETH) =/=
     // 0x8530000A00000001 (9.597170848876199937 ETH) + 0x7550000A00000000
     // (8.453256543524093952 ETH) = RHS LHS = 18.050427392400293888 ETH RHS
@@ -747,14 +747,14 @@ bool TestInvalidJS2In2(
         h_sig,
         phi,
         keypair.pk);
-    libff::leave_block("[END] Generate proof", true);
+    libff::leave_block("Generate proof", true);
 
-    libff::enter_block("[BEGIN] Verify proof", true);
+    libff::enter_block("Verify proof", true);
     // Get the verification key
     libzeth::verificationKeyT<ppT> vk = keypair.vk;
     bool res = libzeth::verify(ext_proof, vk);
     std::cout << "Does the proof verify ? " << res << std::endl;
-    libff::leave_block("[END] Verify proof", true);
+    libff::leave_block("Verify proof", true);
 
     return res;
 }

--- a/src/test/simple_test.tcc
+++ b/src/test/simple_test.tcc
@@ -31,21 +31,13 @@ template<typename FieldT> void simple_circuit(libsnark::protoboard<FieldT> &pb)
 
     pb.set_input_sizes(1);
 
-    //   g1
-    //  /  \
-    //  \  /
-    //   x
+    // g1 == x * x
     pb.add_r1cs_constraint(r1cs_constraint<FieldT>(x, x, g1), "g1");
 
-    //    g2
-    //   /  \
-    //  g1   x
+    // g2 == g1 * x
     pb.add_r1cs_constraint(r1cs_constraint<FieldT>(g1, x, g2), "g2");
 
-    //                      y
-    //                    /   \
-    //                   /     \
-    //  g2 + 4.g1 + 2x + 5      1
+    // y == (g2 + 4.g1 + 2x + 5) * 1
     pb.add_r1cs_constraint(
         r1cs_constraint<FieldT>(g2 + (4 * g1) + (2 * x) + 5, 1, y), "y");
 }


### PR DESCRIPTION
This PR sets up travis to check code formatting, check the build (including compile warnings) and run some fast-running tests on mac and linux.

Addresses issue #60.

All builds execute with "-Werror" to detect compiler warnings.
The linux build pulls the docker container and runs build and tests inside that.  It runs the code checks natively (relying on git to notice any changes).  The mac build uses the default aple compilers.  In the future it would be nice to use the llvm compilers on mac.