### PR TITLE
Fixing non-malleability vulnerability

### DIFF
--- a/pyClient/test/test_signing.py
+++ b/pyClient/test/test_signing.py
@@ -1,0 +1,33 @@
+from zeth import signing
+from hashlib import sha256
+from unittest import TestCase
+from os import urandom
+
+
+class TestSigning(TestCase):
+
+    def test_sign_verify(self) -> None:
+        """
+        Test the correct signing-verification flow:
+        verify(vk, sign(sk,m), m) = 1
+        """
+        m = sha256("clearmatics".encode()).digest()
+        keypair = signing.key_gen()
+        sigma = signing.sign(keypair.sk, m)
+        self.assertTrue(signing.verify(keypair.vk, m, sigma))
+
+        keypair2 = signing.key_gen()
+        self.assertFalse(signing.verify(keypair2.vk, m, sigma))
+
+    def test_sign_verify_random(self) -> None:
+        """
+        Test the correct signing-verification flow with random message:
+        verify(vk, sign(sk,m), m) = 1
+        """
+        m = urandom(32)
+        keypair = signing.key_gen()
+        sigma = signing.sign(keypair.sk, m)
+        self.assertTrue(signing.verify(keypair.vk, m, sigma))
+
+        keypair2 = signing.key_gen()
+        self.assertFalse(signing.verify(keypair2.vk, m, sigma))

--- a/pyClient/test_commands/scenario.py
+++ b/pyClient/test_commands/scenario.py
@@ -1,14 +1,13 @@
 import zeth.joinsplit as joinsplit
 import zeth.contracts as contracts
 from zeth.prover_client import ProverClient
-from zeth.utils import to_zeth_units, int64_to_hex, get_public_key_from_bytes, \
-    encode_to_hash
+from zeth.utils import to_zeth_units, int64_to_hex, get_public_key_from_bytes
 import test_commands.mock as mock
 import api.util_pb2 as util_pb2
 
-from hashlib import sha256
 from web3 import Web3, HTTPProvider  # type: ignore
 from typing import List, Any
+from os import urandom
 
 W3 = Web3(HTTPProvider("http://localhost:8545"))
 
@@ -76,24 +75,13 @@ def bob_deposit(
         (output_note1, pk_bob),
         (output_note2, pk_bob)])
 
-    # Hash the pk_sender and cipher-texts
-    ciphers = pk_sender + ciphertexts[0] + ciphertexts[1]
-    hash_ciphers = sha256(ciphers).hexdigest()
-
-    # Hash the proof
-    proof: List[str] = []
-    for key in proof_json.keys():
-        if key != "inputs":
-            proof.extend(proof_json[key])
-    hash_proof = sha256(encode_to_hash(proof)).hexdigest()
-
-    # Encode and hash the primary inputs
-    encoded_inputs = joinsplit.encode_pub_input_to_hash(proof_json["inputs"])
-    hash_inputs = sha256(encoded_inputs).hexdigest()
-
-    # Compute the joinSplit signature
-    joinsplit_sig = joinsplit.sign(
-        joinsplit_keypair, hash_ciphers, hash_proof, hash_inputs)
+    # Sign the primary inputs, pk_sender and the ciphertexts
+    joinsplit_sig = joinsplit.sign_joinsplit(
+        joinsplit_keypair,
+        pk_sender,
+        ciphertexts,
+        proof_json
+    )
 
     return contracts.mix(
         mixer_instance,
@@ -167,24 +155,13 @@ def bob_to_charlie(
         (output_note2,
          get_public_key_from_bytes(keystore["Charlie"].addr_pk.enc_pk))])
 
-    # Hash the pk_sender and cipher-texts
-    ciphers = pk_sender + ciphertexts[0] + ciphertexts[1]
-    hash_ciphers = sha256(ciphers).hexdigest()
-
-    # Hash the proof
-    proof: List[int] = []
-    for key in proof_json.keys():
-        if key != "inputs":
-            proof.extend(proof_json[key])
-    hash_proof = sha256(encode_to_hash(proof)).hexdigest()
-
-    # Encode and hash the primary inputs
-    encoded_inputs = joinsplit.encode_pub_input_to_hash(proof_json["inputs"])
-    hash_inputs = sha256(encoded_inputs).hexdigest()
-
-    # Compute the joinSplit signature
-    joinsplit_sig = joinsplit.sign(
-        joinsplit_keypair, hash_ciphers, hash_proof, hash_inputs)
+    # Sign the primary inputs, pk_sender and the ciphertexts
+    joinsplit_sig = joinsplit.sign_joinsplit(
+        joinsplit_keypair,
+        pk_sender,
+        ciphertexts,
+        proof_json
+    )
 
     return contracts.mix(
         mixer_instance,
@@ -257,24 +234,13 @@ def charlie_withdraw(
         (output_note1, pk_charlie),
         (output_note2, pk_charlie)])
 
