### PR TITLE
Pyclient fixes

### DIFF
--- a/pyClient/Makefile
+++ b/pyClient/Makefile
@@ -3,14 +3,8 @@
 
 setup:
 	pip install --upgrade pip
-	pip install .
-	$(MAKE) grpc
-
-setup-dev dev:
-	pip install --upgrade pip
 	pip install -e .
 	$(MAKE) grpc
-	@echo "************** INSTALLED FOR DEVELOPMENT **************"
 
 check: syntax test
 

--- a/pyClient/test_commands/test_ether_mixing.py
+++ b/pyClient/test_commands/test_ether_mixing.py
@@ -20,8 +20,8 @@ TEST_GRPC_ENDPOINT = constants.RPC_ENDPOINT
 
 def print_balances(bob: str, alice: str, charlie: str, mixer: str) -> None:
     print("BALANCES:")
-    print(f"  Alice   : {eth.getBalance(bob)}")
-    print(f"  Bob     : {eth.getBalance(alice)}")
+    print(f"  Alice   : {eth.getBalance(alice)}")
+    print(f"  Bob     : {eth.getBalance(bob)}")
     print(f"  Charlie : {eth.getBalance(charlie)}")
     print(f"  Mixer   : {eth.getBalance(mixer)}")
 


### PR DESCRIPTION
- Fix some test script output
- Fix problem with non-dev install happening before grpc code-gen

grpc code-gen relies on the grpc and protobuf packages, installed by `pip install .`, but the code is generated into the source directory, rather than the install directory `env/lib/site-packages/...` and so cannot be found on some systems.

We could try to do something inside `setup.py`, but it seems non-trivial.  For now I'd suggest we always install in development mode.  If we later decide to release a full package that is intended to be installed independently, we can come back and deal with this.  (This probably involves adding logic into setup.py to execute grpc if/when required).

Thanks @rrtoledo for spotting this.