### PR TITLE
Removed useless message and renamed merkle path attribute in JSInput

### DIFF
--- a/api/util.proto
+++ b/api/util.proto
@@ -2,35 +2,39 @@ syntax = "proto3";
 
 package proverpkg;
 
-message PackedDigest {
-    string part1 = 1; // First 253bits of the digest
-    string part2 = 2; // Last 3bits of the digest
-}
-
 message ZethNote {
     string aPK = 1;
-    string value = 2; // Hexadecimal string representing a int64
+    // Hex string representing a int64 value
+    string value = 2;
     string rho = 3;
     string trapR = 4;
 }
 
 message JSInput {
-    repeated string merkleNode = 1; // Merkle path to the commitment
+    // Merkle authentication path to the commitment
+    // of the note in the Merkle tree. Each node of
+    // the merkle tree is treated as a string here
+    repeated string merklePath = 1;
     int64 address = 2;
     ZethNote note = 3;
     string spendingASK = 4;
     string nullifier = 5;
 }
 
-// All the data is given as hexadecimal strings
+// Every point coordinate (ie: base field element)
+// is treated as an hexadecimal string here
 message HexadecimalPointBaseGroup1Affine {
+    // First point coordinate
     string xCoord = 1;
+    // Second point coordinate
     string yCoord = 2;
 }
 
 message HexadecimalPointBaseGroup2Affine {
+    // First point coordinate
     string xC1Coord = 1;
     string xC0Coord = 2;
+    // Second point coordinate
     string yC1Coord = 3;
     string yC0Coord = 4;
 }

--- a/src/util_api.tcc
+++ b/src/util_api.tcc
@@ -12,7 +12,7 @@ template<typename FieldT> FieldT ParseMerkleNode(std::string mk_node)
 template<typename FieldT>
 libzeth::JSInput<FieldT> ParseJSInput(const proverpkg::JSInput &input)
 {
-    if (ZETH_MERKLE_TREE_DEPTH != input.merklenode_size()) {
+    if (ZETH_MERKLE_TREE_DEPTH != input.merklepath_size()) {
         throw std::invalid_argument("Invalid merkle path length");
     }
 
@@ -28,7 +28,7 @@ libzeth::JSInput<FieldT> ParseJSInput(const proverpkg::JSInput &input)
 
     std::vector<FieldT> inputMerklePath;
     for (int i = 0; i < ZETH_MERKLE_TREE_DEPTH; i++) {
-        FieldT mk_node = ParseMerkleNode<FieldT>(input.merklenode(i));
+        FieldT mk_node = ParseMerkleNode<FieldT>(input.merklepath(i));
         inputMerklePath.push_back(mk_node);
     }
 


### PR DESCRIPTION
The message `PackedDigest` was not used, and thus was removed. Likewise, I renamed the `repeated string merkleNode = 1;` entry in the `JSInput` message as `merklePath` since it represents a merkle path and not a node. 