-    # Hash the pk_sender and cipher-texts
-    ciphers = pk_sender + ciphertexts[0] + ciphertexts[1]
-    hash_ciphers = sha256(ciphers).hexdigest()
-
-    # Hash the proof
-    proof: List[str] = []
-    for key in proof_json.keys():
-        if key != "inputs":
-            proof.extend(proof_json[key])
-    hash_proof = sha256(encode_to_hash(proof)).hexdigest()
-
-    # Encode and hash the primary inputs
-    encoded_inputs = joinsplit.encode_pub_input_to_hash(proof_json["inputs"])
-    hash_inputs = sha256(encoded_inputs).hexdigest()
-
-    # Compute the joinSplit signature
-    joinsplit_sig = joinsplit.sign(
-        joinsplit_keypair, hash_ciphers, hash_proof, hash_inputs)
+    # Sign the primary inputs, pk_sender and the ciphertexts
+    joinsplit_sig = joinsplit.sign_joinsplit(
+        joinsplit_keypair,
+        pk_sender,
+        ciphertexts,
+        proof_json
+    )
 
     return contracts.mix(
         mixer_instance,
@@ -323,8 +289,16 @@ def charlie_double_withdraw(
     note1_value = to_zeth_units(str(CHARLIE_WITHDRAW_CHANGE_ETH), 'ether')
     v_out = to_zeth_units(str(CHARLIE_WITHDRAW_ETH), 'ether')
 
+    # ### ATTACK BLOCK
+    # Add malicious nullifiers: we reuse old nullifiers to double spend by
+    # adding $r$ to them so that they have the same value as before in Z_r,
+    # and so the zksnark verification passes, but have different values in
+    # {0;1}^256 so that they appear different to the contract.
+    # See: https://github.com/clearmatics/zeth/issues/38
+
+    # We make sure that h_sig is computed with the malicious nfs
     (output_note1, output_note2, proof_json, joinsplit_keypair) = \
-        joinsplit.get_proof_joinsplit_2_by_2(
+        joinsplit.get_proof_joinsplit_2_by_2_attack_nf(
             prover_client,
             mk_root,
             input_note1,
@@ -343,9 +317,8 @@ def charlie_double_withdraw(
             zksnark
         )
 
-    # ### ATTACK BLOCK
-    # Add malicious nullifiers (located at index 2 and 4 in the array of inputs)
-    # See: https://github.com/clearmatics/zeth/issues/38
+    # We make sure $r$ is added to the primary inputs nfs
+    # as libsnark returns primary inputs in Z_p
     r = 21888242871839275222246405745257275088548364400416034343698204186575808495617  # noqa
     print("proof_json => ", proof_json)
     print("proof_json[inputs][2] => ", proof_json["inputs"][2])
@@ -354,32 +327,21 @@ def charlie_double_withdraw(
     proof_json["inputs"][4] = hex(int(proof_json["inputs"][4], 16) + r)
     # ### ATTACK BLOCK
 
-    # construct pk object from bytes
+    # Construct pk object from bytes
     pk_charlie = get_public_key_from_bytes(keystore["Charlie"].addr_pk.enc_pk)
 
-    # encrypt the coins
+    # Encrypt the coins
     (pk_sender, ciphertexts) = joinsplit.encrypt_notes([
         (output_note1, pk_charlie),
         (output_note2, pk_charlie)])
 
-    # Hash the pk_sender and cipher-texts
-    ciphers = pk_sender + ciphertexts[0] + ciphertexts[1]
-    hash_ciphers = sha256(ciphers).hexdigest()
-
-    # Hash the proof
-    proof: List[str] = []
-    for key in proof_json.keys():
-        if key != "inputs":
-            proof.extend(proof_json[key])
-    hash_proof = sha256(encode_to_hash(proof)).hexdigest()
-
-    # Encode and hash the primary inputs
-    encoded_inputs = joinsplit.encode_pub_input_to_hash(proof_json["inputs"])
-    hash_inputs = sha256(encoded_inputs).hexdigest()
-
-    # Compute the joinSplit signature
-    joinsplit_sig = joinsplit.sign(
-        joinsplit_keypair, hash_ciphers, hash_proof, hash_inputs)
+    # Sign the primary inputs, pk_sender and the ciphertexts
+    joinsplit_sig = joinsplit.sign_joinsplit(
+        joinsplit_keypair,
+        pk_sender,
+        ciphertexts,
+        proof_json
+    )
 
     return contracts.mix(
         mixer_instance,
@@ -393,6 +355,180 @@ def charlie_double_withdraw(
         # Pay an arbitrary amount (1 wei here) that will be refunded since the
         # `mix` function is payable
         W3.toWei(1, 'wei'),
+        4000000,
+        zksnark
+    )
+
+
+def charlie_corrupt_bob_deposit(
+        prover_client: ProverClient,
+        mixer_instance: Any,
+        mk_root: str,
+        bob_eth_address: str,
+        charlie_eth_address: str,
+        keystore: mock.Keystore,
+        mk_tree_depth: int,
+        zksnark: str) -> contracts.MixResult:
+    """
+    Charlie tries to break transaction malleability and corrupt the coins
+    bob is sending in a transaction
+    She does so by intercepting bob's transaction and either:
+    - case 1: replacing the ciphertexts (or pk_sender) by garbage/arbitrary data
+    - case 2: replacing the ciphertexts by garbage/arbitrary data and using a
+    new OT-signature
+    Both attacks should fail,
+    - case 1: the signature check should fail, else Charlie broke UF-CMA
+        of the OT signature
+    - case 2: the h_sig/vk verification should fail, as h_sig is not a function
+        of vk any longer
+
+    NB. If the adversary were to corrupt the ciphertexts (or the encryption key),
+    replace the OT-signature by a new one and modify the h_sig accordingly so that
+    the check on the signature verification (key h_sig/vk) passes, the proof would
+    not verify, which is why we do not test this case.
+    """
+    print(
+        f"=== Bob deposits {BOB_DEPOSIT_ETH} ETH for himself and split into " +
+        f"note1: {BOB_SPLIT_1_ETH}ETH, note2: {BOB_SPLIT_2_ETH}ETH" +
+        f"but Charlie attempts to corrupt the transaction ===")
+    bob_apk = keystore["Bob"].addr_pk.a_pk
+    bob_ask = keystore["Bob"].addr_sk.a_sk
+    # Create the JoinSplit dummy inputs for the deposit
+    (input_note1, _input_nullifier1, input_address1) = mock.get_dummy_input(
+        bob_apk, bob_ask)
+    (input_note2, _input_nullifier2, input_address2) = mock.get_dummy_input(
+        bob_apk, bob_ask)
+    dummy_mk_path = mock.get_dummy_merkle_path(mk_tree_depth)
+
+    note1_value = to_zeth_units(str(BOB_SPLIT_1_ETH), 'ether')
+    note2_value = to_zeth_units(str(BOB_SPLIT_2_ETH), 'ether')
+    v_in = to_zeth_units(str(BOB_DEPOSIT_ETH), 'ether')
+
+    (output_note1, output_note2, proof_json, joinsplit_keypair) = \
+        joinsplit.get_proof_joinsplit_2_by_2(
+            prover_client,
+            mk_root,
+            input_note1,
+            input_address1,
+            dummy_mk_path,
+            input_note2,
+            input_address2,
+            dummy_mk_path,
+            bob_ask,  # sender
+            bob_apk,  # recipient1
+            bob_apk,  # recipient2
+            int64_to_hex(note1_value),  # value output note 1
+            int64_to_hex(note2_value),  # value output note 2
+            int64_to_hex(v_in),  # v_in
+            ZERO_UNITS_HEX,  # v_out
+            zksnark
+    )
+
+    # Construct pk object from bytes
+    pk_bob = get_public_key_from_bytes(keystore["Bob"].addr_pk.enc_pk)
+
+    # Encrypt the coins
+    (pk_sender, ciphertexts) = joinsplit.encrypt_notes([
+        (output_note1, pk_bob),
+        (output_note2, pk_bob)])
+
+    # Sign the primary inputs, pk_sender and the ciphertexts
+    joinsplit_sig = joinsplit.sign_joinsplit(
+        joinsplit_keypair,
+        pk_sender,
+        ciphertexts,
+        proof_json
+    )
+
+    # ### ATTACK BLOCK
+    # Charlie intercepts Bob's deposit, corrupts it and
+    # sends her transaction before Bob's transaction is accepted
+
+    # Case 1: replacing the ciphertexts by garbage/arbitrary data
+    # Corrupt the ciphertexts
+    # (another way would have been to overwrite pk_sender)
+    fake_ciphertext0 = urandom(32)
+    fake_ciphertext1 = urandom(32)
+
+    result_corrupt1 = None
+    try:
+        result_corrupt1 = contracts.mix(
+            mixer_instance,
+            pk_sender,
+            fake_ciphertext0,
+            fake_ciphertext1,
+            proof_json,
+            joinsplit_keypair.vk,
+            joinsplit_sig,
+            charlie_eth_address,
+            # Pay an arbitrary amount (1 wei here) that will be refunded
+            #  since the `mix` function is payable
+            W3.toWei(BOB_DEPOSIT_ETH, 'ether'),
+            4000000,
+            zksnark
+        )
+    except Exception as e:
+        print(
+            f"Charlie's first corruption attempt" +
+            f" successfully rejected! (msg: {e})"
+        )
+    assert(result_corrupt1 is None), \
+        "Charlie managed to corrupt Bob's deposit the first time!"
+    print("")
+
+    # Case 2: replacing the ciphertexts by garbage/arbitrary data and
+    # using a new OT-signature
+    # Corrupt the ciphertexts
+    fake_ciphertext0 = urandom(32)
+    fake_ciphertext1 = urandom(32)
+    new_joinsplit_keypair = joinsplit.gen_one_time_schnorr_vk_sk_pair()
+
+    # Sign the primary inputs, pk_sender and the ciphertexts
+    new_joinsplit_sig = joinsplit.sign_joinsplit(
+        new_joinsplit_keypair,
+        pk_sender,
+        [fake_ciphertext0, fake_ciphertext1],
+        proof_json
+    )
+
+    result_corrupt2 = None
+    try:
+        result_corrupt2 = contracts.mix(
+            mixer_instance,
+            pk_sender,
+            fake_ciphertext0,
+            fake_ciphertext1,
+            proof_json,
+            new_joinsplit_keypair.vk,
+            new_joinsplit_sig,
+            charlie_eth_address,
+            # Pay an arbitrary amount (1 wei here) that will be refunded since the
+            # `mix` function is payable
+            W3.toWei(BOB_DEPOSIT_ETH, 'ether'),
+            4000000,
+            zksnark
+        )
+    except Exception as e:
+        print(
+            f"Charlie's second corruption attempt" +
+            f" successfully rejected! (msg: {e})"
+        )
+    assert(result_corrupt2 is None), \
+        "Charlie managed to corrupt Bob's deposit the second time!"
+
+    # ### ATTACK BLOCK
+
+    # Bob transaction is finally mined
+    return contracts.mix(
+        mixer_instance,
+        pk_sender,
+        ciphertexts[0],
+        ciphertexts[1],
+        proof_json,
+        joinsplit_keypair.vk,
+        joinsplit_sig,
+        bob_eth_address,
+        W3.toWei(BOB_DEPOSIT_ETH, 'ether'),
         4000000,
         zksnark
     )

--- a/pyClient/test_commands/scenario.py
+++ b/pyClient/test_commands/scenario.py
@@ -1,10 +1,12 @@
 import zeth.joinsplit as joinsplit
 import zeth.contracts as contracts
+import zeth.signing as signing
 from zeth.prover_client import ProverClient
 from zeth.utils import to_zeth_units, int64_to_hex, get_public_key_from_bytes
+
+
 import test_commands.mock as mock
 import api.util_pb2 as util_pb2
-
 from web3 import Web3, HTTPProvider  # type: ignore
 from typing import List, Any
 from os import urandom
@@ -77,7 +79,7 @@ def bob_deposit(
 
     # Sign the primary inputs, pk_sender and the ciphertexts
     joinsplit_sig = joinsplit.sign_joinsplit(
-        joinsplit_keypair,
+        joinsplit_keypair.sk,
         pk_sender,
         ciphertexts,
         proof_json
@@ -157,7 +159,7 @@ def bob_to_charlie(
 
     # Sign the primary inputs, pk_sender and the ciphertexts
     joinsplit_sig = joinsplit.sign_joinsplit(
-        joinsplit_keypair,
+        joinsplit_keypair.sk,
         pk_sender,
         ciphertexts,
         proof_json
@@ -236,7 +238,7 @@ def charlie_withdraw(
 
     # Sign the primary inputs, pk_sender and the ciphertexts
     joinsplit_sig = joinsplit.sign_joinsplit(
-        joinsplit_keypair,
+        joinsplit_keypair.sk,
         pk_sender,
         ciphertexts,
         proof_json
@@ -337,7 +339,7 @@ def charlie_double_withdraw(
 
     # Sign the primary inputs, pk_sender and the ciphertexts
     joinsplit_sig = joinsplit.sign_joinsplit(
-        joinsplit_keypair,
+        joinsplit_keypair.sk,
         pk_sender,
         ciphertexts,
         proof_json
@@ -434,7 +436,7 @@ def charlie_corrupt_bob_deposit(
 
     # Sign the primary inputs, pk_sender and the ciphertexts
     joinsplit_sig = joinsplit.sign_joinsplit(
-        joinsplit_keypair,
+        joinsplit_keypair.sk,
         pk_sender,
         ciphertexts,
         proof_json
@@ -481,11 +483,11 @@ def charlie_corrupt_bob_deposit(
     # Corrupt the ciphertexts
     fake_ciphertext0 = urandom(32)
     fake_ciphertext1 = urandom(32)
-    new_joinsplit_keypair = joinsplit.gen_one_time_schnorr_vk_sk_pair()
+    new_joinsplit_keypair = signing.key_gen()
 
     # Sign the primary inputs, pk_sender and the ciphertexts
     new_joinsplit_sig = joinsplit.sign_joinsplit(
-        new_joinsplit_keypair,
+        new_joinsplit_keypair.sk,
         pk_sender,
         [fake_ciphertext0, fake_ciphertext1],
         proof_json

--- a/pyClient/test_commands/test_ether_mixing.py
+++ b/pyClient/test_commands/test_ether_mixing.py
@@ -265,6 +265,41 @@ def main() -> None:
         mixer_instance.address
     )
 
+    # Bob deposits once again ETH, split in 2 notes on the mixer
+    # But Charlie attempts to corrupt the transaction (malleability attack)
+    result_deposit_bob_to_bob = scenario.charlie_corrupt_bob_deposit(
+        prover_client,
+        mixer_instance,
+        new_merkle_root_charlie_withdrawal,
+        bob_eth_address,
+        charlie_eth_address,
+        keystore,
+        mk_tree_depth,
+        zksnark
+    )
+    cm_address_bob_to_bob1 = result_deposit_bob_to_bob.cm_address_1
+    # cm_address_bob_to_bob2 = result_deposit_bob_to_bob.cm_address_2 (unused)
+    new_merkle_root_bob_to_bob = result_deposit_bob_to_bob.new_merkle_root
+    pk_sender_bob_to_bob = result_deposit_bob_to_bob.pk_sender
+    ciphertext_bob_to_bob1 = result_deposit_bob_to_bob.ciphertext_1
+    ciphertext_bob_to_bob2 = result_deposit_bob_to_bob.ciphertext_2
+
+    print("- Balances after Bob's last deposit: ")
+    print_balances(
+        bob_eth_address,
+        alice_eth_address,
+        charlie_eth_address,
+        mixer_instance.address
+    )
+
+    # Bob decrypts one of the note he previously received (should fail if
+    # Charlie's attack succeeded)
+    recovered_notes_bob = bob_wallet.receive_notes(
+        [ciphertext_bob_to_bob1, ciphertext_bob_to_bob2],
+        pk_sender_bob_to_bob)
+    assert(len(recovered_notes_bob) == 2), \
+        f"Bob recovered {len(recovered_notes_bob)} notes from deposit, expected 2"
+
 
 if __name__ == '__main__':
     main()

--- a/pyClient/zeth/contracts.py
+++ b/pyClient/zeth/contracts.py
@@ -2,7 +2,7 @@ import zeth.constants as constants
 import zeth.errors as errors
 from zeth.utils import get_trusted_setup_dir, get_contracts_dir, hex_to_int
 from zeth.joinsplit import GenericVerificationKey, GenericProof, \
-    JoinsplitPublicKey
+    JSVerificationKey
 
 import json
 import os
@@ -301,7 +301,7 @@ def mix_pghr13(
         ciphertext1: bytes,
         ciphertext2: bytes,
         parsed_proof: GenericProof,
-        vk: JoinsplitPublicKey,
+        vk: JSVerificationKey,
         sigma: int,
         sender_address: str,
         wei_pub_value: int,
@@ -319,7 +319,7 @@ def mix_pghr13(
         hex_to_int(parsed_proof["c_p"]),
         hex_to_int(parsed_proof["h"]),
         hex_to_int(parsed_proof["k"]),
-        [[int(vk[0][0]), int(vk[0][1])], [int(vk[1][0]), int(vk[1][1])]],
+        [[int(vk.ppk[0]), int(vk.ppk[1])], [int(vk.spk[0]), int(vk.spk[1])]],
         int(sigma),
         hex_to_int(parsed_proof["inputs"]),
         pk_sender,
@@ -337,7 +337,7 @@ def mix_groth16(
         ciphertext1: bytes,
         ciphertext2: bytes,
         parsed_proof: GenericProof,
-        vk: JoinsplitPublicKey,
+        vk: JSVerificationKey,
         sigma: int,
         sender_address: str,
         wei_pub_value: int,
@@ -347,7 +347,7 @@ def mix_groth16(
         [hex_to_int(parsed_proof["b"][0]),
          hex_to_int(parsed_proof["b"][1])],
         hex_to_int(parsed_proof["c"]),
-        [[int(vk[0][0]), int(vk[0][1])], [int(vk[1][0]), int(vk[1][1])]],
+        [[int(vk.ppk[0]), int(vk.ppk[1])], [int(vk.spk[0]), int(vk.spk[1])]],
         int(sigma),
         hex_to_int(parsed_proof["inputs"]),
         pk_sender,
@@ -365,7 +365,7 @@ def mix(
         ciphertext1: bytes,
         ciphertext2: bytes,
         parsed_proof: GenericProof,
-        vk: JoinsplitPublicKey,
+        vk: JSVerificationKey,
         sigma: int,
         sender_address: str,
         wei_pub_value: int,

--- a/pyClient/zeth/contracts.py
+++ b/pyClient/zeth/contracts.py
@@ -2,7 +2,7 @@ import zeth.constants as constants
 import zeth.errors as errors
 from zeth.utils import get_trusted_setup_dir, get_contracts_dir, hex_to_int
 from zeth.joinsplit import GenericVerificationKey, GenericProof, \
-    JSVerificationKey
+    JoinsplitSigPubKey
 
 import json
 import os
@@ -301,7 +301,7 @@ def mix_pghr13(
         ciphertext1: bytes,
         ciphertext2: bytes,
         parsed_proof: GenericProof,
-        vk: JSVerificationKey,
+        vk: JoinsplitSigPubKey,
         sigma: int,
         sender_address: str,
         wei_pub_value: int,
@@ -337,7 +337,7 @@ def mix_groth16(
         ciphertext1: bytes,
         ciphertext2: bytes,
         parsed_proof: GenericProof,
-        vk: JSVerificationKey,
+        vk: JoinsplitSigPubKey,
         sigma: int,
         sender_address: str,
         wei_pub_value: int,
@@ -365,7 +365,7 @@ def mix(
         ciphertext1: bytes,
         ciphertext2: bytes,
         parsed_proof: GenericProof,
-        vk: JSVerificationKey,
+        vk: JoinsplitSigPubKey,
         sigma: int,
         sender_address: str,
         wei_pub_value: int,

--- a/pyClient/zeth/joinsplit.py
+++ b/pyClient/zeth/joinsplit.py
@@ -32,9 +32,9 @@ class ApkAskPair:
 
 
 # JoinSplit Keys definitions
-JSKeyPair = signing.SchnorrKeyPair
-JSSigningKey = signing.SchnorrSigningKey
-JSVerificationKey = signing.SchnorrVerificationKey
+JoinsplitSigKeyPair = signing.SchnorrKeyPair
+JoinsplitSigPrivKey = signing.SchnorrSigningKey
+JoinsplitSigPubKey = signing.SchnorrVerificationKey
 
 
 # Dictionary representing a VerificationKey from any supported snark
@@ -209,7 +209,7 @@ def create_joinsplit_input(
 
 
 def sign_joinsplit(
-        joinsplit_sk: JSSigningKey,
+        joinsplit_sk: JoinsplitSigPrivKey,
         pk_sender: bytes,
         ciphertexts: List[bytes],
         proof_json: Dict[str, Any]) -> int:
@@ -239,7 +239,7 @@ def sign_joinsplit(
     data_to_be_signed += encode_to_hash(proof_json["inputs"])
 
     # Hash data_to_be_sign
-    hash_to_be_signed = sha256(data_to_be_signed).hexdigest()
+    hash_to_be_signed = sha256(data_to_be_signed).digest()
 
     # Compute the joinSplit signature
     joinsplit_sig = signing.sign(joinsplit_sk, hash_to_be_signed)
@@ -346,7 +346,7 @@ def compute_joinsplit2x2_inputs(
         output_note_value1: str,
         public_in_value: str,
         public_out_value: str,
-        joinsplit_vk: JSVerificationKey) -> prover_pb2.ProofInputs:
+        joinsplit_vk: JoinsplitSigPubKey) -> prover_pb2.ProofInputs:
     """
     Create a ProofInput object for joinsplit parameters
     """
@@ -404,7 +404,7 @@ def compute_joinsplit2x2_inputs_attack_nf(
         output_note_value1: str,
         public_in_value: str,
         public_out_value: str,
-        joinsplit_vk: JSVerificationKey) -> prover_pb2.ProofInputs:
+        joinsplit_vk: JoinsplitSigPubKey) -> prover_pb2.ProofInputs:
     """
     Create a ProofInput object for joinsplit parameters
     """
@@ -491,7 +491,7 @@ def get_proof_joinsplit_2_by_2(
         public_in_value: str,
         public_out_value: str,
         zksnark: str
-) -> Tuple[ZethNote, ZethNote, Dict[str, Any], JSKeyPair]:
+) -> Tuple[ZethNote, ZethNote, Dict[str, Any], JoinsplitSigKeyPair]:
     """
     Query the prover server to generate a proof for the given joinsplit
     parameters.
@@ -542,7 +542,7 @@ def get_proof_joinsplit_2_by_2_attack_nf(
         public_in_value: str,
         public_out_value: str,
         zksnark: str
-) -> Tuple[ZethNote, ZethNote, Dict[str, Any], JSKeyPair]:
+) -> Tuple[ZethNote, ZethNote, Dict[str, Any], JoinsplitSigKeyPair]:
     """
     Query the prover server to generate a proof for the given joinsplit
     parameters.
@@ -617,9 +617,9 @@ def receive_notes(
 def _compute_h_sig(
         nf0: str,
         nf1: str,
-        joinsplit_pub_key: JSVerificationKey) -> str:
+        joinsplit_pub_key: JoinsplitSigPubKey) -> str:
     """
-    Compute h_sig = blake2s(randomSeed, nf0, nf1, joinSplitPubKey)
+    Compute h_sig = blake2s(nf0, nf1, joinSplitPubKey)
     Flatten the verification key
     """
 
@@ -630,7 +630,7 @@ def _compute_h_sig(
                 bytes.fromhex(nf0),
                 bytes.fromhex(nf1),
             ]
-        ) + signing.encode_vk(joinsplit_pub_key)
+        ) + signing.encode_vk_to_bytes(joinsplit_pub_key)
     ).hexdigest()
     return h_sig
 

--- a/pyClient/zeth/signing.py
+++ b/pyClient/zeth/signing.py
@@ -1,0 +1,145 @@
+from math import ceil
+from os import urandom
+from typing import Tuple
+from hashlib import sha256
+from py_ecc import bn128 as ec
+
+from zeth.utils import encode_single, encode_abi
+import zeth.constants as constants
+
+FQ = ec.FQ
+G1 = Tuple[ec.FQ, ec.FQ]
+
+"""
+This package implements the Schnorr based one-time signature from:
+"Two-tier signatures, strongly unforgeable signatures,
+and Fiat-Shamir without random oracles" by Bellare and Shoup
+(https://eprint.iacr.org/2007/273.pdf)
+"""
+
+
+class SchnorrVerificationKey:
+    """
+    An OT-Schnorr verification key.
+    """
+    def __init__(self, x_g1: G1, y_g1: G1):
+        self.ppk = x_g1
+        self.spk = y_g1
+
+class SchnorrSigningKey:
+    """
+    An OT-Schnorr signing key.
+    """
+    def __init__(self, x: FQ, y: FQ, y_g1: G1):
+        self.psk = x
+        self.ssk = (y, y_g1)
+
+class SchnorrKeyPair:
+    """
+    An OT-Schnorr signing and verification keypair.
+    """
+    def __init__(self, x: FQ, y: FQ, x_g1: G1, y_g1: G1):
+        self.vk = SchnorrVerificationKey(x_g1, y_g1)
+        # We include in the signing key the verfication key
+        self.sk = SchnorrSigningKey(x, y, y_g1)
+
+
+def key_gen() -> SchnorrKeyPair:
+    """
+    Return a random signature keypair
+    composed of elements of F_q and G1.
+    """
+    key_size_byte = ceil(len("{0:b}".format(constants.ZETH_PRIME)) / 8)
+    x = FQ(
+        int(bytes(urandom(key_size_byte)).hex(), 16) % constants.ZETH_PRIME)
+    y = FQ(
+        int(bytes(urandom(key_size_byte)).hex(), 16) % constants.ZETH_PRIME)
+    X = ec.multiply(ec.G1, x.n)
+    Y = ec.multiply(ec.G1, y.n)
+    return SchnorrKeyPair(x, y, X, Y)
+
+def gen_vk(sk: SchnorrSigningKey) -> SchnorrVerificationKey:
+    """
+    Generate an OT-Schnorr verification key from an OT-Schnorr signing key
+    """
+    x = sk.psk
+    y, _ = sk.ssk
+    X = ec.multiply(ec.G1, x.n)
+    Y = ec.multiply(ec.G1, y.n)
+    return SchnorrVerificationKey(X, Y)
+
+
+def encode_group_element(group_el: G1) -> bytes:
+    """
+    Encode a group element into a byte string
+    We assume here the group prime $p$ is written in less than 256 bits
+    to conform with Ethereum bytes32 type.
+    """
+    res = encode_abi(
+        ["bytes32", "bytes32"],
+        [
+            bytes.fromhex("{0:0>64X}".format(int(group_el[0]))),
+            bytes.fromhex("{0:0>64X}".format(int(group_el[1])))
+        ]
+    )
+    return res
+
+
+def encode_vk(vk: SchnorrVerificationKey) -> bytes:
+    """
+    Encode a verification key as a byte string
+    We assume here the group prime $p$ is written in less than 256 bits
+    to conform with Ethereum bytes32 type
+    """
+    vk_byte = encode_group_element(vk.ppk)
+    vk_byte += encode_group_element(vk.spk)
+    return vk_byte
+
+
+def sign(
+        sk: SchnorrSigningKey,
+        m: str) -> int:
+    """
+    Generate a Schnorr signature on a message m.
+    We assume here that the message is an hexadecimal string written in
+    less than 256 bits to conform with Ethereum bytes32 type.
+    """
+
+    # Encode and hash the verifying key and input hashes
+    challenge_to_hash = encode_group_element(sk.ssk[1]) + encode_single("bytes32", bytes.fromhex(m))
+
+    # Convert the hex digest into a field element
+    challenge = int(sha256(challenge_to_hash).hexdigest(), 16) % constants.ZETH_PRIME
+
+    # Compute the signature sigma
+    sigma = (sk.ssk[0].n + challenge * sk.psk.n) % constants.ZETH_PRIME
+
+    return sigma
+
+def verify(
+    vk: SchnorrVerificationKey,
+    m: str,
+    sigma: int) -> bool:
+    """
+    Return true if the signature sigma is valid on message m and vk.
+    We assume here that the message is an hexadecimal string written in
+    less than 256 bits to conform with Ethereum bytes32 type.
+    """
+    # Encode and hash the verifying key and input hashes
+    challenge_to_hash = encode_group_element(vk.spk) + encode_single("bytes32", bytes.fromhex(m))
+
+    challenge = int(sha256(challenge_to_hash).hexdigest(), 16) % constants.ZETH_PRIME
+
+    left_part = ec.multiply(ec.G1, FQ(sigma).n)
+    right_part = ec.add(vk.spk, ec.multiply(vk.ppk, FQ(challenge).n))
+
+    return ec.eq(left_part, right_part)
+
+def test_all() -> None:
+    """
+    Unit test on the package
+    """
+    m = urandom(32).hex()
+    keypair = key_gen()
+    sigma = sign(keypair.sk, m)
+    assert verify(keypair.vk, m, sigma)

--- a/pyClient/zeth/signing.py
+++ b/pyClient/zeth/signing.py
@@ -125,16 +125,3 @@ def verify(
     right_part = ec.add(vk.spk, ec.multiply(vk.ppk, FQ(challenge).n))
 
     return ec.eq(left_part, right_part)
-
-
-def test_all() -> None:
-    """
-    Test on the package
-    """
-    m = urandom(32)
-    keypair = key_gen()
-    sigma = sign(keypair.sk, m)
-    assert verify(keypair.vk, m, sigma)
-
-    keypair2 = key_gen()
-    assert verify(keypair2.vk, m, sigma) is False

--- a/pyClient/zeth/utils.py
+++ b/pyClient/zeth/utils.py
@@ -58,17 +58,6 @@ def hex_to_int(elements: List[str]) -> List[int]:
     return ints
 
 
-def hex_extend_32bytes(element: str) -> str:
-    """
-    Extend a hex string to represent 32 bytes
-    """
-    res = str(element)
-    if len(res) % 2 != 0:
-        res = "0" + res
-    res = "00"*int((64-len(res))/2) + res
-    return res
-
-
 def get_private_key_from_bytes(sk_bytes: bytes) -> PrivateKey:
     """
     Gets PrivateKey object from raw representation
@@ -242,8 +231,10 @@ def encode_to_hash(message_list: Any) -> bytes:
         elif isinstance(m, str) and (m[0:2] == "0x"):
             m_hex = m[2:]
 
-        # [SANITY CHECK] Make sure the hex is 32 byte long
-        m_hex = hex_extend_32bytes(m_hex)
+        m_hex = str(m_hex)
+        if len(m_hex) % 2 != 0:
+            m_hex = "0" + m_hex
+        m_hex = "00"*int((64-len(m_hex))/2) + m_hex
 
         # Encode the hex into a byte array and append it to result
         input_sha += encode_single("bytes32", bytes.fromhex(m_hex))

--- a/pyClient/zeth/utils.py
+++ b/pyClient/zeth/utils.py
@@ -12,9 +12,10 @@ import eth_abi
 import nacl.utils  # type: ignore
 from nacl.public import PrivateKey, PublicKey, Box  # type: ignore
 from web3 import Web3, HTTPProvider  # type: ignore
-from typing import List, Union, Any, cast
+from typing import List, Tuple, Union, Any, cast
 from py_ecc import bn128 as ec
 FQ = ec.FQ
+G1 = Tuple[ec.FQ, ec.FQ]
 
 # Value of a single unit (in Wei) of vpub_in and vpub_out.  Use Szabos (10^12
 # Wei).
@@ -35,6 +36,22 @@ def encode_abi(type_names: List[str], data: List[bytes]) -> bytes:
     Typed wrapper around eth_abi.encode_abi
     """
     return eth_abi.encode_abi(type_names, data)  # type: ignore
+
+
+def encode_g1_to_bytes(group_el: G1) -> bytes:
+    """
+    Encode a group element into a byte string
+    We assume here the group prime $p$ is written in less than 256 bits
+    to conform with Ethereum bytes32 type.
+    """
+    res = encode_abi(
+        ["bytes32", "bytes32"],
+        [
+            bytes.fromhex("{0:0>64X}".format(int(group_el[0]))),
+            bytes.fromhex("{0:0>64X}".format(int(group_el[1])))
+        ]
+    )
+    return res
 
 
 def int64_to_hex(number: int) -> str:

--- a/zeth-contracts/contracts/BaseMixer.sol
+++ b/zeth-contracts/contracts/BaseMixer.sol
@@ -111,80 +111,43 @@ contract BaseMixer is MerkleTreeMiMC7, ERC223ReceivingContract {
     // This function processes the primary inputs to append and check the root and nullifiers in the primary inputs (instance)
     // and modifies the state of the mixer contract accordingly
     // (ie: Appends the commitments to the tree, appends the nullifiers to the list and so on)
-    function assemble_root_and_nullifiers_and_append_to_state(uint[] memory primary_inputs) internal {
-        // 1. We re-assemble the full root digest from the 2 field elements it was packed into
-        uint256[] memory digest_inputs = new uint[](2);
-        digest_inputs[0] = primary_inputs[0];
+    function check_mkroot_nullifiers_hsig_append_nullifiers_state(
+        uint[2][2] memory vk,
+        uint[] memory primary_inputs)
 
+        internal {
+        // 1. We re-assemble the full root digest and check it is in the tree
         require(
-            roots[bytes32(digest_inputs[0])],
+            roots[bytes32(primary_inputs[0])],
             "Invalid root: This root doesn't exist"
         );
 
-        // 2. We re-assemble the nullifiers (JSInputs)
+        // 2. We re-assemble the nullifiers (JSInputs) and check they were not already seen
+        bytes32[jsIn] memory nfs;
+        uint256[] memory digest_inputs = new uint[](2);
         for(uint i = 1; i < 1 + 2*jsIn; i += 2) {
             digest_inputs[0] = primary_inputs[i];
             digest_inputs[1] = primary_inputs[i+1];
-            bytes32 current_nullifier = Bytes.sha256_digest_from_field_elements(digest_inputs);
+            nfs[(i-1)/2] = Bytes.sha256_digest_from_field_elements(digest_inputs);
             require(
-                !nullifiers[current_nullifier],
+                !nullifiers[nfs[(i-1)/2]],
                 "Invalid nullifier: This nullifier has already been used"
             );
-            nullifiers[current_nullifier] = true;
-        }
-    }
-
-    function assemble_primary_inputs_and_hash(uint[] memory primary_inputs) public returns (bytes32) {
-        bytes32[1 + jsIn + jsOut + 1 + 1 + 1 + jsIn] memory formatted_inputs;
-        uint256[] memory digest_inputs = new uint[](2);
-
-        //Format and append the root
-        bytes32 formatted = bytes32(primary_inputs[0]);
-        formatted_inputs[0] = formatted;
-
-        //Format and append the nullifiers
-        for(uint i = 1; i < 1 + 2 * (jsIn); i += 2) {
-            digest_inputs[0] = primary_inputs[i];
-            digest_inputs[1] = primary_inputs[i+1];
-            formatted = Bytes.sha256_digest_from_field_elements(digest_inputs);
-            formatted_inputs[(i-1)/2 + 1] = formatted;
+            nullifiers[nfs[(i-1)/2]] = true;
         }
 
-        //Format and append the commitments
-        for(uint i = 1 + 2 * (jsIn); i < 1 + 2 * (jsIn + jsOut); i += 2) {
-            digest_inputs[0] = primary_inputs[i];
-            digest_inputs[1] = primary_inputs[i+1];
-            formatted = Bytes.sha256_digest_from_field_elements(digest_inputs);
-            formatted_inputs[(i-1)/2 + 1] = formatted;
-        }
+        // 3. We re-compute h_sig, re-assemble the expected h_sig and check they are equal
+        // (i.e. that h_sig re-assembled was correctly generated from vk)
+        bytes32 expected_hsig = sha256(abi.encodePacked(nfs, vk));
 
-        //Format and append the v_pub_in
-        formatted = bytes32(primary_inputs[1 + 2 * (jsIn + jsOut)]);
-        formatted_inputs[1 + jsIn + jsOut] = formatted;
-
-        //Format and append the v_pub_out
-        formatted = bytes32(primary_inputs[1 + 2 * (jsIn + jsOut) + 1]);
-        formatted_inputs[1 + jsIn + jsOut + 1] = formatted;
-
-        //Format and append h_sig
         digest_inputs[0] = primary_inputs[1 + 2 * (jsIn + jsOut) + 1 + 1];
         digest_inputs[1] = primary_inputs[1 + 2 * (jsIn + jsOut + 1) + 1];
-        formatted = Bytes.sha256_digest_from_field_elements(digest_inputs);
-        formatted_inputs[1 + jsIn + jsOut + 1 + 1] = formatted;
-
-        //Format and append the h_iS
-        for(uint i = 1 + 2 * (jsIn + jsOut + 1) + 1 + 1; i < 1 + 2 * (jsIn + jsOut + 1 + jsIn) + 1 + 1; i += 2) {
-            digest_inputs[0] = primary_inputs[i];
-            digest_inputs[1] = primary_inputs[i+1];
-            formatted = Bytes.sha256_digest_from_field_elements(digest_inputs);
-            formatted_inputs[(i-1)/2 + 2] = formatted;
-        }
-
-        bytes32 hash_inputs = sha256(abi.encodePacked(formatted_inputs));
-
-        return hash_inputs;
+        bytes32 hsig = Bytes.sha256_digest_from_field_elements(digest_inputs);
+        require(
+            expected_hsig == hsig,
+            "Invalid hsig: This hsig does not correspond to the hash of vk and the nfs"
+        );
     }
-
 
     function assemble_commitments_and_append_to_state(uint[] memory primary_inputs) internal {
         // We re-assemble the commitments (JSOutputs)

--- a/zeth-contracts/contracts/Groth16Mixer.sol
+++ b/zeth-contracts/contracts/Groth16Mixer.sol
@@ -28,25 +28,33 @@ contract Groth16Mixer is BaseMixer {
         bytes memory ciphertext0,
         bytes memory ciphertext1 // The nb of ciphertexts depends on the JS description (Here 2 inputs)
     ) public payable {
-        // 1. Check the root and the nullifiers
-        assemble_root_and_nullifiers_and_append_to_state(input);
+        // 1. Check the root and the nullifiers and vk
+        check_mkroot_nullifiers_hsig_append_nullifiers_state(vk, input);
 
-        // 2.a Verify the proof
+        // 2.a Verify the proof and that the primary inputs are in the scalar field
         require(
             zksnark_verifier.verifyTx(a, b, c, input),
             "Invalid proof: Unable to verify the proof correctly"
         );
 
-        // 2.b Verify the signature
-        bytes32 hash_proof = sha256(abi.encodePacked(a, b, c));
-        bytes32 hash_ciphers = sha256(abi.encodePacked(pk_sender, ciphertext0, ciphertext1));
+        // 2.b Verify the signature on the hash of data_to_be_signed
+        bytes32 hash_to_be_signed = sha256(
+            abi.encodePacked(
+                pk_sender,
+                ciphertext0,
+                ciphertext1,
+                a,
+                b,
+                c,
+                input
+            )
+        );
+
         require(
             otsig_verifier.verify(
                 vk,
                 sigma,
-                hash_ciphers,
-                hash_proof,
-                assemble_primary_inputs_and_hash(input)
+                hash_to_be_signed
             ),
             "Invalid signature: Unable to verify the signature correctly"
         );

--- a/zeth-contracts/contracts/Groth16Verifier.sol
+++ b/zeth-contracts/contracts/Groth16Verifier.sol
@@ -115,7 +115,7 @@ contract Groth16Verifier {
             // Make sure that all primary inputs lie in the scalar field
             require(
                 primaryInputs[i] < r,
-                "Input is not is scalar field"
+                "Input is not a scalar field"
             );
             inputValues[i] = primaryInputs[i];
         }

--- a/zeth-contracts/contracts/OTSchnorrVerifier.sol
+++ b/zeth-contracts/contracts/OTSchnorrVerifier.sol
@@ -21,11 +21,15 @@ contract OTSchnorrVerifier {
     function verify(
         uint[2][2] memory vk,
         uint sigma,
-        bytes32 hash_ciphers,
-        bytes32 hash_proof,
-        bytes32 hash_inputs
+        bytes32 hash_to_be_signed
     ) public returns (bool) {
-        bytes32 h_bytes = sha256(abi.encodePacked(vk[1][0], vk[1][1], hash_ciphers, hash_proof, hash_inputs));
+        bytes32 h_bytes = sha256(
+            abi.encodePacked(
+                vk[1][0],
+                vk[1][1],
+                hash_to_be_signed
+            )
+        );
         uint h = uint(h_bytes);
 
         // X = g^{x}, where g represents a generator of the cyclic group G

--- a/zeth-contracts/contracts/Pghr13Mixer.sol
+++ b/zeth-contracts/contracts/Pghr13Mixer.sol
@@ -33,25 +33,37 @@ contract Pghr13Mixer is BaseMixer {
         bytes memory ciphertext0,
         bytes memory ciphertext1 // Nb of ciphertexts depends on the JS description (Here 2 inputs)
         ) public payable {
-        // 1. Check the root and the nullifiers
-        assemble_root_and_nullifiers_and_append_to_state(input);
+        // 1. Check the root and the nullifiers and vk
+        check_mkroot_nullifiers_hsig_append_nullifiers_state(vk, input);
 
-        // 2.a Verify the proof
+        // 2.a Verify the proof and that the primary inputs are in the scalar field
         require(
             zksnark_verifier.verifyTx(a, a_p, b, b_p, c, c_p, h, k, input),
             "Invalid proof: Unable to verify the proof correctly"
         );
 
-        // 2.b Verify the signature
-        bytes32 hash_proof = sha256(abi.encodePacked(a, a_p, b, b_p, c, c_p, h, k));
-        bytes32 hash_ciphers = sha256(abi.encodePacked(pk_sender, ciphertext0, ciphertext1));
+        // 2.b Verify the signature on the hash of data_to_be_signed
+        bytes32 hash_to_be_signed = sha256(
+            abi.encodePacked(
+                pk_sender,
+                ciphertext0,
+                ciphertext1,
+                a,
+                a_p,
+                b,
+                b_p,
+                c,
+                c_p,
+                h,
+                k,
+                input
+            )
+        );
         require(
             otsig_verifier.verify(
                 vk,
                 sigma,
-                hash_ciphers,
-                hash_proof,
-                assemble_primary_inputs_and_hash(input)
+                hash_to_be_signed
                 ),
             "Invalid signature: Unable to verify the signature correctly"
         );

--- a/zeth-contracts/contracts/Pghr13Verifier.sol
+++ b/zeth-contracts/contracts/Pghr13Verifier.sol
@@ -180,7 +180,7 @@ contract Pghr13Verifier {
             // Make sure that all primary inputs lie in the scalar field
             require(
                 primaryInputs[i] < r,
-                "Input is not is scalar field"
+                "Input is not a scalar field"
             );
             inputValues[i] = primaryInputs[i];
         }


### PR DESCRIPTION
h_sig was not checked to be the hash of the signing key vk (and other parameters) which led to a transaction malleability attack.

PR linked to issue https://github.com/clearmatics/zeth/issues/120