### PR TITLE
Further pyclient types and refactoring

### DIFF
--- a/pyClient/.pylintrc
+++ b/pyClient/.pylintrc
@@ -13,7 +13,7 @@ disable=
     too-many-function-args,
     duplicate-code,
 
-good-names=i,e,x,y,m,k,h,c,cm,rc,ek,ct,vk,sk,X,Y,r,el,nf,w3
+good-names=i,e,x,y,m,k,h,c,cm,rc,ek,ct,vk,sk,pk,X,Y,r,el,nf,w3
 
 [REPORTS]
 output-format=text

--- a/pyClient/test_commands/mock.py
+++ b/pyClient/test_commands/mock.py
@@ -1,11 +1,8 @@
 from zeth.joinsplit import \
-    EncryptionKeyPair, ZethAddress, gen_ownership_keypair, \
-    trap_r_randomness, compute_nullifier, ownership_key_as_hex
+    EncryptionKeyPair, ZethAddress, gen_ownership_keypair
 from zeth.utils import get_private_key_from_bytes, get_public_key_from_bytes
-import api.util_pb2 as util_pb2
 
-from Crypto import Random
-from typing import Tuple, Dict, List
+from typing import Dict, List
 
 
 KeyStore = Dict[str, ZethAddress]
@@ -72,21 +69,3 @@ def get_dummy_merkle_path(length: int) -> List[str]:
     for _ in range(length):
         mk_path.append(dummy_node)
     return mk_path
-
-
-def get_dummy_input(
-        recipient_apk: bytes,
-        recipient_ask: bytes) -> Tuple[util_pb2.ZethNote, str, int]:
-    zero_wei_hex = "0000000000000000"
-    dummy_note = util_pb2.ZethNote(
-        apk=ownership_key_as_hex(recipient_apk),
-        value=zero_wei_hex,
-        rho=get_dummy_rho(),
-        trap_r=trap_r_randomness())
-    dummy_note_nullifier = compute_nullifier(dummy_note, recipient_ask)
-    dummy_note_address = 7
-    return (dummy_note, dummy_note_nullifier, dummy_note_address)
-
-
-def get_dummy_rho() -> str:
-    return bytes(Random.get_random_bytes(32)).hex()

--- a/pyClient/test_commands/mock.py
+++ b/pyClient/test_commands/mock.py
@@ -1,5 +1,5 @@
-from zeth.joinsplit import \
-    EncryptionKeyPair, ZethAddress, gen_ownership_keypair
+from zeth.joinsplit import EncryptionKeyPair, ZethAddress
+from zeth.ownership import gen_ownership_keypair
 from zeth.utils import get_private_key_from_bytes, get_public_key_from_bytes
 
 from typing import Dict, List

--- a/pyClient/test_commands/mock.py
+++ b/pyClient/test_commands/mock.py
@@ -1,78 +1,66 @@
-import zeth.joinsplit as joinsplit
+from zeth.joinsplit import \
+    EncryptionKeyPair, ZethAddress, gen_ownership_keypair, \
+    trap_r_randomness, compute_nullifier, ownership_key_as_hex
+from zeth.utils import get_private_key_from_bytes, get_public_key_from_bytes
 import api.util_pb2 as util_pb2
+
 from Crypto import Random
 from typing import Tuple, Dict, List
 
 
-class AddrPk:
-    def __init__(self, enc_pk: bytes, a_pk: str):
-        self.enc_pk = enc_pk
-        self.a_pk = a_pk
+KeyStore = Dict[str, ZethAddress]
 
 
-class AddrSk:
-    def __init__(self, enc_sk: bytes, a_sk: str):
-        self.enc_sk = enc_sk
-        self.a_sk = a_sk
-
-
-class KeyEntry:
-    def __init__(
-            self,
-            keypair: joinsplit.ApkAskPair,
-            enc_pk: bytes,
-            enc_sk: bytes):
-        self.addr_pk = AddrPk(enc_pk, keypair.a_pk)
-        self.addr_sk = AddrSk(enc_sk, keypair.a_sk)
-
-
-Keystore = Dict[str, KeyEntry]
-
-
-def init_test_keystore() -> Keystore:
+def init_test_keystore() -> KeyStore:
     """
     Keystore for the tests
     """
 
-    # Alice credentials in the zeth abstraction
-    alice_ownership_keys = joinsplit.gen_apk_ask_keypair()
-    alice_25519_enc_public_key = \
-        b'\x1eO"\n\xdaWnU+\xf5\xaa\x8a#\xd2*\xd3\x11\x9fc\xe52 \xd8^\xbc-' + \
-        b'\xb6\xf1\xeej\xf41'
     alice_25519_enc_private_key = \
         b'\xde\xa2\xc1\x0b\xd1\xf7\x13\xf8J\xa4:\xa4\xb6\xfa\xbd\xd5\xc9' + \
         b'\x8a\xd9\xb6\xb4\xc4\xc4I\x88\xa4\xd9\xe2\xee\x9e\x9a\xff'
+    alice_25519_enc_public_key = \
+        b'\x1eO"\n\xdaWnU+\xf5\xaa\x8a#\xd2*\xd3\x11\x9fc\xe52 \xd8^\xbc-' + \
+        b'\xb6\xf1\xeej\xf41'
 
-    # Bob credentials in the zeth abstraction
-    bob_ownership_keys = joinsplit.gen_apk_ask_keypair()
-    bob_25519_enc_public_key = \
-        b't\xc5{5j\xb5\x8a\xd3n\xb3\xab9\xe8s^13\xba\xa2\x91x\xb01(\xf9' + \
-        b'\xbb\xf9@r_\x91}'
     bob_25519_enc_private_key = \
         b'\xd3\xf0\x8f ,\x1d#\xdc\xac,\x93\xbd\xd0\xd9\xed\x8c\x92\x822' + \
         b'\xef\xd6\x97^\x86\xf7\xe4/\x85\xb6\x10\xe6o'
+    bob_25519_enc_public_key = \
+        b't\xc5{5j\xb5\x8a\xd3n\xb3\xab9\xe8s^13\xba\xa2\x91x\xb01(\xf9' + \
+        b'\xbb\xf9@r_\x91}'
 
-    # Charlie credentials in the zeth abstraction
-    charlie_ownership_keys = joinsplit.gen_apk_ask_keypair()
+    charlie_25519_enc_private_key = b'zH\xb66q\x97\x0bO\xcb\xb9q\x9b\xbd-1`I' + \
+        b'\xae\x00-\x11\xb9\xed}\x18\x9f\xf6\x8dr\xaa\xd4R'
     charlie_25519_enc_public_key = \
         b'u\xe7\x88\x9c\xbfE(\xf8\x99\xca<\xa8[<\xa2\x88m\xad\rN"\xf0}' + \
         b'\xec\xfcB\x89\xe6\x96\xcf\x19U'
-    charlie_25519_enc_private_key = b'zH\xb66q\x97\x0bO\xcb\xb9q\x9b\xbd-1`I' + \
-        b'\xae\x00-\x11\xb9\xed}\x18\x9f\xf6\x8dr\xaa\xd4R'
+
+    # Alice credentials in the zeth abstraction
+    alice_ownership = gen_ownership_keypair()
+    alice_encryption = EncryptionKeyPair(
+        get_private_key_from_bytes(alice_25519_enc_private_key),
+        get_public_key_from_bytes(alice_25519_enc_public_key))
+
+    # Bob credentials in the zeth abstraction
+    bob_ownership = gen_ownership_keypair()
+    bob_encryption = EncryptionKeyPair(
+        get_private_key_from_bytes(bob_25519_enc_private_key),
+        get_public_key_from_bytes(bob_25519_enc_public_key))
+
+    # Charlie credentials in the zeth abstraction
+    charlie_ownership = gen_ownership_keypair()
+    charlie_encryption = EncryptionKeyPair(
+        get_private_key_from_bytes(charlie_25519_enc_private_key),
+        get_public_key_from_bytes(charlie_25519_enc_public_key))
 
     return {
-        "Alice": KeyEntry(
-            alice_ownership_keys,
-            alice_25519_enc_public_key,
-            alice_25519_enc_private_key),
-        "Bob": KeyEntry(
-            bob_ownership_keys,
-            bob_25519_enc_public_key,
-            bob_25519_enc_private_key),
-        "Charlie": KeyEntry(
-            charlie_ownership_keys,
-            charlie_25519_enc_public_key,
-            charlie_25519_enc_private_key),
+        "Alice": ZethAddress.from_key_pairs(
+            alice_ownership, alice_encryption),
+        "Bob": ZethAddress.from_key_pairs(
+            bob_ownership, bob_encryption),
+        "Charlie": ZethAddress.from_key_pairs(
+            charlie_ownership, charlie_encryption),
     }
 
 
@@ -87,17 +75,15 @@ def get_dummy_merkle_path(length: int) -> List[str]:
 
 
 def get_dummy_input(
-        recipient_apk: str,
-        recipient_ask: str) -> Tuple[util_pb2.ZethNote, str, int]:
+        recipient_apk: bytes,
+        recipient_ask: bytes) -> Tuple[util_pb2.ZethNote, str, int]:
     zero_wei_hex = "0000000000000000"
     dummy_note = util_pb2.ZethNote(
-        apk=recipient_apk,
+        apk=ownership_key_as_hex(recipient_apk),
         value=zero_wei_hex,
         rho=get_dummy_rho(),
-        trap_r=joinsplit.trap_r_randomness(),
-
-    )
-    dummy_note_nullifier = joinsplit.compute_nullifier(dummy_note, recipient_ask)
+        trap_r=trap_r_randomness())
+    dummy_note_nullifier = compute_nullifier(dummy_note, recipient_ask)
     dummy_note_address = 7
     return (dummy_note, dummy_note_nullifier, dummy_note_address)
 

--- a/pyClient/test_commands/scenario.py
+++ b/pyClient/test_commands/scenario.py
@@ -8,7 +8,7 @@ import api.util_pb2 as util_pb2
 
 from hashlib import sha256
 from web3 import Web3, HTTPProvider  # type: ignore
-from typing import List, Any
+from typing import List, Tuple, Any
 import nacl.utils  # type: ignore
 
 W3 = Web3(HTTPProvider("http://localhost:8545"))
@@ -44,10 +44,10 @@ def bob_deposit(
         f"note1: {BOB_SPLIT_1_ETH}ETH, note2: {BOB_SPLIT_2_ETH}ETH ===")
     bob_apk = keystore["Bob"].addr_pk.a_pk
     bob_ask = keystore["Bob"].addr_sk.a_sk
-    # Create the JoinSplit dummy inputs for the deposit
 
-    (input_address1, input_note1) = joinsplit.get_dummy_input_and_address(bob_apk)
-    (input_address2, input_note2) = joinsplit.get_dummy_input_and_address(bob_apk)
+    # Create the JoinSplit dummy inputs for the deposit
+    input1 = joinsplit.get_dummy_input_and_address(bob_apk)
+    input2 = joinsplit.get_dummy_input_and_address(bob_apk)
     dummy_mk_path = mock.get_dummy_merkle_path(mk_tree_depth)
 
     note1_value = to_zeth_units(str(BOB_SPLIT_1_ETH), 'ether')
@@ -58,11 +58,9 @@ def bob_deposit(
         joinsplit.get_proof_joinsplit_2_by_2(
             prover_client,
             mk_root,
-            input_note1,
-            input_address1,
+            input1,
             dummy_mk_path,
-            input_note2,
-            input_address2,
+            input2,
             dummy_mk_path,
             bob_ask,  # sender
             bob_apk,  # recipient1
@@ -122,8 +120,7 @@ def bob_to_charlie(
         mixer_instance: Any,
         mk_root: str,
         mk_path1: List[str],
-        input_note1: util_pb2.ZethNote,
-        input_address1: int,
+        input1: Tuple[int, util_pb2.ZethNote],
         bob_eth_address: str,
         keystore: mock.KeyStore,
         mk_tree_depth: int,
@@ -140,7 +137,7 @@ def bob_to_charlie(
     bob_ask = keystore["Bob"].addr_sk.a_sk
 
     # Create the an additional dummy input for the JoinSplit
-    (input_address2, input_note2) = joinsplit.get_dummy_input_and_address(bob_apk)
+    input2 = joinsplit.get_dummy_input_and_address(bob_apk)
     dummy_mk_path = mock.get_dummy_merkle_path(mk_tree_depth)
 
     note1_value = to_zeth_units(str(BOB_TO_CHARLIE_ETH), 'ether')
@@ -150,11 +147,9 @@ def bob_to_charlie(
         joinsplit.get_proof_joinsplit_2_by_2(
             prover_client,
             mk_root,
-            input_note1,
-            input_address1,
+            input1,
             mk_path1,
-            input_note2,
-            input_address2,
+            input2,
             dummy_mk_path,
             bob_ask,  # sender
             bob_apk,  # recipient1 (change)
@@ -213,8 +208,7 @@ def charlie_withdraw(
         mixer_instance: Any,
         mk_root: str,
         mk_path1: List[str],
-        input_note1: util_pb2.ZethNote,
-        input_address1: int,
+        input1: Tuple[int, util_pb2.ZethNote],
         charlie_eth_address: str,
         keystore: mock.KeyStore,
         mk_tree_depth: int,
@@ -227,8 +221,7 @@ def charlie_withdraw(
     charlie_ask = keystore["Charlie"].addr_sk.a_sk
 
     # Create the an additional dummy input for the JoinSplit
-    (input_address2, input_note2) = \
-        joinsplit.get_dummy_input_and_address(charlie_apk)
+    input2 = joinsplit.get_dummy_input_and_address(charlie_apk)
     dummy_mk_path = mock.get_dummy_merkle_path(mk_tree_depth)
 
     note1_value = to_zeth_units(str(CHARLIE_WITHDRAW_CHANGE_ETH), 'ether')
@@ -238,11 +231,9 @@ def charlie_withdraw(
         joinsplit.get_proof_joinsplit_2_by_2(
             prover_client,
             mk_root,
-            input_note1,
-            input_address1,
+            input1,
             mk_path1,
-            input_note2,
-            input_address2,
+            input2,
             dummy_mk_path,
             charlie_ask,  # sender
             charlie_apk,  # recipient1
@@ -304,8 +295,7 @@ def charlie_double_withdraw(
         mixer_instance: Any,
         mk_root: str,
         mk_path1: List[str],
-        input_note1: util_pb2.ZethNote,
-        input_address1: int,
+        input1: Tuple[int, util_pb2.ZethNote],
         charlie_eth_address: str,
         keystore: mock.KeyStore,
         mk_tree_depth: int,
@@ -322,8 +312,7 @@ def charlie_double_withdraw(
     charlie_ask = keystore["Charlie"].addr_sk.a_sk
 
     # Create the an additional dummy input for the JoinSplit
-    (input_address2, input_note2) = \
-        joinsplit.get_dummy_input_and_address(charlie_apk)
+    input2 = joinsplit.get_dummy_input_and_address(charlie_apk)
     dummy_mk_path = mock.get_dummy_merkle_path(mk_tree_depth)
 
     note1_value = to_zeth_units(str(CHARLIE_WITHDRAW_CHANGE_ETH), 'ether')
@@ -333,11 +322,9 @@ def charlie_double_withdraw(
         joinsplit.get_proof_joinsplit_2_by_2(
             prover_client,
             mk_root,
-            input_note1,
-            input_address1,
+            input1,
             mk_path1,
-            input_note2,
-            input_address2,
+            input2,
             dummy_mk_path,
             charlie_ask,  # sender
             charlie_apk,  # recipient1

--- a/pyClient/test_commands/scenario.py
+++ b/pyClient/test_commands/scenario.py
@@ -49,7 +49,7 @@ def bob_deposit(
     note2_value = to_zeth_units(str(BOB_SPLIT_2_ETH), 'ether')
     v_in = to_zeth_units(str(BOB_DEPOSIT_ETH), 'ether')
 
-    (output_note1, output_note2, proof_json, joinsplit_keypair) = \
+    (output_note1, output_note2, proof_json, signing_keypair) = \
         joinsplit.get_proof_joinsplit_2_by_2(
             prover_client,
             mk_root,
@@ -94,7 +94,7 @@ def bob_deposit(
 
     # Compute the joinSplit signature
     joinsplit_sig = joinsplit.sign(
-        joinsplit_keypair, hash_ciphers, hash_proof, hash_inputs)
+        signing_keypair, hash_ciphers, hash_proof, hash_inputs)
 
     return contracts.mix(
         mixer_instance,
@@ -102,7 +102,7 @@ def bob_deposit(
         ciphertexts[0],
         ciphertexts[1],
         proof_json,
-        joinsplit_keypair.vk,
+        signing_keypair.pk,
         joinsplit_sig,
         bob_eth_address,
         W3.toWei(BOB_DEPOSIT_ETH, 'ether'),
@@ -141,7 +141,7 @@ def bob_to_charlie(
     note1_value = to_zeth_units(str(BOB_TO_CHARLIE_ETH), 'ether')
     note2_value = to_zeth_units(str(BOB_TO_CHARLIE_CHANGE_ETH), 'ether')
 
-    (output_note1, output_note2, proof_json, joinsplit_keypair) = \
+    (output_note1, output_note2, proof_json, signing_keypair) = \
         joinsplit.get_proof_joinsplit_2_by_2(
             prover_client,
             mk_root,
@@ -185,7 +185,7 @@ def bob_to_charlie(
 
     # Compute the joinSplit signature
     joinsplit_sig = joinsplit.sign(
-        joinsplit_keypair, hash_ciphers, hash_proof, hash_inputs)
+        signing_keypair, hash_ciphers, hash_proof, hash_inputs)
 
     return contracts.mix(
         mixer_instance,
@@ -193,7 +193,7 @@ def bob_to_charlie(
         ciphertexts[0],
         ciphertexts[1],
         proof_json,
-        joinsplit_keypair.vk,
+        signing_keypair.pk,
         joinsplit_sig,
         bob_eth_address,
         # Pay an arbitrary amount (1 wei here) that will be refunded since the
@@ -230,7 +230,7 @@ def charlie_withdraw(
     note1_value = to_zeth_units(str(CHARLIE_WITHDRAW_CHANGE_ETH), 'ether')
     v_out = to_zeth_units(str(CHARLIE_WITHDRAW_ETH), 'ether')
 
-    (output_note1, output_note2, proof_json, joinsplit_keypair) = \
+    (output_note1, output_note2, proof_json, signing_keypair) = \
         joinsplit.get_proof_joinsplit_2_by_2(
             prover_client,
             mk_root,
@@ -275,7 +275,7 @@ def charlie_withdraw(
 
     # Compute the joinSplit signature
     joinsplit_sig = joinsplit.sign(
-        joinsplit_keypair, hash_ciphers, hash_proof, hash_inputs)
+        signing_keypair, hash_ciphers, hash_proof, hash_inputs)
 
     return contracts.mix(
         mixer_instance,
@@ -283,7 +283,7 @@ def charlie_withdraw(
         ciphertexts[0],
         ciphertexts[1],
         proof_json,
-        joinsplit_keypair.vk,
+        signing_keypair.pk,
         joinsplit_sig,
         charlie_eth_address,
         # Pay an arbitrary amount (1 wei here) that will be refunded since the
@@ -324,7 +324,7 @@ def charlie_double_withdraw(
     note1_value = to_zeth_units(str(CHARLIE_WITHDRAW_CHANGE_ETH), 'ether')
     v_out = to_zeth_units(str(CHARLIE_WITHDRAW_ETH), 'ether')
 
-    (output_note1, output_note2, proof_json, joinsplit_keypair) = \
+    (output_note1, output_note2, proof_json, signing_keypair) = \
         joinsplit.get_proof_joinsplit_2_by_2(
             prover_client,
             mk_root,
@@ -380,7 +380,7 @@ def charlie_double_withdraw(
 
     # Compute the joinSplit signature
     joinsplit_sig = joinsplit.sign(
-        joinsplit_keypair, hash_ciphers, hash_proof, hash_inputs)
+        signing_keypair, hash_ciphers, hash_proof, hash_inputs)
 
     return contracts.mix(
         mixer_instance,
@@ -388,7 +388,7 @@ def charlie_double_withdraw(
         ciphertexts[0],
         ciphertexts[1],
         proof_json,
-        joinsplit_keypair.vk,
+        signing_keypair.pk,
         joinsplit_sig,
         charlie_eth_address,
         # Pay an arbitrary amount (1 wei here) that will be refunded since the

--- a/pyClient/test_commands/scenario.py
+++ b/pyClient/test_commands/scenario.py
@@ -45,10 +45,9 @@ def bob_deposit(
     bob_apk = keystore["Bob"].addr_pk.a_pk
     bob_ask = keystore["Bob"].addr_sk.a_sk
     # Create the JoinSplit dummy inputs for the deposit
-    (input_note1, _input_nullifier1, input_address1) = mock.get_dummy_input(
-        bob_apk, bob_ask)
-    (input_note2, _input_nullifier2, input_address2) = mock.get_dummy_input(
-        bob_apk, bob_ask)
+
+    (input_address1, input_note1) = joinsplit.get_dummy_input_and_address(bob_apk)
+    (input_address2, input_note2) = joinsplit.get_dummy_input_and_address(bob_apk)
     dummy_mk_path = mock.get_dummy_merkle_path(mk_tree_depth)
 
     note1_value = to_zeth_units(str(BOB_SPLIT_1_ETH), 'ether')
@@ -141,8 +140,7 @@ def bob_to_charlie(
     bob_ask = keystore["Bob"].addr_sk.a_sk
 
     # Create the an additional dummy input for the JoinSplit
-    (input_note2, _input_nullifier2, input_address2) = mock.get_dummy_input(
-        bob_apk, bob_ask)
+    (input_address2, input_note2) = joinsplit.get_dummy_input_and_address(bob_apk)
     dummy_mk_path = mock.get_dummy_merkle_path(mk_tree_depth)
 
     note1_value = to_zeth_units(str(BOB_TO_CHARLIE_ETH), 'ether')
@@ -229,8 +227,8 @@ def charlie_withdraw(
     charlie_ask = keystore["Charlie"].addr_sk.a_sk
 
     # Create the an additional dummy input for the JoinSplit
-    (input_note2, _input_nullifier2, input_address2) = mock.get_dummy_input(
-        charlie_apk, charlie_ask)
+    (input_address2, input_note2) = \
+        joinsplit.get_dummy_input_and_address(charlie_apk)
     dummy_mk_path = mock.get_dummy_merkle_path(mk_tree_depth)
 
     note1_value = to_zeth_units(str(CHARLIE_WITHDRAW_CHANGE_ETH), 'ether')
@@ -324,8 +322,8 @@ def charlie_double_withdraw(
     charlie_ask = keystore["Charlie"].addr_sk.a_sk
 
     # Create the an additional dummy input for the JoinSplit
-    (input_note2, _input_nullifier2, input_address2) = \
-        mock.get_dummy_input(charlie_apk, charlie_ask)
+    (input_address2, input_note2) = \
+        joinsplit.get_dummy_input_and_address(charlie_apk)
     dummy_mk_path = mock.get_dummy_merkle_path(mk_tree_depth)
 
     note1_value = to_zeth_units(str(CHARLIE_WITHDRAW_CHANGE_ETH), 'ether')

--- a/pyClient/test_commands/scenario.py
+++ b/pyClient/test_commands/scenario.py
@@ -2,7 +2,7 @@ import zeth.joinsplit as joinsplit
 import zeth.contracts as contracts
 from zeth.prover_client import ProverClient
 from zeth.zksnark import IZKSnarkProvider
-from zeth.utils import to_zeth_units, int64_to_hex, compute_merkle_path
+from zeth.utils import EtherValue, compute_merkle_path
 import test_commands.mock as mock
 import api.util_pb2 as util_pb2
 
@@ -45,8 +45,8 @@ def bob_deposit(
     bob_addr = keystore["Bob"].addr_pk
 
     outputs = [
-        (bob_addr, to_zeth_units(BOB_SPLIT_1_ETH, 'ether')),
-        (bob_addr, to_zeth_units(BOB_SPLIT_2_ETH, 'ether')),
+        (bob_addr, EtherValue(BOB_SPLIT_1_ETH)),
+        (bob_addr, EtherValue(BOB_SPLIT_2_ETH)),
     ]
 
     mk_tree = contracts.get_merkle_tree(mixer_instance)
@@ -61,9 +61,9 @@ def bob_deposit(
         bob_eth_address,
         [],
         outputs,
-        int64_to_hex(to_zeth_units(BOB_DEPOSIT_ETH, 'ether')),
-        ZERO_UNITS_HEX,
-        W3.toWei(BOB_DEPOSIT_ETH, 'ether'))
+        EtherValue(BOB_DEPOSIT_ETH),
+        EtherValue(0),
+        EtherValue(BOB_DEPOSIT_ETH))
 
 
 def bob_to_charlie(
@@ -84,11 +84,9 @@ def bob_to_charlie(
     bob_addr = keystore["Bob"].addr_pk
 
     # Coin for Bob (change)
-    value_to_bob = to_zeth_units(BOB_TO_CHARLIE_ETH, 'ether')
-    output0 = (bob_addr, value_to_bob)
+    output0 = (bob_addr, EtherValue(BOB_TO_CHARLIE_ETH))
     # Coin for Charlie
-    value_to_charlie = to_zeth_units(BOB_TO_CHARLIE_CHANGE_ETH, 'ether')
-    output1 = (charlie_addr, value_to_charlie)
+    output1 = (charlie_addr, EtherValue(BOB_TO_CHARLIE_CHANGE_ETH))
 
     # Send the tx
     mk_tree = contracts.get_merkle_tree(mixer_instance)
@@ -103,9 +101,9 @@ def bob_to_charlie(
         bob_eth_address,
         [input1],
         [output0, output1],
-        ZERO_UNITS_HEX,
-        ZERO_UNITS_HEX,
-        W3.toWei(1, 'wei'))
+        EtherValue(0),
+        EtherValue(0),
+        EtherValue(1, 'wei'))
 
 
 def charlie_withdraw(
@@ -138,10 +136,10 @@ def charlie_withdraw(
         charlie_ownership_key,
         charlie_eth_address,
         [input1],
-        [(charlie_pk, to_zeth_units(CHARLIE_WITHDRAW_CHANGE_ETH, 'ether'))],
-        ZERO_UNITS_HEX,
-        int64_to_hex(to_zeth_units(CHARLIE_WITHDRAW_ETH, 'ether')),
-        W3.toWei(1, 'wei'))
+        [(charlie_pk, EtherValue(CHARLIE_WITHDRAW_CHANGE_ETH))],
+        EtherValue(0),
+        EtherValue(CHARLIE_WITHDRAW_ETH),
+        EtherValue(1, 'wei'))
 
 
 def charlie_double_withdraw(
@@ -171,8 +169,8 @@ def charlie_double_withdraw(
     input2 = joinsplit.get_dummy_input_and_address(charlie_apk)
     dummy_mk_path = mock.get_dummy_merkle_path(mk_tree_depth)
 
-    note1_value = to_zeth_units(CHARLIE_WITHDRAW_CHANGE_ETH, 'ether')
-    v_out = to_zeth_units(CHARLIE_WITHDRAW_ETH, 'ether')
+    note1_value = joinsplit.to_zeth_units(EtherValue(CHARLIE_WITHDRAW_CHANGE_ETH))
+    v_out = EtherValue(CHARLIE_WITHDRAW_ETH)
 
     (output_note1, output_note2, proof_json, signing_keypair) = \
         joinsplit.get_proof_joinsplit_2_by_2(
@@ -185,8 +183,8 @@ def charlie_double_withdraw(
             charlie_ask,  # sender
             (charlie_apk, note1_value),  # recipient1
             (charlie_apk, 0),  # recipient2
-            ZERO_UNITS_HEX,  # v_in
-            int64_to_hex(v_out),  # v_out
+            joinsplit.to_zeth_units(EtherValue(0)),  # v_in
+            joinsplit.to_zeth_units(v_out),  # v_out
             zksnark
         )
 

--- a/pyClient/test_commands/scenario.py
+++ b/pyClient/test_commands/scenario.py
@@ -1,6 +1,7 @@
 import zeth.joinsplit as joinsplit
 import zeth.contracts as contracts
 from zeth.prover_client import ProverClient
+from zeth.zksnark import IZKSnarkProvider
 from zeth.utils import to_zeth_units, int64_to_hex, get_public_key_from_bytes, \
     encode_to_hash
 import test_commands.mock as mock
@@ -31,7 +32,7 @@ def bob_deposit(
         bob_eth_address: str,
         keystore: mock.Keystore,
         mk_tree_depth: int,
-        zksnark: str) -> contracts.MixResult:
+        zksnark: IZKSnarkProvider) -> contracts.MixResult:
     print(
         f"=== Bob deposits {BOB_DEPOSIT_ETH} ETH for himself and splits into " +
         f"note1: {BOB_SPLIT_1_ETH}ETH, note2: {BOB_SPLIT_2_ETH}ETH ===")
@@ -120,7 +121,7 @@ def bob_to_charlie(
         bob_eth_address: str,
         keystore: mock.Keystore,
         mk_tree_depth: int,
-        zksnark: str) -> contracts.MixResult:
+        zksnark: IZKSnarkProvider) -> contracts.MixResult:
     print(
         f"=== Bob transfers {BOB_TO_CHARLIE_ETH}ETH to Charlie from his funds " +
         "on the mixer ===")
@@ -213,7 +214,7 @@ def charlie_withdraw(
         charlie_eth_address: str,
         keystore: mock.Keystore,
         mk_tree_depth: int,
-        zksnark: str) -> contracts.MixResult:
+        zksnark: IZKSnarkProvider) -> contracts.MixResult:
     print(
         f" === Charlie withdraws {CHARLIE_WITHDRAW_ETH}ETH from his funds " +
         "on the Mixer ===")
@@ -303,7 +304,7 @@ def charlie_double_withdraw(
         charlie_eth_address: str,
         keystore: mock.Keystore,
         mk_tree_depth: int,
-        zksnark: str) -> contracts.MixResult:
+        zksnark: IZKSnarkProvider) -> contracts.MixResult:
     """
     Charlie tries to carry out a double spending by modifying the value of the
     nullifier of the previous payment

--- a/pyClient/test_commands/scenario.py
+++ b/pyClient/test_commands/scenario.py
@@ -25,6 +25,12 @@ CHARLIE_WITHDRAW_ETH = 10.5
 CHARLIE_WITHDRAW_CHANGE_ETH = 39.5
 
 
+def dump_merkle_tree(mk_tree: List[bytes]) -> None:
+    print("[DEBUG] Displaying the Merkle tree of commitments: ")
+    for node in mk_tree:
+        print("Node: " + W3.toHex(node)[2:])
+
+
 def bob_deposit(
         prover_client: ProverClient,
         mixer_instance: Any,

--- a/pyClient/test_commands/scenario.py
+++ b/pyClient/test_commands/scenario.py
@@ -9,6 +9,7 @@ import api.util_pb2 as util_pb2
 from hashlib import sha256
 from web3 import Web3, HTTPProvider  # type: ignore
 from typing import List, Any
+import nacl.utils  # type: ignore
 
 W3 = Web3(HTTPProvider("http://localhost:8545"))
 
@@ -77,7 +78,8 @@ def bob_deposit(
         (output_note2, pk_bob)])
 
     # Hash the pk_sender and cipher-texts
-    ciphers = pk_sender + ciphertexts[0] + ciphertexts[1]
+    pk_sender_bytes = pk_sender.encode(encoder=nacl.encoding.RawEncoder)
+    ciphers = pk_sender_bytes + ciphertexts[0] + ciphertexts[1]
     hash_ciphers = sha256(ciphers).hexdigest()
 
     # Hash the proof
@@ -166,7 +168,8 @@ def bob_to_charlie(
         (output_note2, keystore["Charlie"].addr_pk.k_pk)])
 
     # Hash the pk_sender and cipher-texts
-    ciphers = pk_sender + ciphertexts[0] + ciphertexts[1]
+    pk_sender_bytes = pk_sender.encode(encoder=nacl.encoding.RawEncoder)
+    ciphers = pk_sender_bytes + ciphertexts[0] + ciphertexts[1]
     hash_ciphers = sha256(ciphers).hexdigest()
 
     # Hash the proof
@@ -256,7 +259,8 @@ def charlie_withdraw(
         (output_note2, pk_charlie)])
 
     # Hash the pk_sender and cipher-texts
-    ciphers = pk_sender + ciphertexts[0] + ciphertexts[1]
+    pk_sender_bytes = pk_sender.encode(encoder=nacl.encoding.RawEncoder)
+    ciphers = pk_sender_bytes + ciphertexts[0] + ciphertexts[1]
     hash_ciphers = sha256(ciphers).hexdigest()
 
     # Hash the proof
@@ -361,7 +365,8 @@ def charlie_double_withdraw(
         (output_note2, pk_charlie)])
 
     # Hash the pk_sender and cipher-texts
-    ciphers = pk_sender + ciphertexts[0] + ciphertexts[1]
+    pk_sender_bytes = pk_sender.encode(encoder=nacl.encoding.RawEncoder)
+    ciphers = pk_sender_bytes + ciphertexts[0] + ciphertexts[1]
     hash_ciphers = sha256(ciphers).hexdigest()
 
     # Hash the proof

--- a/pyClient/test_commands/scenario.py
+++ b/pyClient/test_commands/scenario.py
@@ -2,8 +2,7 @@ import zeth.joinsplit as joinsplit
 import zeth.contracts as contracts
 from zeth.prover_client import ProverClient
 from zeth.zksnark import IZKSnarkProvider
-from zeth.utils import to_zeth_units, int64_to_hex, get_public_key_from_bytes, \
-    encode_to_hash
+from zeth.utils import to_zeth_units, int64_to_hex, encode_to_hash
 import test_commands.mock as mock
 import api.util_pb2 as util_pb2
 
@@ -30,7 +29,7 @@ def bob_deposit(
         mixer_instance: Any,
         mk_root: str,
         bob_eth_address: str,
-        keystore: mock.Keystore,
+        keystore: mock.KeyStore,
         mk_tree_depth: int,
         zksnark: IZKSnarkProvider) -> contracts.MixResult:
     print(
@@ -70,7 +69,7 @@ def bob_deposit(
     )
 
     # construct pk object from bytes
-    pk_bob = get_public_key_from_bytes(keystore["Bob"].addr_pk.enc_pk)
+    pk_bob = keystore["Bob"].addr_pk.k_pk
 
     # encrypt the coins
     (pk_sender, ciphertexts) = joinsplit.encrypt_notes([
@@ -119,7 +118,7 @@ def bob_to_charlie(
         input_note1: util_pb2.ZethNote,
         input_address1: int,
         bob_eth_address: str,
-        keystore: mock.Keystore,
+        keystore: mock.KeyStore,
         mk_tree_depth: int,
         zksnark: IZKSnarkProvider) -> contracts.MixResult:
     print(
@@ -163,10 +162,8 @@ def bob_to_charlie(
 
     # Encrypt the output notes for the senders
     (pk_sender, ciphertexts) = joinsplit.encrypt_notes([
-        (output_note1,
-         get_public_key_from_bytes(keystore["Bob"].addr_pk.enc_pk)),
-        (output_note2,
-         get_public_key_from_bytes(keystore["Charlie"].addr_pk.enc_pk))])
+        (output_note1, keystore["Bob"].addr_pk.k_pk),
+        (output_note2, keystore["Charlie"].addr_pk.k_pk)])
 
     # Hash the pk_sender and cipher-texts
     ciphers = pk_sender + ciphertexts[0] + ciphertexts[1]
@@ -212,7 +209,7 @@ def charlie_withdraw(
         input_note1: util_pb2.ZethNote,
         input_address1: int,
         charlie_eth_address: str,
-        keystore: mock.Keystore,
+        keystore: mock.KeyStore,
         mk_tree_depth: int,
         zksnark: IZKSnarkProvider) -> contracts.MixResult:
     print(
@@ -251,7 +248,7 @@ def charlie_withdraw(
         )
 
     # construct pk object from bytes
-    pk_charlie = get_public_key_from_bytes(keystore["Charlie"].addr_pk.enc_pk)
+    pk_charlie = keystore["Charlie"].addr_pk.k_pk
 
     # encrypt the coins
     (pk_sender, ciphertexts) = joinsplit.encrypt_notes([
@@ -302,7 +299,7 @@ def charlie_double_withdraw(
         input_note1: util_pb2.ZethNote,
         input_address1: int,
         charlie_eth_address: str,
-        keystore: mock.Keystore,
+        keystore: mock.KeyStore,
         mk_tree_depth: int,
         zksnark: IZKSnarkProvider) -> contracts.MixResult:
     """
@@ -356,7 +353,7 @@ def charlie_double_withdraw(
     # ### ATTACK BLOCK
 
     # construct pk object from bytes
-    pk_charlie = get_public_key_from_bytes(keystore["Charlie"].addr_pk.enc_pk)
+    pk_charlie = keystore["Charlie"].addr_pk.k_pk
 
     # encrypt the coins
     (pk_sender, ciphertexts) = joinsplit.encrypt_notes([

--- a/pyClient/test_commands/scenario.py
+++ b/pyClient/test_commands/scenario.py
@@ -2,7 +2,7 @@ import zeth.joinsplit as joinsplit
 import zeth.contracts as contracts
 from zeth.prover_client import ProverClient
 from zeth.zksnark import IZKSnarkProvider
-from zeth.utils import to_zeth_units, int64_to_hex
+from zeth.utils import to_zeth_units, int64_to_hex, compute_merkle_path
 import test_commands.mock as mock
 import api.util_pb2 as util_pb2
 
@@ -40,66 +40,36 @@ def bob_deposit(
     print(
         f"=== Bob deposits {BOB_DEPOSIT_ETH} ETH for himself and splits into " +
         f"note1: {BOB_SPLIT_1_ETH}ETH, note2: {BOB_SPLIT_2_ETH}ETH ===")
-    bob_apk = keystore["Bob"].addr_pk.a_pk
+
     bob_ask = keystore["Bob"].addr_sk.a_sk
+    bob_addr = keystore["Bob"].addr_pk
 
-    # Create the JoinSplit dummy inputs for the deposit
-    input1 = joinsplit.get_dummy_input_and_address(bob_apk)
-    input2 = joinsplit.get_dummy_input_and_address(bob_apk)
-    dummy_mk_path = mock.get_dummy_merkle_path(mk_tree_depth)
+    outputs = [
+        (bob_addr, to_zeth_units(str(BOB_SPLIT_1_ETH), 'ether')),
+        (bob_addr, to_zeth_units(str(BOB_SPLIT_2_ETH), 'ether')),
+    ]
 
-    note1_value = to_zeth_units(str(BOB_SPLIT_1_ETH), 'ether')
-    note2_value = to_zeth_units(str(BOB_SPLIT_2_ETH), 'ether')
-    v_in = to_zeth_units(str(BOB_DEPOSIT_ETH), 'ether')
-
-    (output_note1, output_note2, proof_json, signing_keypair) = \
-        joinsplit.get_proof_joinsplit_2_by_2(
-            prover_client,
-            mk_root,
-            input1,
-            dummy_mk_path,
-            input2,
-            dummy_mk_path,
-            bob_ask,  # sender
-            (bob_apk, note1_value),  # output1
-            (bob_apk, note2_value),  # output2
-            int64_to_hex(v_in),  # v_in
-            ZERO_UNITS_HEX,  # v_out
-            zksnark
-    )
-
-    # k_pk object
-    pk_bob = keystore["Bob"].addr_pk.k_pk
-
-    # encrypt the coins for Bob
-    (sender_eph_pk, ciphertexts) = joinsplit.encrypt_notes([
-        (output_note1, pk_bob),
-        (output_note2, pk_bob)])
-
-    # Compute the joinSplit signature
-    joinsplit_sig = joinsplit.sign_mix_tx(
-        sender_eph_pk, ciphertexts, proof_json, signing_keypair)
-
-    return contracts.mix(
+    mk_tree = contracts.get_merkle_tree(mixer_instance)
+    return joinsplit.zeth_spend(
+        prover_client,
         mixer_instance,
-        sender_eph_pk,
-        ciphertexts[0],
-        ciphertexts[1],
-        proof_json,
-        signing_keypair.pk,
-        joinsplit_sig,
+        mk_root,
+        mk_tree,
+        mk_tree_depth,
+        zksnark,
+        joinsplit.OwnershipKeyPair(bob_ask, bob_addr.a_pk),
         bob_eth_address,
-        W3.toWei(BOB_DEPOSIT_ETH, 'ether'),
-        4000000,
-        zksnark
-    )
+        [],
+        outputs,
+        int64_to_hex(to_zeth_units(str(BOB_DEPOSIT_ETH), 'ether')),
+        ZERO_UNITS_HEX,
+        W3.toWei(BOB_DEPOSIT_ETH, 'ether'))
 
 
 def bob_to_charlie(
         prover_client: ProverClient,
         mixer_instance: Any,
         mk_root: str,
-        mk_path1: List[str],
         input1: Tuple[int, util_pb2.ZethNote],
         bob_eth_address: str,
         keystore: mock.KeyStore,
@@ -109,66 +79,39 @@ def bob_to_charlie(
         f"=== Bob transfers {BOB_TO_CHARLIE_ETH}ETH to Charlie from his funds " +
         "on the mixer ===")
 
-    # We generate a coin for Charlie (recipient1)
-    charlie_apk = keystore["Charlie"].addr_pk.a_pk
-    # We generate a coin for Bob: the change (recipient2)
-    bob_apk = keystore["Bob"].addr_pk.a_pk
-    # Bob is the sender
     bob_ask = keystore["Bob"].addr_sk.a_sk
+    charlie_addr = keystore["Charlie"].addr_pk
+    bob_addr = keystore["Bob"].addr_pk
 
-    # Create the an additional dummy input for the JoinSplit
-    input2 = joinsplit.get_dummy_input_and_address(bob_apk)
-    dummy_mk_path = mock.get_dummy_merkle_path(mk_tree_depth)
+    # Coin for Bob (change)
+    value_to_bob = to_zeth_units(str(BOB_TO_CHARLIE_ETH), 'ether')
+    output0 = (bob_addr, value_to_bob)
+    # Coin for Charlie
+    value_to_charlie = to_zeth_units(str(BOB_TO_CHARLIE_CHANGE_ETH), 'ether')
+    output1 = (charlie_addr, value_to_charlie)
 
-    note1_value = to_zeth_units(str(BOB_TO_CHARLIE_ETH), 'ether')
-    note2_value = to_zeth_units(str(BOB_TO_CHARLIE_CHANGE_ETH), 'ether')
-
-    (output_note1, output_note2, proof_json, signing_keypair) = \
-        joinsplit.get_proof_joinsplit_2_by_2(
-            prover_client,
-            mk_root,
-            input1,
-            mk_path1,
-            input2,
-            dummy_mk_path,
-            bob_ask,  # sender
-            (bob_apk, note1_value),  # recipient1 (change)
-            (charlie_apk, note2_value),  # recipient2 (transfer)
-            ZERO_UNITS_HEX,  # v_in
-            ZERO_UNITS_HEX,  # v_out
-            zksnark
-        )
-
-    # Encrypt the output notes for the recipients
-    (sender_eph_pk, ciphertexts) = joinsplit.encrypt_notes([
-        (output_note1, keystore["Bob"].addr_pk.k_pk),
-        (output_note2, keystore["Charlie"].addr_pk.k_pk)])
-
-    # Compute the joinSplit signature
-    joinsplit_sig = joinsplit.sign_mix_tx(
-        sender_eph_pk, ciphertexts, proof_json, signing_keypair)
-    return contracts.mix(
+    # Send the tx
+    mk_tree = contracts.get_merkle_tree(mixer_instance)
+    return joinsplit.zeth_spend(
+        prover_client,
         mixer_instance,
-        sender_eph_pk,
-        ciphertexts[0],
-        ciphertexts[1],
-        proof_json,
-        signing_keypair.pk,
-        joinsplit_sig,
+        mk_root,
+        mk_tree,
+        mk_tree_depth,
+        zksnark,
+        joinsplit.OwnershipKeyPair(bob_ask, bob_addr.a_pk),
         bob_eth_address,
-        # Pay an arbitrary amount (1 wei here) that will be refunded since the
-        # `mix` function is payable
-        W3.toWei(1, 'wei'),
-        4000000,
-        zksnark
-    )
+        [input1],
+        [output0, output1],
+        ZERO_UNITS_HEX,
+        ZERO_UNITS_HEX,
+        W3.toWei(1, 'wei'))
 
 
 def charlie_withdraw(
         prover_client: ProverClient,
         mixer_instance: Any,
         mk_root: str,
-        mk_path1: List[str],
         input1: Tuple[int, util_pb2.ZethNote],
         charlie_eth_address: str,
         keystore: mock.KeyStore,
@@ -178,66 +121,33 @@ def charlie_withdraw(
         f" === Charlie withdraws {CHARLIE_WITHDRAW_ETH}ETH from his funds " +
         "on the Mixer ===")
 
-    charlie_apk = keystore["Charlie"].addr_pk.a_pk
+    mk_tree = contracts.get_merkle_tree(mixer_instance)
+    charlie_pk = keystore["Charlie"].addr_pk
+    charlie_apk = charlie_pk.a_pk
     charlie_ask = keystore["Charlie"].addr_sk.a_sk
+    charlie_ownership_key = \
+        joinsplit.OwnershipKeyPair(charlie_ask, charlie_apk)
 
-    # Create the an additional dummy input for the JoinSplit
-    input2 = joinsplit.get_dummy_input_and_address(charlie_apk)
-    dummy_mk_path = mock.get_dummy_merkle_path(mk_tree_depth)
-
-    note1_value = to_zeth_units(str(CHARLIE_WITHDRAW_CHANGE_ETH), 'ether')
-    v_out = to_zeth_units(str(CHARLIE_WITHDRAW_ETH), 'ether')
-
-    (output_note1, output_note2, proof_json, signing_keypair) = \
-        joinsplit.get_proof_joinsplit_2_by_2(
-            prover_client,
-            mk_root,
-            input1,
-            mk_path1,
-            input2,
-            dummy_mk_path,
-            charlie_ask,  # sender
-            (charlie_apk, note1_value),  # recipient1
-            (charlie_apk, 0),  # recipient2
-            ZERO_UNITS_HEX,  # v_in
-            int64_to_hex(v_out),  # v_out
-            zksnark
-        )
-
-    # construct pk object from bytes
-    pk_charlie = keystore["Charlie"].addr_pk.k_pk
-
-    # encrypt the coins
-    (sender_eph_pk, ciphertexts) = joinsplit.encrypt_notes([
-        (output_note1, pk_charlie),
-        (output_note2, pk_charlie)])
-
-    # Compute the joinSplit signature
-    joinsplit_sig = joinsplit.sign_mix_tx(
-        sender_eph_pk, ciphertexts, proof_json, signing_keypair)
-
-    return contracts.mix(
+    return joinsplit.zeth_spend(
+        prover_client,
         mixer_instance,
-        sender_eph_pk,
-        ciphertexts[0],
-        ciphertexts[1],
-        proof_json,
-        signing_keypair.pk,
-        joinsplit_sig,
+        mk_root,
+        mk_tree,
+        mk_tree_depth,
+        zksnark,
+        charlie_ownership_key,
         charlie_eth_address,
-        # Pay an arbitrary amount (1 wei here) that will be refunded since the
-        # `mix` function is payable
-        W3.toWei(1, 'wei'),
-        4000000,
-        zksnark
-    )
+        [input1],
+        [(charlie_pk, to_zeth_units(str(CHARLIE_WITHDRAW_CHANGE_ETH), 'ether'))],
+        ZERO_UNITS_HEX,
+        int64_to_hex(to_zeth_units(str(CHARLIE_WITHDRAW_ETH), 'ether')),
+        W3.toWei(1, 'wei'))
 
 
 def charlie_double_withdraw(
         prover_client: ProverClient,
         mixer_instance: Any,
         mk_root: str,
-        mk_path1: List[str],
         input1: Tuple[int, util_pb2.ZethNote],
         charlie_eth_address: str,
         keystore: mock.KeyStore,
@@ -253,6 +163,9 @@ def charlie_double_withdraw(
 
     charlie_apk = keystore["Charlie"].addr_pk.a_pk
     charlie_ask = keystore["Charlie"].addr_sk.a_sk
+
+    mk_byte_tree = contracts.get_merkle_tree(mixer_instance)
+    mk_path1 = compute_merkle_path(input1[0], mk_tree_depth, mk_byte_tree)
 
     # Create the an additional dummy input for the JoinSplit
     input2 = joinsplit.get_dummy_input_and_address(charlie_apk)

--- a/pyClient/test_commands/scenario.py
+++ b/pyClient/test_commands/scenario.py
@@ -45,8 +45,8 @@ def bob_deposit(
     bob_addr = keystore["Bob"].addr_pk
 
     outputs = [
-        (bob_addr, to_zeth_units(str(BOB_SPLIT_1_ETH), 'ether')),
-        (bob_addr, to_zeth_units(str(BOB_SPLIT_2_ETH), 'ether')),
+        (bob_addr, to_zeth_units(BOB_SPLIT_1_ETH, 'ether')),
+        (bob_addr, to_zeth_units(BOB_SPLIT_2_ETH, 'ether')),
     ]
 
     mk_tree = contracts.get_merkle_tree(mixer_instance)
@@ -61,7 +61,7 @@ def bob_deposit(
         bob_eth_address,
         [],
         outputs,
-        int64_to_hex(to_zeth_units(str(BOB_DEPOSIT_ETH), 'ether')),
+        int64_to_hex(to_zeth_units(BOB_DEPOSIT_ETH, 'ether')),
         ZERO_UNITS_HEX,
         W3.toWei(BOB_DEPOSIT_ETH, 'ether'))
 
@@ -84,10 +84,10 @@ def bob_to_charlie(
     bob_addr = keystore["Bob"].addr_pk
 
     # Coin for Bob (change)
-    value_to_bob = to_zeth_units(str(BOB_TO_CHARLIE_ETH), 'ether')
+    value_to_bob = to_zeth_units(BOB_TO_CHARLIE_ETH, 'ether')
     output0 = (bob_addr, value_to_bob)
     # Coin for Charlie
-    value_to_charlie = to_zeth_units(str(BOB_TO_CHARLIE_CHANGE_ETH), 'ether')
+    value_to_charlie = to_zeth_units(BOB_TO_CHARLIE_CHANGE_ETH, 'ether')
     output1 = (charlie_addr, value_to_charlie)
 
     # Send the tx
@@ -138,9 +138,9 @@ def charlie_withdraw(
         charlie_ownership_key,
         charlie_eth_address,
         [input1],
-        [(charlie_pk, to_zeth_units(str(CHARLIE_WITHDRAW_CHANGE_ETH), 'ether'))],
+        [(charlie_pk, to_zeth_units(CHARLIE_WITHDRAW_CHANGE_ETH, 'ether'))],
         ZERO_UNITS_HEX,
-        int64_to_hex(to_zeth_units(str(CHARLIE_WITHDRAW_ETH), 'ether')),
+        int64_to_hex(to_zeth_units(CHARLIE_WITHDRAW_ETH, 'ether')),
         W3.toWei(1, 'wei'))
 
 
@@ -171,8 +171,8 @@ def charlie_double_withdraw(
     input2 = joinsplit.get_dummy_input_and_address(charlie_apk)
     dummy_mk_path = mock.get_dummy_merkle_path(mk_tree_depth)
 
-    note1_value = to_zeth_units(str(CHARLIE_WITHDRAW_CHANGE_ETH), 'ether')
-    v_out = to_zeth_units(str(CHARLIE_WITHDRAW_ETH), 'ether')
+    note1_value = to_zeth_units(CHARLIE_WITHDRAW_CHANGE_ETH, 'ether')
+    v_out = to_zeth_units(CHARLIE_WITHDRAW_ETH, 'ether')
 
     (output_note1, output_note2, proof_json, signing_keypair) = \
         joinsplit.get_proof_joinsplit_2_by_2(

--- a/pyClient/test_commands/scenario.py
+++ b/pyClient/test_commands/scenario.py
@@ -63,19 +63,17 @@ def bob_deposit(
             input2,
             dummy_mk_path,
             bob_ask,  # sender
-            bob_apk,  # recipient1
-            bob_apk,  # recipient2
-            int64_to_hex(note1_value),  # value output note 1
-            int64_to_hex(note2_value),  # value output note 2
+            (bob_apk, note1_value),  # output1
+            (bob_apk, note2_value),  # output2
             int64_to_hex(v_in),  # v_in
             ZERO_UNITS_HEX,  # v_out
             zksnark
     )
 
-    # construct pk object from bytes
+    # k_pk object
     pk_bob = keystore["Bob"].addr_pk.k_pk
 
-    # encrypt the coins
+    # encrypt the coins for Bob
     (pk_sender, ciphertexts) = joinsplit.encrypt_notes([
         (output_note1, pk_bob),
         (output_note2, pk_bob)])
@@ -152,10 +150,8 @@ def bob_to_charlie(
             input2,
             dummy_mk_path,
             bob_ask,  # sender
-            bob_apk,  # recipient1 (change)
-            charlie_apk,  # recipient2 (transfer)
-            int64_to_hex(note1_value),  # value output note 1
-            int64_to_hex(note2_value),  # value output note 2
+            (bob_apk, note1_value),  # recipient1 (change)
+            (charlie_apk, note2_value),  # recipient2 (transfer)
             ZERO_UNITS_HEX,  # v_in
             ZERO_UNITS_HEX,  # v_out
             zksnark
@@ -236,10 +232,8 @@ def charlie_withdraw(
             input2,
             dummy_mk_path,
             charlie_ask,  # sender
-            charlie_apk,  # recipient1
-            charlie_apk,  # recipient2
-            int64_to_hex(note1_value),  # value output note 1
-            ZERO_UNITS_HEX,  # value output note 2
+            (charlie_apk, note1_value),  # recipient1
+            (charlie_apk, 0),  # recipient2
             ZERO_UNITS_HEX,  # v_in
             int64_to_hex(v_out),  # v_out
             zksnark
@@ -327,10 +321,8 @@ def charlie_double_withdraw(
             input2,
             dummy_mk_path,
             charlie_ask,  # sender
-            charlie_apk,  # recipient1
-            charlie_apk,  # recipient2
-            int64_to_hex(note1_value),  # value output note 1
-            ZERO_UNITS_HEX,  # value output note 2
+            (charlie_apk, note1_value),  # recipient1
+            (charlie_apk, 0),  # recipient2
             ZERO_UNITS_HEX,  # v_in
             int64_to_hex(v_out),  # v_out
             zksnark

--- a/pyClient/test_commands/test_erc_token_mixing.py
+++ b/pyClient/test_commands/test_erc_token_mixing.py
@@ -152,6 +152,9 @@ def main() -> None:
         zksnark
     )
 
+    zeth_client = zeth.joinsplit.ZethClient(
+        prover_client, mixer_instance, zksnark)
+
     print("[INFO] 4. Running tests (asset mixed: ERC20 token)...")
     # We assign ETHToken to Bob
     mint_token(
@@ -172,14 +175,7 @@ def main() -> None:
     # approving)
     try:
         result_deposit_bob_to_bob = scenario.bob_deposit(
-            prover_client,
-            mixer_instance,
-            initial_root,
-            bob_eth_address,
-            keystore,
-            mk_tree_depth,
-            zksnark
-        )
+            zeth_client, initial_root, bob_eth_address, keystore, mk_tree_depth)
     except Exception as e:
         allowance_mixer = allowance(
             token_instance, bob_eth_address, mixer_instance.address)
@@ -199,14 +195,7 @@ def main() -> None:
     print("- The allowance for the Mixer from Bob is:", allowance_mixer)
     # Bob deposits ETHToken, split in 2 notes on the mixer
     result_deposit_bob_to_bob = scenario.bob_deposit(
-        prover_client,
-        mixer_instance,
-        initial_root,
-        bob_eth_address,
-        keystore,
-        mk_tree_depth,
-        zksnark
-    )
+        zeth_client, initial_root, bob_eth_address, keystore, mk_tree_depth)
     new_merkle_root_bob_to_bob = result_deposit_bob_to_bob.new_merkle_root
 
     print("- Balances after Bob's deposit: ")
@@ -241,15 +230,12 @@ def main() -> None:
 
     # Execution of the transfer
     result_transfer_bob_to_charlie = scenario.bob_to_charlie(
-        prover_client,
-        mixer_instance,
+        zeth_client,
         new_merkle_root_bob_to_bob,
         input_bob_to_charlie,
         bob_eth_address,
         keystore,
-        mk_tree_depth,
-        zksnark
-    )
+        mk_tree_depth)
 
     new_merkle_root_bob_to_charlie = \
         result_transfer_bob_to_charlie.new_merkle_root
@@ -258,15 +244,12 @@ def main() -> None:
     result_double_spending = None
     try:
         result_double_spending = scenario.bob_to_charlie(
-            prover_client,
-            mixer_instance,
+            zeth_client,
             new_merkle_root_bob_to_bob,
             input_bob_to_charlie,
             bob_eth_address,
             keystore,
-            mk_tree_depth,
-            zksnark
-        )
+            mk_tree_depth)
     except Exception as e:
         print(f"Bob's double spending successfully rejected! (msg: {e})")
     assert(result_double_spending is None), "Bob spent the same note twice!"
@@ -291,15 +274,12 @@ def main() -> None:
         result_transfer_bob_to_charlie.encrypted_notes[1][0]
 
     result_charlie_withdrawal = scenario.charlie_withdraw(
-        prover_client,
-        mixer_instance,
+        zeth_client,
         new_merkle_root_bob_to_charlie,
         notes_charlie[0],
         charlie_eth_address,
         keystore,
-        mk_tree_depth,
-        zksnark
-    )
+        mk_tree_depth)
 
     new_merkle_root_charlie_withdrawal = \
         result_charlie_withdrawal.new_merkle_root
@@ -319,15 +299,12 @@ def main() -> None:
         # New commitments are added in the tree at each withdraw so we
         # recompute the path to have the updated nodes
         result_double_spending = scenario.charlie_double_withdraw(
-            prover_client,
-            mixer_instance,
+            zeth_client,
             new_merkle_root_charlie_withdrawal,
             notes_charlie[0],
             charlie_eth_address,
             keystore,
-            mk_tree_depth,
-            zksnark
-        )
+            mk_tree_depth)
     except Exception as e:
         print(f"Charlie's double spending successfully rejected! (msg: {e})")
     print("Balances after Charlie's double withdrawal attempt: ")
@@ -338,8 +315,7 @@ def main() -> None:
         bob_eth_address,
         alice_eth_address,
         charlie_eth_address,
-        mixer_instance.address
-    )
+        mixer_instance.address)
 
 
 if __name__ == '__main__':

--- a/pyClient/test_commands/test_erc_token_mixing.py
+++ b/pyClient/test_commands/test_erc_token_mixing.py
@@ -218,7 +218,7 @@ def main() -> None:
     cm_address_bob_to_bob1 = result_deposit_bob_to_bob.cm_address_1
     cm_address_bob_to_bob2 = result_deposit_bob_to_bob.cm_address_2
     new_merkle_root_bob_to_bob = result_deposit_bob_to_bob.new_merkle_root
-    pk_sender_bob_to_bob = result_deposit_bob_to_bob.pk_sender
+    pk_sender_bob_to_bob = result_deposit_bob_to_bob.sender_k_pk
     ciphertext_bob_to_bob1 = result_deposit_bob_to_bob.ciphertext_1
     ciphertext_bob_to_bob2 = result_deposit_bob_to_bob.ciphertext_2
 
@@ -280,7 +280,7 @@ def main() -> None:
     cm_address_bob_to_charlie2 = result_transfer_bob_to_charlie.cm_address_2
     new_merkle_root_bob_to_charlie = \
         result_transfer_bob_to_charlie.new_merkle_root
-    pk_sender_bob_to_charlie = result_transfer_bob_to_charlie.pk_sender
+    pk_sender_bob_to_charlie = result_transfer_bob_to_charlie.sender_k_pk
     ciphertext_bob_to_charlie1 = result_transfer_bob_to_charlie.ciphertext_1
     ciphertext_bob_to_charlie2 = result_transfer_bob_to_charlie.ciphertext_2
 

--- a/pyClient/test_commands/test_erc_token_mixing.py
+++ b/pyClient/test_commands/test_erc_token_mixing.py
@@ -2,6 +2,7 @@
 
 import zeth.contracts as contracts
 import zeth.joinsplit
+import zeth.zksnark
 from zeth.prover_client import ProverClient
 from zeth.wallet import Wallet
 import zeth.utils
@@ -109,7 +110,7 @@ def mint_token(
 
 
 def main() -> None:
-    zksnark = zeth.utils.parse_zksnark_arg()
+    zksnark = zeth.zksnark.get_zksnark_provider(zeth.utils.parse_zksnark_arg())
 
     # Ethereum addresses
     deployer_eth_address = eth.accounts[0]

--- a/pyClient/test_commands/test_erc_token_mixing.py
+++ b/pyClient/test_commands/test_erc_token_mixing.py
@@ -207,12 +207,7 @@ def main() -> None:
         mk_tree_depth,
         zksnark
     )
-    cm_address_bob_to_bob1 = result_deposit_bob_to_bob.cm_address_1
-    cm_address_bob_to_bob2 = result_deposit_bob_to_bob.cm_address_2
     new_merkle_root_bob_to_bob = result_deposit_bob_to_bob.new_merkle_root
-    pk_sender_bob_to_bob = result_deposit_bob_to_bob.sender_k_pk
-    ciphertext_bob_to_bob1 = result_deposit_bob_to_bob.ciphertext_1
-    ciphertext_bob_to_bob2 = result_deposit_bob_to_bob.ciphertext_2
 
     print("- Balances after Bob's deposit: ")
     print_token_balances(
@@ -226,9 +221,8 @@ def main() -> None:
     # Alice sees a deposit and tries to decrypt the ciphertexts to see if she
     # was the recipient, but Bob was the recipient so Alice fails to decrypt
     recovered_notes_alice = alice_wallet.receive_notes(
-        [(cm_address_bob_to_bob1, ciphertext_bob_to_bob1),
-         (cm_address_bob_to_bob2, ciphertext_bob_to_bob2)],
-        pk_sender_bob_to_bob)
+        result_deposit_bob_to_bob.encrypted_notes,
+        result_deposit_bob_to_bob.sender_k_pk)
     assert(len(recovered_notes_alice) == 0), \
         "Alice decrypted a ciphertext that was not encrypted with her key!"
 
@@ -238,19 +232,20 @@ def main() -> None:
     # he wants to spend
     mk_byte_tree = contracts.get_merkle_tree(mixer_instance)
     mk_path = zeth.utils.compute_merkle_path(
-        cm_address_bob_to_bob1, mk_tree_depth, mk_byte_tree)
+        result_deposit_bob_to_bob.encrypted_notes[0][0],
+        mk_tree_depth,
+        mk_byte_tree)
 
     # Bob decrypts one of the note he previously received (useless here but
     # useful if the payment came from someone else)
     recovered_notes_bob = bob_wallet.receive_notes(
-        [(cm_address_bob_to_bob1, ciphertext_bob_to_bob1),
-         (cm_address_bob_to_bob2, ciphertext_bob_to_bob2)],
-        pk_sender_bob_to_bob)
+        result_deposit_bob_to_bob.encrypted_notes,
+        result_deposit_bob_to_bob.sender_k_pk)
     assert(len(recovered_notes_bob) == 2), \
         f"Bob recovered {len(recovered_notes_bob)} notes from deposit, expected 2"
-    (addr_input_note_bob_to_charlie, input_note_bob_to_charlie) = \
-        recovered_notes_bob[0]
-    assert addr_input_note_bob_to_charlie == cm_address_bob_to_bob1
+    input_bob_to_charlie = recovered_notes_bob[0]
+    assert input_bob_to_charlie[0] == \
+        result_deposit_bob_to_bob.encrypted_notes[0][0]
 
     # Execution of the transfer
     result_transfer_bob_to_charlie = scenario.bob_to_charlie(
@@ -258,23 +253,15 @@ def main() -> None:
         mixer_instance,
         new_merkle_root_bob_to_bob,
         mk_path,
-        input_note_bob_to_charlie,
-        cm_address_bob_to_bob1,
+        input_bob_to_charlie,
         bob_eth_address,
         keystore,
         mk_tree_depth,
         zksnark
     )
 
-    # Bob -> Bob (Change)
-    cm_address_bob_to_charlie1 = result_transfer_bob_to_charlie.cm_address_1
-    # Bob -> Charlie (payment to Charlie)
-    cm_address_bob_to_charlie2 = result_transfer_bob_to_charlie.cm_address_2
     new_merkle_root_bob_to_charlie = \
         result_transfer_bob_to_charlie.new_merkle_root
-    pk_sender_bob_to_charlie = result_transfer_bob_to_charlie.sender_k_pk
-    ciphertext_bob_to_charlie1 = result_transfer_bob_to_charlie.ciphertext_1
-    ciphertext_bob_to_charlie2 = result_transfer_bob_to_charlie.ciphertext_2
 
     # Bob tries to spend `input_note_bob_to_charlie` twice
     result_double_spending = None
@@ -284,8 +271,7 @@ def main() -> None:
             mixer_instance,
             new_merkle_root_bob_to_bob,
             mk_path,
-            input_note_bob_to_charlie,
-            cm_address_bob_to_bob1,
+            input_bob_to_charlie,
             bob_eth_address,
             keystore,
             mk_tree_depth,
@@ -306,27 +292,24 @@ def main() -> None:
 
     # Charlie tries to decrypt the notes from Bob's previous transaction.
     notes_charlie = charlie_wallet.receive_notes(
-        [(cm_address_bob_to_charlie1, ciphertext_bob_to_charlie1),
-         (cm_address_bob_to_charlie2, ciphertext_bob_to_charlie2)],
-        pk_sender_bob_to_charlie)
+        result_transfer_bob_to_charlie.encrypted_notes,
+        result_transfer_bob_to_charlie.sender_k_pk)
     assert(len(notes_charlie) == 1), \
         f"Charlie decrypted {len(notes_charlie)}.  Expected 1!"
 
     # Charlie now gets the merkle path for the commitment he wants to spend
     mk_byte_tree = contracts.get_merkle_tree(mixer_instance)
     mk_path = zeth.utils.compute_merkle_path(
-        cm_address_bob_to_charlie2, mk_tree_depth, mk_byte_tree)
-    (addr_input_note_charlie_withdraw, input_note_charlie_withdraw) = \
-        notes_charlie[0]
-    assert addr_input_note_charlie_withdraw == cm_address_bob_to_charlie2
+        notes_charlie[0][0], mk_tree_depth, mk_byte_tree)
+    assert notes_charlie[0][0] == \
+        result_transfer_bob_to_charlie.encrypted_notes[1][0]
 
     result_charlie_withdrawal = scenario.charlie_withdraw(
         prover_client,
         mixer_instance,
         new_merkle_root_bob_to_charlie,
         mk_path,
-        input_note_charlie_withdraw,
-        cm_address_bob_to_charlie2,
+        notes_charlie[0],
         charlie_eth_address,
         keystore,
         mk_tree_depth,
@@ -352,14 +335,13 @@ def main() -> None:
         # recompiute the path to have the updated nodes
         mk_byte_tree = contracts.get_merkle_tree(mixer_instance)
         mk_path = zeth.utils.compute_merkle_path(
-            cm_address_bob_to_charlie2, mk_tree_depth, mk_byte_tree)
+            notes_charlie[0][0], mk_tree_depth, mk_byte_tree)
         result_double_spending = scenario.charlie_double_withdraw(
             prover_client,
             mixer_instance,
             new_merkle_root_charlie_withdrawal,
             mk_path,
-            input_note_charlie_withdraw,
-            cm_address_bob_to_charlie2,
+            notes_charlie[0],
             charlie_eth_address,
             keystore,
             mk_tree_depth,

--- a/pyClient/test_commands/test_erc_token_mixing.py
+++ b/pyClient/test_commands/test_erc_token_mixing.py
@@ -227,14 +227,6 @@ def main() -> None:
         "Alice decrypted a ciphertext that was not encrypted with her key!"
 
     # Bob does a transfer of ETHToken to Charlie on the mixer
-    #
-    # Bob looks in the merkle tree and gets the merkle path to the commitment
-    # he wants to spend
-    mk_byte_tree = contracts.get_merkle_tree(mixer_instance)
-    mk_path = zeth.utils.compute_merkle_path(
-        result_deposit_bob_to_bob.encrypted_notes[0][0],
-        mk_tree_depth,
-        mk_byte_tree)
 
     # Bob decrypts one of the note he previously received (useless here but
     # useful if the payment came from someone else)
@@ -252,7 +244,6 @@ def main() -> None:
         prover_client,
         mixer_instance,
         new_merkle_root_bob_to_bob,
-        mk_path,
         input_bob_to_charlie,
         bob_eth_address,
         keystore,
@@ -270,7 +261,6 @@ def main() -> None:
             prover_client,
             mixer_instance,
             new_merkle_root_bob_to_bob,
-            mk_path,
             input_bob_to_charlie,
             bob_eth_address,
             keystore,
@@ -297,10 +287,6 @@ def main() -> None:
     assert(len(notes_charlie) == 1), \
         f"Charlie decrypted {len(notes_charlie)}.  Expected 1!"
 
-    # Charlie now gets the merkle path for the commitment he wants to spend
-    mk_byte_tree = contracts.get_merkle_tree(mixer_instance)
-    mk_path = zeth.utils.compute_merkle_path(
-        notes_charlie[0][0], mk_tree_depth, mk_byte_tree)
     assert notes_charlie[0][0] == \
         result_transfer_bob_to_charlie.encrypted_notes[1][0]
 
@@ -308,7 +294,6 @@ def main() -> None:
         prover_client,
         mixer_instance,
         new_merkle_root_bob_to_charlie,
-        mk_path,
         notes_charlie[0],
         charlie_eth_address,
         keystore,
@@ -332,15 +317,11 @@ def main() -> None:
     result_double_spending = None
     try:
         # New commitments are added in the tree at each withdraw so we
-        # recompiute the path to have the updated nodes
-        mk_byte_tree = contracts.get_merkle_tree(mixer_instance)
-        mk_path = zeth.utils.compute_merkle_path(
-            notes_charlie[0][0], mk_tree_depth, mk_byte_tree)
+        # recompute the path to have the updated nodes
         result_double_spending = scenario.charlie_double_withdraw(
             prover_client,
             mixer_instance,
             new_merkle_root_charlie_withdrawal,
-            mk_path,
             notes_charlie[0],
             charlie_eth_address,
             keystore,

--- a/pyClient/test_commands/test_erc_token_mixing.py
+++ b/pyClient/test_commands/test_erc_token_mixing.py
@@ -14,7 +14,7 @@ import os
 from web3 import Web3, HTTPProvider  # type: ignore
 from solcx import compile_files  # type: ignore
 from os.path import join
-from typing import List, Any
+from typing import Any
 
 W3 = Web3(HTTPProvider(constants.WEB3_HTTP_PROVIDER))
 eth = W3.eth  # pylint: disable=no-member,invalid-name
@@ -58,14 +58,6 @@ def deploy_token(
         abi=token_interface['abi'],
     )
     return token
-
-
-def get_merkle_tree(mixer_instance: Any) -> List[bytes]:
-    mk_byte_tree = mixer_instance.functions.getTree().call()
-    print("[DEBUG] Displaying the Merkle tree of commitments: ")
-    for node in mk_byte_tree:
-        print("Node: " + W3.toHex(node)[2:])
-    return mk_byte_tree
 
 
 def print_token_balances(
@@ -244,7 +236,7 @@ def main() -> None:
     #
     # Bob looks in the merkle tree and gets the merkle path to the commitment
     # he wants to spend
-    mk_byte_tree = get_merkle_tree(mixer_instance)
+    mk_byte_tree = contracts.get_merkle_tree(mixer_instance)
     mk_path = zeth.utils.compute_merkle_path(
         cm_address_bob_to_bob1, mk_tree_depth, mk_byte_tree)
 
@@ -321,7 +313,7 @@ def main() -> None:
         f"Charlie decrypted {len(notes_charlie)}.  Expected 1!"
 
     # Charlie now gets the merkle path for the commitment he wants to spend
-    mk_byte_tree = get_merkle_tree(mixer_instance)
+    mk_byte_tree = contracts.get_merkle_tree(mixer_instance)
     mk_path = zeth.utils.compute_merkle_path(
         cm_address_bob_to_charlie2, mk_tree_depth, mk_byte_tree)
     (addr_input_note_charlie_withdraw, input_note_charlie_withdraw) = \
@@ -358,7 +350,7 @@ def main() -> None:
     try:
         # New commitments are added in the tree at each withdraw so we
         # recompiute the path to have the updated nodes
-        mk_byte_tree = get_merkle_tree(mixer_instance)
+        mk_byte_tree = contracts.get_merkle_tree(mixer_instance)
         mk_path = zeth.utils.compute_merkle_path(
             cm_address_bob_to_charlie2, mk_tree_depth, mk_byte_tree)
         result_double_spending = scenario.charlie_double_withdraw(

--- a/pyClient/test_commands/test_erc_token_mixing.py
+++ b/pyClient/test_commands/test_erc_token_mixing.py
@@ -127,16 +127,13 @@ def main() -> None:
     coinstore_dir = os.environ['ZETH_COINSTORE']
 
     # Keys and wallets
-    sk_alice = zeth.utils.get_private_key_from_bytes(
-        keystore["Alice"].addr_sk.enc_sk)
-    sk_bob = zeth.utils.get_private_key_from_bytes(
-        keystore["Bob"].addr_sk.enc_sk)
-    sk_charlie = zeth.utils.get_private_key_from_bytes(
-        keystore["Charlie"].addr_sk.enc_sk)
+    k_sk_alice = keystore["Alice"].addr_sk.k_sk
+    k_sk_bob = keystore["Bob"].addr_sk.k_sk
+    k_sk_charlie = keystore["Charlie"].addr_sk.k_sk
 
-    alice_wallet = Wallet("alice", coinstore_dir, sk_alice)
-    bob_wallet = Wallet("bob", coinstore_dir, sk_bob)
-    charlie_wallet = Wallet("charlie", coinstore_dir, sk_charlie)
+    alice_wallet = Wallet("alice", coinstore_dir, k_sk_alice)
+    bob_wallet = Wallet("bob", coinstore_dir, k_sk_bob)
+    charlie_wallet = Wallet("charlie", coinstore_dir, k_sk_charlie)
 
     print("[INFO] 1. Fetching the verification key from the proving server")
     vk = prover_client.get_verification_key()

--- a/pyClient/test_commands/test_ether_mixing.py
+++ b/pyClient/test_commands/test_ether_mixing.py
@@ -2,6 +2,7 @@
 
 import zeth.contracts
 import zeth.joinsplit
+import zeth.zksnark
 import zeth.utils
 import zeth.constants as constants
 import test_commands.mock as mock
@@ -35,7 +36,7 @@ def get_merkle_tree(mixer_instance: Any) -> List[bytes]:
 
 
 def main() -> None:
-    zksnark = zeth.utils.parse_zksnark_arg()
+    zksnark = zeth.zksnark.get_zksnark_provider(zeth.utils.parse_zksnark_arg())
 
     # Zeth addresses
     keystore = mock.init_test_keystore()

--- a/pyClient/test_commands/test_ether_mixing.py
+++ b/pyClient/test_commands/test_ether_mixing.py
@@ -115,14 +115,6 @@ def main() -> None:
         "Alice decrypted a ciphertext that was not encrypted with her key!"
 
     # Bob does a transfer to Charlie on the mixer
-    #
-    # Bob looks in the merkle tree and gets the merkle path to the commitment
-    # he wants to spend
-    mk_byte_tree = zeth.contracts.get_merkle_tree(mixer_instance)
-    mk_path = zeth.utils.compute_merkle_path(
-        result_deposit_bob_to_bob.encrypted_notes[0][0],
-        mk_tree_depth,
-        mk_byte_tree)
 
     # Bob decrypts one of the note he previously received (useless here but
     # useful if the payment came from someone else)
@@ -138,7 +130,6 @@ def main() -> None:
         prover_client,
         mixer_instance,
         new_merkle_root_bob_to_bob,
-        mk_path,
         bob_to_charlie,
         bob_eth_address,
         keystore,
@@ -156,7 +147,6 @@ def main() -> None:
             prover_client,
             mixer_instance,
             new_merkle_root_bob_to_bob,
-            mk_path,
             bob_to_charlie,
             bob_eth_address,
             keystore,
@@ -176,19 +166,13 @@ def main() -> None:
         mixer_instance.address
     )
 
-    # Charlie recovers his notes.
+    # Charlie recovers his notes and attempts to withdraw them.
     notes_charlie = charlie_wallet.receive_notes(
         result_transfer_bob_to_charlie.encrypted_notes,
         result_transfer_bob_to_charlie.sender_k_pk)
     assert(len(notes_charlie) == 1), \
         f"Charlie decrypted {len(notes_charlie)}.  Expected 1!"
 
-    # Charlie now gets the merkle path for the commitment he wants to spend
-    mk_byte_tree = zeth.contracts.get_merkle_tree(mixer_instance)
-    mk_path = zeth.utils.compute_merkle_path(
-        notes_charlie[0][0],
-        mk_tree_depth,
-        mk_byte_tree)
     input_charlie_withdraw = notes_charlie[0]
     assert input_charlie_withdraw[0] == \
         result_transfer_bob_to_charlie.encrypted_notes[1][0]
@@ -197,7 +181,6 @@ def main() -> None:
         prover_client,
         mixer_instance,
         new_merkle_root_bob_to_charlie,
-        mk_path,
         input_charlie_withdraw,
         charlie_eth_address,
         keystore,
@@ -218,14 +201,10 @@ def main() -> None:
     try:
         # New commitments are added in the tree at each withdraw so we
         # recompiute the path to have the updated nodes
-        mk_byte_tree = zeth.contracts.get_merkle_tree(mixer_instance)
-        mk_path = zeth.utils.compute_merkle_path(
-            notes_charlie[0][0], mk_tree_depth, mk_byte_tree)
         result_double_spending = scenario.charlie_double_withdraw(
             prover_client,
             mixer_instance,
             new_merkle_root_charlie_withdrawal,
-            mk_path,
             input_charlie_withdraw,
             charlie_eth_address,
             keystore,

--- a/pyClient/test_commands/test_ether_mixing.py
+++ b/pyClient/test_commands/test_ether_mixing.py
@@ -76,24 +76,24 @@ def main() -> None:
         zksnark
     )
 
+    zeth_client = zeth.joinsplit.ZethClient(
+        prover_client, mixer_instance, zksnark)
+
     print("[INFO] 4. Running tests (asset mixed: Ether)...")
     print("- Initial balances: ")
     print_balances(
         bob_eth_address,
         alice_eth_address,
         charlie_eth_address,
-        mixer_instance.address
-    )
+        mixer_instance.address)
 
     # Bob deposits ETH, split in 2 notes on the mixer
     result_deposit_bob_to_bob = scenario.bob_deposit(
-        prover_client,
-        mixer_instance,
+        zeth_client,
         initial_root,
         bob_eth_address,
         keystore,
-        mk_tree_depth,
-        zksnark
+        mk_tree_depth
     )
     new_merkle_root_bob_to_bob = result_deposit_bob_to_bob.new_merkle_root
 
@@ -127,15 +127,12 @@ def main() -> None:
 
     # Execution of the transfer
     result_transfer_bob_to_charlie = scenario.bob_to_charlie(
-        prover_client,
-        mixer_instance,
+        zeth_client,
         new_merkle_root_bob_to_bob,
         bob_to_charlie,
         bob_eth_address,
         keystore,
-        mk_tree_depth,
-        zksnark
-    )
+        mk_tree_depth)
 
     new_merkle_root_bob_to_charlie = \
         result_transfer_bob_to_charlie.new_merkle_root
@@ -144,15 +141,12 @@ def main() -> None:
     result_double_spending = None
     try:
         result_double_spending = scenario.bob_to_charlie(
-            prover_client,
-            mixer_instance,
+            zeth_client,
             new_merkle_root_bob_to_bob,
             bob_to_charlie,
             bob_eth_address,
             keystore,
-            mk_tree_depth,
-            zksnark
-        )
+            mk_tree_depth)
     except Exception as e:
         print(f"Bob's double spending successfully rejected! (msg: {e})")
     assert(result_double_spending is None), \
@@ -178,15 +172,12 @@ def main() -> None:
         result_transfer_bob_to_charlie.encrypted_notes[1][0]
 
     result_charlie_withdrawal = scenario.charlie_withdraw(
-        prover_client,
-        mixer_instance,
+        zeth_client,
         new_merkle_root_bob_to_charlie,
         input_charlie_withdraw,
         charlie_eth_address,
         keystore,
-        mk_tree_depth,
-        zksnark
-    )
+        mk_tree_depth)
     new_merkle_root_charlie_withdrawal = result_charlie_withdrawal.new_merkle_root
     print("Balances after Charlie's withdrawal: ")
     print_balances(
@@ -202,15 +193,12 @@ def main() -> None:
         # New commitments are added in the tree at each withdraw so we
         # recompiute the path to have the updated nodes
         result_double_spending = scenario.charlie_double_withdraw(
-            prover_client,
-            mixer_instance,
+            zeth_client,
             new_merkle_root_charlie_withdrawal,
             input_charlie_withdraw,
             charlie_eth_address,
             keystore,
-            mk_tree_depth,
-            zksnark
-        )
+            mk_tree_depth)
     except Exception as e:
         print(f"Charlie's double spending successfully rejected! (msg: {e})")
     print("Balances after Charlie's double withdrawal attempt: ")

--- a/pyClient/test_commands/test_ether_mixing.py
+++ b/pyClient/test_commands/test_ether_mixing.py
@@ -107,7 +107,7 @@ def main() -> None:
     cm_address_bob_to_bob1 = result_deposit_bob_to_bob.cm_address_1
     cm_address_bob_to_bob2 = result_deposit_bob_to_bob.cm_address_2
     new_merkle_root_bob_to_bob = result_deposit_bob_to_bob.new_merkle_root
-    pk_sender_bob_to_bob = result_deposit_bob_to_bob.pk_sender
+    pk_sender_bob_to_bob = result_deposit_bob_to_bob.sender_k_pk
     ciphertext_bob_to_bob1 = result_deposit_bob_to_bob.ciphertext_1
     ciphertext_bob_to_bob2 = result_deposit_bob_to_bob.ciphertext_2
 
@@ -169,8 +169,7 @@ def main() -> None:
     cm_address_bob_to_charlie2 = result_transfer_bob_to_charlie.cm_address_2
     new_merkle_root_bob_to_charlie = \
         result_transfer_bob_to_charlie.new_merkle_root
-    pk_sender_bob_to_charlie = \
-        result_transfer_bob_to_charlie.pk_sender
+    pk_sender_bob_to_charlie = result_transfer_bob_to_charlie.sender_k_pk
     ciphertext_bob_to_charlie1 = result_transfer_bob_to_charlie.ciphertext_1
     ciphertext_bob_to_charlie2 = result_transfer_bob_to_charlie.ciphertext_2
 

--- a/pyClient/test_commands/test_ether_mixing.py
+++ b/pyClient/test_commands/test_ether_mixing.py
@@ -53,16 +53,13 @@ def main() -> None:
     coinstore_dir = os.environ['ZETH_COINSTORE']
 
     # Keys and wallets
-    sk_alice = zeth.utils.get_private_key_from_bytes(
-        keystore["Alice"].addr_sk.enc_sk)
-    sk_bob = zeth.utils.get_private_key_from_bytes(
-        keystore["Bob"].addr_sk.enc_sk)
-    sk_charlie = zeth.utils.get_private_key_from_bytes(
-        keystore["Charlie"].addr_sk.enc_sk)
+    k_sk_alice = keystore["Alice"].addr_sk.k_sk
+    k_sk_bob = keystore["Bob"].addr_sk.k_sk
+    k_sk_charlie = keystore["Charlie"].addr_sk.k_sk
 
-    alice_wallet = Wallet("alice", coinstore_dir, sk_alice)
-    bob_wallet = Wallet("bob", coinstore_dir, sk_bob)
-    charlie_wallet = Wallet("charlie", coinstore_dir, sk_charlie)
+    alice_wallet = Wallet("alice", coinstore_dir, k_sk_alice)
+    bob_wallet = Wallet("bob", coinstore_dir, k_sk_bob)
+    charlie_wallet = Wallet("charlie", coinstore_dir, k_sk_charlie)
 
     print("[INFO] 1. Fetching the verification key from the proving server")
     vk = prover_client.get_verification_key()

--- a/pyClient/test_commands/test_ether_mixing.py
+++ b/pyClient/test_commands/test_ether_mixing.py
@@ -12,7 +12,6 @@ from zeth.wallet import Wallet
 
 import os
 from web3 import Web3, HTTPProvider  # type: ignore
-from typing import List, Any
 
 W3 = Web3(HTTPProvider(constants.WEB3_HTTP_PROVIDER))
 eth = W3.eth  # pylint: disable=no-member,invalid-name
@@ -25,14 +24,6 @@ def print_balances(bob: str, alice: str, charlie: str, mixer: str) -> None:
     print(f"  Bob     : {eth.getBalance(bob)}")
     print(f"  Charlie : {eth.getBalance(charlie)}")
     print(f"  Mixer   : {eth.getBalance(mixer)}")
-
-
-def get_merkle_tree(mixer_instance: Any) -> List[bytes]:
-    mk_byte_tree = mixer_instance.functions.getTree().call()
-    print("[DEBUG] Displaying the Merkle tree of commitments: ")
-    for node in mk_byte_tree:
-        print("Node: " + W3.toHex(node)[2:])
-    return mk_byte_tree
 
 
 def main() -> None:
@@ -133,7 +124,7 @@ def main() -> None:
     #
     # Bob looks in the merkle tree and gets the merkle path to the commitment
     # he wants to spend
-    mk_byte_tree = get_merkle_tree(mixer_instance)
+    mk_byte_tree = zeth.contracts.get_merkle_tree(mixer_instance)
     mk_path = zeth.utils.compute_merkle_path(
         cm_address_bob_to_bob1, mk_tree_depth, mk_byte_tree)
 
@@ -210,7 +201,7 @@ def main() -> None:
         f"Charlie decrypted {len(notes_charlie)}.  Expected 1!"
 
     # Charlie now gets the merkle path for the commitment he wants to spend
-    mk_byte_tree = get_merkle_tree(mixer_instance)
+    mk_byte_tree = zeth.contracts.get_merkle_tree(mixer_instance)
     mk_path = zeth.utils.compute_merkle_path(
         cm_address_bob_to_charlie2, mk_tree_depth, mk_byte_tree)
     (input_note_charlie_withdraw_addr, input_note_charlie_withdraw) = \
@@ -243,7 +234,7 @@ def main() -> None:
     try:
         # New commitments are added in the tree at each withdraw so we
         # recompiute the path to have the updated nodes
-        mk_byte_tree = get_merkle_tree(mixer_instance)
+        mk_byte_tree = zeth.contracts.get_merkle_tree(mixer_instance)
         mk_path = zeth.utils.compute_merkle_path(
             cm_address_bob_to_charlie2, mk_tree_depth, mk_byte_tree)
         result_double_spending = scenario.charlie_double_withdraw(

--- a/pyClient/test_commands/test_mimc_hash.py
+++ b/pyClient/test_commands/test_mimc_hash.py
@@ -94,8 +94,8 @@ def test_mimc() -> None:
     # MerkleTreeMiMCHash of depth 3 unit test
 
     # Recover root and merkle tree from the contract
-    tree = contracts.get_tree(tree_instance)
-    recovered_root = contracts.get_root(tree_instance)
+    tree = contracts.get_merkle_tree(tree_instance)
+    recovered_root = contracts.get_merkle_root(tree_instance)
 
     # Leaves
     for i in range(7, 15):

--- a/pyClient/zeth/contracts.py
+++ b/pyClient/zeth/contracts.py
@@ -1,10 +1,12 @@
 import zeth.constants as constants
 from zeth.zksnark import IZKSnarkProvider, GenericProof
-from zeth.utils import get_trusted_setup_dir, get_contracts_dir, hex_to_int
+from zeth.utils import get_trusted_setup_dir, get_contracts_dir, hex_to_int, \
+    get_public_key_from_bytes
 from zeth.joinsplit import SigningPublicKey
 
 import json
 import os
+from nacl.public import PublicKey  # type: ignore
 from web3 import Web3, HTTPProvider  # type: ignore
 from solcx import compile_files  # type: ignore
 from typing import Tuple, Dict, List, Any
@@ -25,7 +27,7 @@ class MixResult:
             cm_address_1: int,
             cm_address_2: int,
             new_merkle_root: str,
-            pk_sender: bytes,
+            pk_sender: PublicKey,
             ciphertext_1: bytes,
             ciphertext_2: bytes):
         self.cm_address_1 = cm_address_1
@@ -273,7 +275,8 @@ def parse_mix_call(
         cm_address_1=event_logs_log_address[0].args.commAddr,
         cm_address_2=event_logs_log_address[1].args.commAddr,
         new_merkle_root=new_merkle_root,
-        pk_sender=event_logs_log_secret_ciphers[0].args.pk_sender,
+        pk_sender=get_public_key_from_bytes(
+            event_logs_log_secret_ciphers[0].args.pk_sender),
         ciphertext_1=event_logs_log_secret_ciphers[0].args.ciphertext,
         ciphertext_2=event_logs_log_secret_ciphers[1].args.ciphertext)
 

--- a/pyClient/zeth/contracts.py
+++ b/pyClient/zeth/contracts.py
@@ -1,12 +1,10 @@
 import zeth.constants as constants
-import zeth.errors as errors
+from zeth.zksnark import IZKSnarkProvider, GenericProof
 from zeth.utils import get_trusted_setup_dir, get_contracts_dir, hex_to_int
-from zeth.joinsplit import GenericVerificationKey, GenericProof, \
-    JoinsplitPublicKey
+from zeth.joinsplit import JoinsplitPublicKey
 
 import json
 import os
-import sys
 from web3 import Web3, HTTPProvider  # type: ignore
 from solcx import compile_files  # type: ignore
 from typing import Tuple, Dict, List, Any
@@ -38,23 +36,10 @@ class MixResult:
         self.ciphertext_2 = ciphertext_2
 
 
-def get_zksnark_files(zksnark: str) -> Tuple[str, str]:
-    """
-    Returns the files to use for the given zkSNARK (verifier_contract,
-    mixer_contract)
-    """
-    if zksnark == constants.PGHR13_ZKSNARK:
-        return (
-            constants.PGHR13_VERIFIER_CONTRACT, constants.PGHR13_MIXER_CONTRACT)
-    if zksnark == constants.GROTH16_ZKSNARK:
-        return (
-            constants.GROTH16_VERIFIER_CONTRACT, constants.GROTH16_MIXER_CONTRACT)
-    return sys.exit(errors.SNARK_NOT_SUPPORTED)
-
-
-def compile_contracts(zksnark: str) -> Tuple[Interface, Interface, Interface]:
+def compile_contracts(
+        zksnark: IZKSnarkProvider) -> Tuple[Interface, Interface, Interface]:
     contracts_dir = get_contracts_dir()
-    (proof_verifier_name, mixer_name) = get_zksnark_files(zksnark)
+    (proof_verifier_name, mixer_name) = zksnark.get_contract_names()
     otsig_verifier_name = constants.SCHNORR_VERIFIER_CONTRACT
 
     path_to_proof_verifier = os.path.join(
@@ -86,37 +71,6 @@ def compile_util_contracts() -> Tuple[Interface, Interface]:
     mimc_interface = compiled_sol[path_to_mimc7 + ':' + "MiMC7"]
     tree_interface = compiled_sol[path_to_tree + ':' + "MerkleTreeMiMC7"]
     return mimc_interface, tree_interface
-
-
-def deploy_pghr13_verifier(
-        vk: Dict[str, Any],
-        verifier: Any,
-        deployer_address: str,
-        deployment_gas: int) -> str:
-    """
-    Deploy the verifier used with PGHR13
-    """
-    # Deploy the verifier contract with the good verification key
-    tx_hash = verifier.constructor(
-        A1=hex_to_int(vk["a"][0]),
-        A2=hex_to_int(vk["a"][1]),
-        B=hex_to_int(vk["b"]),
-        C1=hex_to_int(vk["c"][0]),
-        C2=hex_to_int(vk["c"][1]),
-        gamma1=hex_to_int(vk["g"][0]),
-        gamma2=hex_to_int(vk["g"][1]),
-        gammaBeta1=hex_to_int(vk["gb1"]),
-        gammaBeta2_1=hex_to_int(vk["gb2"][0]),
-        gammaBeta2_2=hex_to_int(vk["gb2"][1]),
-        Z1=hex_to_int(vk["z"][0]),
-        Z2=hex_to_int(vk["z"][1]),
-        IC_coefficients=hex_to_int(sum(vk["IC"], []))
-    ).transact({'from': deployer_address, 'gas': deployment_gas})
-
-    # Get tx receipt to get Verifier contract address
-    tx_receipt = eth.waitForTransactionReceipt(tx_hash, 10000)
-    verifier_address = tx_receipt['contractAddress']
-    return verifier_address
 
 
 def deploy_mixer(
@@ -159,30 +113,6 @@ def deploy_mixer(
     return(mixer, initial_root[2:])
 
 
-def deploy_groth16_verifier(
-        vk: GenericVerificationKey,
-        verifier: Any,
-        deployer_address: str,
-        deployment_gas: int) -> str:
-    """
-    Deploy the verifier and the mixer used with GROTH16
-    """
-    # Deploy the verifier contract with the good verification key
-    tx_hash = verifier.constructor(
-        Alpha=hex_to_int(vk["alpha_g1"]),
-        Beta1=hex_to_int(vk["beta_g2"][0]),
-        Beta2=hex_to_int(vk["beta_g2"][1]),
-        Delta1=hex_to_int(vk["delta_g2"][0]),
-        Delta2=hex_to_int(vk["delta_g2"][1]),
-        ABC_coords=hex_to_int(sum(vk["abc_g1"], []))
-    ).transact({'from': deployer_address, 'gas': deployment_gas})
-
-    # Get tx receipt to get Verifier contract address
-    tx_receipt = eth.waitForTransactionReceipt(tx_hash, 10000)
-    verifier_address = tx_receipt['contractAddress']
-    return verifier_address
-
-
 def deploy_otschnorr_contracts(
         verifier: Any,
         deployer_address: str,
@@ -209,7 +139,7 @@ def deploy_contracts(
         deployer_address: str,
         deployment_gas: int,
         token_address: str,
-        zksnark: str) -> Tuple[Any, str]:
+        zksnark: IZKSnarkProvider) -> Tuple[Any, str]:
     """
     Deploy the mixer contract with the given merkle tree depth and returns an
     instance of the mixer along with the initial merkle tree root to use for
@@ -225,15 +155,12 @@ def deploy_contracts(
         abi=proof_verifier_interface['abi'],
         bytecode=proof_verifier_interface['bin']
     )
-    proof_verifier_address = ""
-    if zksnark == constants.PGHR13_ZKSNARK:
-        proof_verifier_address = deploy_pghr13_verifier(
-            vk, proof_verifier, deployer_address, deployment_gas)
-    elif zksnark == constants.GROTH16_ZKSNARK:
-        proof_verifier_address = deploy_groth16_verifier(
-                vk, proof_verifier, deployer_address, deployment_gas)
-    else:
-        return sys.exit(errors.SNARK_NOT_SUPPORTED)
+
+    verifier_constr_params = zksnark.verifier_constructor_parameters(vk)
+    tx_hash = proof_verifier.constructor(**verifier_constr_params) \
+        .transact({'from': deployer_address, 'gas': deployment_gas})
+    tx_receipt = eth.waitForTransactionReceipt(tx_hash, 10000)
+    proof_verifier_address = tx_receipt['contractAddress']
 
     # Deploy MiMC contract
     _, hasher_address = deploy_mimc_contract(hasher_interface)  # type: ignore
@@ -295,70 +222,6 @@ def deploy_tree_contract(
     return instance
 
 
-def mix_pghr13(
-        mixer_instance: Any,
-        pk_sender: bytes,
-        ciphertext1: bytes,
-        ciphertext2: bytes,
-        parsed_proof: GenericProof,
-        vk: JoinsplitPublicKey,
-        sigma: int,
-        sender_address: str,
-        wei_pub_value: int,
-        call_gas: int) -> MixResult:
-    """
-    Call to the mixer's mix function to do zero knowledge payments
-    """
-    tx_hash = mixer_instance.functions.mix(
-        hex_to_int(parsed_proof["a"]),
-        hex_to_int(parsed_proof["a_p"]),
-        [hex_to_int(parsed_proof["b"][0]),
-         hex_to_int(parsed_proof["b"][1])],
-        hex_to_int(parsed_proof["b_p"]),
-        hex_to_int(parsed_proof["c"]),
-        hex_to_int(parsed_proof["c_p"]),
-        hex_to_int(parsed_proof["h"]),
-        hex_to_int(parsed_proof["k"]),
-        [[int(vk[0][0]), int(vk[0][1])], [int(vk[1][0]), int(vk[1][1])]],
-        int(sigma),
-        hex_to_int(parsed_proof["inputs"]),
-        pk_sender,
-        ciphertext1,
-        ciphertext2,
-    ).transact({'from': sender_address, 'value': wei_pub_value, 'gas': call_gas})
-
-    tx_receipt = eth.waitForTransactionReceipt(tx_hash, 10000)
-    return parse_mix_call(mixer_instance, tx_receipt)
-
-
-def mix_groth16(
-        mixer_instance: Any,
-        pk_sender: bytes,
-        ciphertext1: bytes,
-        ciphertext2: bytes,
-        parsed_proof: GenericProof,
-        vk: JoinsplitPublicKey,
-        sigma: int,
-        sender_address: str,
-        wei_pub_value: int,
-        call_gas: int) -> MixResult:
-    tx_hash = mixer_instance.functions.mix(
-        hex_to_int(parsed_proof["a"]),
-        [hex_to_int(parsed_proof["b"][0]),
-         hex_to_int(parsed_proof["b"][1])],
-        hex_to_int(parsed_proof["c"]),
-        [[int(vk[0][0]), int(vk[0][1])], [int(vk[1][0]), int(vk[1][1])]],
-        int(sigma),
-        hex_to_int(parsed_proof["inputs"]),
-        pk_sender,
-        ciphertext1,
-        ciphertext2,
-    ).transact({'from': sender_address, 'value': wei_pub_value, 'gas': call_gas})
-
-    tx_receipt = eth.waitForTransactionReceipt(tx_hash, 10000)
-    return parse_mix_call(mixer_instance, tx_receipt)
-
-
 def mix(
         mixer_instance: Any,
         pk_sender: bytes,
@@ -370,34 +233,19 @@ def mix(
         sender_address: str,
         wei_pub_value: int,
         call_gas: int,
-        zksnark: str) -> MixResult:
-    if zksnark == constants.PGHR13_ZKSNARK:
-        return mix_pghr13(
-            mixer_instance,
-            pk_sender,
-            ciphertext1,
-            ciphertext2,
-            parsed_proof,
-            vk,
-            sigma,
-            sender_address,
-            wei_pub_value,
-            call_gas
-        )
-    if zksnark == constants.GROTH16_ZKSNARK:
-        return mix_groth16(
-            mixer_instance,
-            pk_sender,
-            ciphertext1,
-            ciphertext2,
-            parsed_proof,
-            vk,
-            sigma,
-            sender_address,
-            wei_pub_value,
-            call_gas
-        )
-    return sys.exit(errors.SNARK_NOT_SUPPORTED)
+        zksnark: IZKSnarkProvider) -> MixResult:
+    proof_params = zksnark.mixer_proof_parameters(parsed_proof)
+    tx_hash = mixer_instance.functions.mix(
+        *proof_params,
+        [[int(vk[0][0]), int(vk[0][1])], [int(vk[1][0]), int(vk[1][1])]],
+        int(sigma),
+        hex_to_int(parsed_proof["inputs"]),
+        pk_sender,
+        ciphertext1,
+        ciphertext2,
+    ).transact({'from': sender_address, 'value': wei_pub_value, 'gas': call_gas})
+    tx_receipt = eth.waitForTransactionReceipt(tx_hash, 10000)
+    return parse_mix_call(mixer_instance, tx_receipt)
 
 
 def parse_mix_call(

--- a/pyClient/zeth/contracts.py
+++ b/pyClient/zeth/contracts.py
@@ -292,15 +292,15 @@ def mimc_hash(instance: Any, m: bytes, k: bytes, seed: bytes) -> bytes:
     return instance.functions.hash(m, k, seed).call()
 
 
-def get_tree(instance: Any) -> List[bytes]:
+def get_merkle_tree(mixer_instance: Any) -> List[bytes]:
     """
     Return the Merkle tree
     """
-    return instance.functions.getTree().call()
+    return mixer_instance.functions.getTree().call()
 
 
-def get_root(instance: Any) -> bytes:
+def get_merkle_root(mixer_instance: Any) -> bytes:
     """
     Return the Merkle tree root
     """
-    return instance.functions.getRoot().call()
+    return mixer_instance.functions.getRoot().call()

--- a/pyClient/zeth/contracts.py
+++ b/pyClient/zeth/contracts.py
@@ -1,13 +1,13 @@
 import zeth.constants as constants
+from zeth.encryption import EncryptionPublicKey, encode_encryption_public_key
+from zeth.signing import SigningPublicKey
 from zeth.zksnark import IZKSnarkProvider, GenericProof
 from zeth.utils import get_trusted_setup_dir, get_contracts_dir, hex_to_int, \
     get_public_key_from_bytes
-from zeth.joinsplit import SigningPublicKey, EncryptionPublicKey
 
 import json
 import os
 from web3 import Web3, HTTPProvider  # type: ignore
-import nacl.encoding  # type: ignore
 from solcx import compile_files  # type: ignore
 from typing import Tuple, Dict, List, Any
 
@@ -25,19 +25,11 @@ class MixResult:
     def __init__(
             self,
             encrypted_notes: List[Tuple[int, bytes]],
-            # cm_address_1: int,
-            # cm_address_2: int,
             new_merkle_root: str,
             sender_k_pk: EncryptionPublicKey):
-        # ciphertext_1: bytes,
-        # ciphertext_2: bytes):
         self.encrypted_notes = encrypted_notes
-        # self.cm_address_1 = cm_address_1
-        # self.cm_address_2 = cm_address_2
         self.new_merkle_root = new_merkle_root
         self.sender_k_pk = sender_k_pk
-        # self.ciphertext_1 = ciphertext_1
-        # self.ciphertext_2 = ciphertext_2
 
 
 def compile_contracts(
@@ -241,7 +233,7 @@ def mix(
     """
     Run the mixer
     """
-    pk_sender_encoded = pk_sender.encode(encoder=nacl.encoding.RawEncoder)
+    pk_sender_encoded = encode_encryption_public_key(pk_sender)
     proof_params = zksnark.mixer_proof_parameters(parsed_proof)
     tx_hash = mixer_instance.functions.mix(
         *proof_params,

--- a/pyClient/zeth/contracts.py
+++ b/pyClient/zeth/contracts.py
@@ -1,7 +1,7 @@
 import zeth.constants as constants
 from zeth.zksnark import IZKSnarkProvider, GenericProof
 from zeth.utils import get_trusted_setup_dir, get_contracts_dir, hex_to_int
-from zeth.joinsplit import JoinsplitPublicKey
+from zeth.joinsplit import SigningPublicKey
 
 import json
 import os
@@ -228,7 +228,7 @@ def mix(
         ciphertext1: bytes,
         ciphertext2: bytes,
         parsed_proof: GenericProof,
-        vk: JoinsplitPublicKey,
+        vk: SigningPublicKey,
         sigma: int,
         sender_address: str,
         wei_pub_value: int,

--- a/pyClient/zeth/encryption.py
+++ b/pyClient/zeth/encryption.py
@@ -1,0 +1,41 @@
+from nacl.public import PrivateKey  # type: ignore
+import nacl.encoding  # type: ignore
+from typing import NewType
+
+# Thin wrapper around the nacl PublicKey and PrivateKey.  Note nacl doesn't
+# include much type information, so we try to enforce strict types.
+
+
+# Represents a PublicKey from
+EncryptionSecretKey = NewType('EncryptionSecretKey', object)
+
+
+# EncryptionPublicKey = PublicKey
+EncryptionPublicKey = NewType('EncryptionPublicKey', object)
+
+
+class EncryptionKeyPair:
+    """
+    Key-pair for encrypting joinsplit notes.
+    """
+    def __init__(self, k_sk: EncryptionSecretKey, k_pk: EncryptionPublicKey):
+        self.k_pk: EncryptionPublicKey = k_pk
+        self.k_sk: EncryptionSecretKey = k_sk
+
+
+def encode_encryption_public_key(pk: EncryptionPublicKey) -> bytes:
+    return pk.encode(encoder=nacl.encoding.RawEncoder)  # type: ignore
+
+
+def get_encryption_public_key(
+        enc_secret: EncryptionSecretKey) -> EncryptionPublicKey:
+    return enc_secret.public_key  # type: ignore
+
+
+def generate_encryption_secret_key() -> EncryptionSecretKey:
+    return PrivateKey.generate()  # type: ignore
+
+
+def generate_encryption_keypair() -> EncryptionKeyPair:
+    sk = generate_encryption_secret_key()
+    return EncryptionKeyPair(sk, get_encryption_public_key(sk))

--- a/pyClient/zeth/joinsplit.py
+++ b/pyClient/zeth/joinsplit.py
@@ -474,11 +474,9 @@ def get_dummy_input_and_address(
 
 def compute_joinsplit2x2_inputs(
         mk_root: str,
-        input_note0: ZethNote,
-        input_address0: int,
+        input0: Tuple[int, ZethNote],
         mk_path0: List[str],
-        input_note1: ZethNote,
-        input_address1: int,
+        input1: Tuple[int, ZethNote],
         mk_path1: List[str],
         sender_ask: OwnershipSecretKey,
         recipient0_apk: OwnershipPublicKey,
@@ -491,9 +489,12 @@ def compute_joinsplit2x2_inputs(
     """
     Create a ProofInput object for joinsplit parameters
     """
+    (input_address0, input_note0) = input0
+    (input_address1, input_note1) = input1
+
     input_nullifier0 = compute_nullifier(input_note0, sender_ask)
     input_nullifier1 = compute_nullifier(input_note1, sender_ask)
-    js_inputs = [
+    js_inputs: List[JoinsplitInput] = [
         create_joinsplit_input(
             mk_path0, input_address0, input_note0, sender_ask, input_nullifier0),
         create_joinsplit_input(
@@ -535,11 +536,9 @@ def compute_joinsplit2x2_inputs(
 def get_proof_joinsplit_2_by_2(
         prover_client: ProverClient,
         mk_root: str,
-        input_note0: ZethNote,
-        input_address0: int,
+        input0: Tuple[int, ZethNote],
         mk_path0: List[str],
-        input_note1: ZethNote,
-        input_address1: int,
+        input1: Tuple[int, ZethNote],
         mk_path1: List[str],
         sender_ask: OwnershipSecretKey,
         recipient0_apk: OwnershipPublicKey,
@@ -557,11 +556,9 @@ def get_proof_joinsplit_2_by_2(
     signing_keypair = _gen_signing_keypair()
     proof_input = compute_joinsplit2x2_inputs(
         mk_root,
-        input_note0,
-        input_address0,
+        input0,
         mk_path0,
-        input_note1,
-        input_address1,
+        input1,
         mk_path1,
         sender_ask,
         recipient0_apk,

--- a/pyClient/zeth/joinsplit.py
+++ b/pyClient/zeth/joinsplit.py
@@ -17,6 +17,9 @@ from py_ecc import bn128 as ec
 from typing import Tuple, Dict, List, Iterable, Union, Any, NewType
 
 
+ZERO_UNITS_HEX = "0000000000000000"
+
+
 FQ = ec.FQ
 G1 = Tuple[ec.FQ, ec.FQ]
 
@@ -448,6 +451,25 @@ def write_verification_key(
     filename = os.path.join(setup_dir, "vk.json")
     with open(filename, 'w') as outfile:
         json.dump(vk_json, outfile)
+
+
+def get_dummy_rho() -> str:
+    return bytes(Random.get_random_bytes(32)).hex()
+
+
+def get_dummy_input_and_address(
+        a_pk: OwnershipPublicKey) -> Tuple[int, ZethNote]:
+    """
+    Create a zeth note and address, for use as circuit inputs where there is no
+    real input.
+    """
+    dummy_note = ZethNote(
+        apk=ownership_key_as_hex(a_pk),
+        value=ZERO_UNITS_HEX,
+        rho=get_dummy_rho(),
+        trap_r=trap_r_randomness())
+    dummy_note_address = 7
+    return (dummy_note_address, dummy_note)
 
 
 def compute_joinsplit2x2_inputs(

--- a/pyClient/zeth/joinsplit.py
+++ b/pyClient/zeth/joinsplit.py
@@ -23,53 +23,63 @@ FQ = ec.FQ
 G1 = Tuple[ec.FQ, ec.FQ]
 
 
+# Secret key for signing joinsplit data
 SigningSecretKey = NewType('SigningSecretKey', Tuple[FQ, FQ])
 
 
+# Public key for signing joinsplit data
 SigningPublicKey = NewType('SigningPublicKey', Tuple[G1, G1])
 
 
 class SigningKeyPair:
     """
-    Key-pair used for signing transaction data.
+    Key-pair for signing joinsplit data.
     """
     def __init__(self, sk: SigningSecretKey, pk: SigningPublicKey):
         self.sk: SigningSecretKey = sk
         self.pk: SigningPublicKey = pk
 
 
-def ownership_key_as_hex(a_sk: bytes) -> str:
-    return hex_extend_32bytes(a_sk.hex())
-
-
+# Secret key for proving ownership
 OwnershipSecretKey = NewType('OwnershipSecretKey', bytes)
 
 
+# Public key for proving owenership
 OwnershipPublicKey = NewType('OwnershipPublicKey', bytes)
 
 
 class OwnershipKeyPair:
+    """
+    Key-pair for ownership proof
+    """
     def __init__(self, a_sk: OwnershipSecretKey, a_pk: OwnershipPublicKey):
         self.a_pk: OwnershipPublicKey = a_pk
         self.a_sk: OwnershipSecretKey = a_sk
 
 
+def ownership_key_as_hex(a_sk: bytes) -> str:
+    """
+    Convert either a secret or public ownership key to hex representation of the
+    underlying 32-byte object.
+    """
+    return hex_extend_32bytes(a_sk.hex())
+
+
 class EncryptionKeyPair:
+    """
+    Key-pair for encrypting joinsplit notes.
+    """
     def __init__(self, k_sk: PrivateKey, k_pk: PublicKey):
         self.k_pk: PublicKey = k_pk
         self.k_sk: PrivateKey = k_sk
 
 
-# # Joinsplit Secret Key
-# JoinsplitSecretKey = Tuple[FQ, FQ]
-
-
 class ZethAddressPub:
     """
-    Public addr_pk, consisting of a_pk and k_pk
+    Public half of a zethAddress.  addr_pk = (a_pk and k_pk)
     """
-    def __init__(self, a_pk: bytes, k_pk: PublicKey):
-        self.a_pk: bytes = a_pk
+    def __init__(self, a_pk: OwnershipPublicKey, k_pk: PublicKey):
+        self.a_pk: OwnershipPublicKey = a_pk
         self.k_pk: PublicKey = k_pk
 
 
@@ -77,8 +87,8 @@ class ZethAddressPriv:
     """
     Secret addr_sk, consisting of a_sk and k_sk
     """
-    def __init__(self, a_sk: bytes, k_sk: PrivateKey):
-        self.a_sk: bytes = a_sk
+    def __init__(self, a_sk: OwnershipSecretKey, k_sk: PrivateKey):
+        self.a_sk: OwnershipSecretKey = a_sk
         self.k_sk: PrivateKey = k_sk
 
 
@@ -88,7 +98,11 @@ class ZethAddress:
     "zethAddress" in the paper).
     """
     def __init__(
-            self, a_pk: bytes, k_pk: PublicKey, a_sk: bytes, k_sk: PrivateKey):
+            self,
+            a_pk: OwnershipPublicKey,
+            k_pk: PublicKey,
+            a_sk: OwnershipSecretKey,
+            k_sk: PrivateKey):
         self.addr_pk = ZethAddressPub(a_pk, k_pk)
         self.addr_sk = ZethAddressPriv(a_sk, k_sk)
 

--- a/pyClient/zeth/ownership.py
+++ b/pyClient/zeth/ownership.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from zeth.utils import hex_extend_32bytes, digest_to_binary_string, encode_abi
+
+from Crypto import Random
+from hashlib import blake2s
+from typing import NewType
+
+
+# Secret key for proving ownership
+OwnershipSecretKey = NewType('OwnershipSecretKey', bytes)
+
+
+# Public key for proving owenership
+OwnershipPublicKey = NewType('OwnershipPublicKey', bytes)
+
+
+class OwnershipKeyPair:
+    """
+    Key-pair for ownership proof
+    """
+    def __init__(self, a_sk: OwnershipSecretKey, a_pk: OwnershipPublicKey):
+        self.a_sk: OwnershipSecretKey = a_sk
+        self.a_pk: OwnershipPublicKey = a_pk
+
+
+def ownership_key_as_hex(a_sk: bytes) -> str:
+    """
+    Convert either a secret or public ownership key to hex representation of the
+    underlying 32-byte object.
+    """
+    return hex_extend_32bytes(a_sk.hex())
+
+
+def gen_ownership_keypair() -> OwnershipKeyPair:
+    a_sk = OwnershipSecretKey(Random.get_random_bytes(32))
+    a_pk = _derive_a_pk(a_sk)
+    keypair = OwnershipKeyPair(a_sk, a_pk)
+    return keypair
+
+
+def _derive_a_pk(a_sk: OwnershipSecretKey) -> OwnershipPublicKey:
+    """
+    Returns a_pk = blake2s(1100 || [a_sk]_252 || 0^256)
+    """
+    binary_a_sk = digest_to_binary_string(a_sk)
+    first_252bits_ask = binary_a_sk[:252]
+    left_leg_bin = "1100" + first_252bits_ask
+    left_leg_hex = "{0:0>4X}".format(int(left_leg_bin, 2))
+    zeroes = "0000000000000000000000000000000000000000000000000000000000000000"
+    a_pk = blake2s(
+        encode_abi(
+            ["bytes32", "bytes32"],
+            [bytes.fromhex(left_leg_hex), bytes.fromhex(zeroes)])
+    ).digest()
+    return OwnershipPublicKey(a_pk)

--- a/pyClient/zeth/signing.py
+++ b/pyClient/zeth/signing.py
@@ -1,0 +1,39 @@
+"""
+Types and basic operations for signing joinsplit data.
+"""
+
+import zeth.constants as constants
+from py_ecc import bn128 as ec
+from Crypto import Random
+from typing import Tuple, NewType
+
+
+FQ = ec.FQ
+G1 = Tuple[ec.FQ, ec.FQ]
+
+
+# Secret key for signing joinsplit data
+SigningSecretKey = NewType('SigningSecretKey', Tuple[FQ, FQ])
+
+
+# Public key for signing joinsplit data
+SigningPublicKey = NewType('SigningPublicKey', Tuple[G1, G1])
+
+
+class SigningKeyPair:
+    """
+    Key-pair for signing joinsplit data.
+    """
+    def __init__(self, sk: SigningSecretKey, pk: SigningPublicKey):
+        self.sk: SigningSecretKey = sk
+        self.pk: SigningPublicKey = pk
+
+
+def gen_signing_keypair() -> SigningKeyPair:
+    x = FQ(
+        int(bytes(Random.get_random_bytes(32)).hex(), 16) % constants.ZETH_PRIME)
+    X = ec.multiply(ec.G1, x.n)
+    y = FQ(
+        int(bytes(Random.get_random_bytes(32)).hex(), 16) % constants.ZETH_PRIME)
+    Y = ec.multiply(ec.G1, y.n)
+    return SigningKeyPair(SigningSecretKey((x, y)), SigningPublicKey((X, Y)))

--- a/pyClient/zeth/utils.py
+++ b/pyClient/zeth/utils.py
@@ -177,7 +177,7 @@ def parse_zksnark_arg() -> str:
     return args.zksnark
 
 
-def to_zeth_units(value: str, unit: str) -> int:
+def to_zeth_units(value: Union[str, int], unit: str) -> int:
     return int(Web3.toWei(value, unit) / ZETH_PUBLIC_UNIT_VALUE)
 
 

--- a/pyClient/zeth/utils.py
+++ b/pyClient/zeth/utils.py
@@ -177,7 +177,7 @@ def parse_zksnark_arg() -> str:
     return args.zksnark
 
 
-def to_zeth_units(value: Union[str, int], unit: str) -> int:
+def to_zeth_units(value: Union[str, int, float], unit: str) -> int:
     return int(Web3.toWei(value, unit) / ZETH_PUBLIC_UNIT_VALUE)
 
 

--- a/pyClient/zeth/utils.py
+++ b/pyClient/zeth/utils.py
@@ -45,6 +45,10 @@ def hex_digest_to_binary_string(digest: str) -> str:
     return "".join(["{0:04b}".format(int(c, 16)) for c in digest])
 
 
+def digest_to_binary_string(digest: bytes) -> str:
+    return "".join(["{0:08b}".format(b) for b in digest])
+
+
 def hex_to_int(elements: List[str]) -> List[int]:
     """
     Given an array of hex strings, return an array of int values

--- a/pyClient/zeth/utils.py
+++ b/pyClient/zeth/utils.py
@@ -216,9 +216,8 @@ def string_list_flatten(
     return cast(List[str], strs_list)
 
 
-def encode_to_hash(message_list: Any) -> bytes:
+def encode_message_to_bytes(message_list: Any) -> bytes:
     # message_list: Union[List[str], List[Union[int, str, List[str]]]]) -> bytes:
-
     """
     Encode a list of variables, or list of lists of variables into a byte
     vector
@@ -226,7 +225,7 @@ def encode_to_hash(message_list: Any) -> bytes:
 
     messages = string_list_flatten(message_list)
 
-    input_sha = bytearray()
+    data_bytes = bytearray()
     for m in messages:
         # For each element
         m_hex = m
@@ -241,6 +240,6 @@ def encode_to_hash(message_list: Any) -> bytes:
         m_hex = hex_extend_32bytes(m_hex)
 
         # Encode the hex into a byte array and append it to result
-        input_sha += encode_single("bytes32", bytes.fromhex(m_hex))
+        data_bytes += encode_single("bytes32", bytes.fromhex(m_hex))
 
-    return input_sha
+    return data_bytes

--- a/pyClient/zeth/utils.py
+++ b/pyClient/zeth/utils.py
@@ -14,11 +14,19 @@ from nacl.public import PrivateKey, PublicKey, Box  # type: ignore
 from web3 import Web3, HTTPProvider  # type: ignore
 from typing import List, Union, Any, cast
 
-# Value of a single unit (in Wei) of vpub_in and vpub_out.  Use Szabos (10^12
-# Wei).
-ZETH_PUBLIC_UNIT_VALUE = 1000000000000
-
 W3 = Web3(HTTPProvider(constants.WEB3_HTTP_PROVIDER))
+
+
+class EtherValue:
+    """
+    Representation of some amount of Ether (or any token) in terms of Wei.
+    Disambiguates Ether values from other units such as zeth_units.
+    """
+    def __init__(self, val: Union[str, int, float], units: str = 'ether'):
+        self.wei = W3.toWei(val, units)
+
+    def __str__(self) -> str:
+        return str(self.wei)
 
 
 def encode_single(type_name: str, data: bytes) -> bytes:
@@ -175,10 +183,6 @@ def parse_zksnark_arg() -> str:
     if args.zksnark not in constants.VALID_ZKSNARKS:
         return sys.exit(errors.SNARK_NOT_SUPPORTED)
     return args.zksnark
-
-
-def to_zeth_units(value: Union[str, int, float], unit: str) -> int:
-    return int(Web3.toWei(value, unit) / ZETH_PUBLIC_UNIT_VALUE)
 
 
 def get_zeth_dir() -> str:

--- a/pyClient/zeth/utils.py
+++ b/pyClient/zeth/utils.py
@@ -48,12 +48,9 @@ def hex_digest_to_binary_string(digest: str) -> str:
 
 def hex_to_int(elements: List[str]) -> List[int]:
     """
-    Given an error of hex strings, return an array of int values
+    Given an array of hex strings, return an array of int values
     """
-    ints = []
-    for el in elements:
-        ints.append(int(el, 16))
-    return ints
+    return [int(x, 16) for x in elements]
 
 
 def hex_extend_32bytes(element: str) -> str:

--- a/pyClient/zeth/utils.py
+++ b/pyClient/zeth/utils.py
@@ -40,10 +40,9 @@ def int64_to_hex(number: int) -> str:
 
 
 def hex_digest_to_binary_string(digest: str) -> str:
-    padded = "0" + digest
-    digest_bits = ["{0:04b}".format(int(c, 16)) for c in reversed(padded)]
-    zipped = zip(*[digest_bits[n::2] for n in [1, 0]])
-    return "".join(reversed([i+j for i, j in zipped]))
+    if len(digest) % 2 == 1:
+        digest = "0" + digest
+    return "".join(["{0:04b}".format(int(c, 16)) for c in digest])
 
 
 def hex_to_int(elements: List[str]) -> List[int]:

--- a/pyClient/zeth/utils.py
+++ b/pyClient/zeth/utils.py
@@ -247,3 +247,33 @@ def encode_message_to_bytes(message_list: Any) -> bytes:
         data_bytes += encode_single("bytes32", bytes.fromhex(m_hex))
 
     return data_bytes
+
+
+def field_elements_to_hex(longfield: str, shortfield: str) -> str:
+    """
+    Encode a 256 bit array written over two field elements into a single 32
+    byte long hex
+
+    if A= x0 ... x255 and B = y0 ... y7, returns R = hex(x255 ... x3 || y7 y6 y5)
+    """
+    # Convert longfield into a 253 bit long array
+    long_bit = "{0:b}".format(int(longfield, 16))
+    if len(long_bit) > 253:
+        long_bit = long_bit[:253]
+    long_bit = "0"*(253-len(long_bit)) + long_bit
+
+    # Convert shortfield into a 3 bit long array
+    short_bit = "{0:b}".format(int(shortfield, 16))
+    if len(short_bit) < 3:
+        short_bit = "0"*(3-len(short_bit)) + short_bit
+
+    # Reverse the bit arrays
+    reversed_long = long_bit[::-1]
+    reversed_short = short_bit[::-1]
+
+    # Fill the result 256 bit long array
+    res = reversed_long[:253]
+    res += reversed_short[:3]
+    res = hex_extend_32bytes("{0:0>4X}".format(int(res, 2)))
+
+    return res

--- a/pyClient/zeth/wallet.py
+++ b/pyClient/zeth/wallet.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 import zeth.joinsplit as joinsplit
 from api.util_pb2 import ZethNote
-from nacl.public import PrivateKey  # type: ignore
+from nacl.public import PrivateKey, PublicKey  # type: ignore
 from nacl import encoding  # type: ignore
 from os.path import join
-from typing import List
+from typing import List, Tuple
 import time
 import json
 
@@ -19,15 +19,16 @@ class Wallet:
 
     def receive_notes(
             self,
-            ciphertexts: List[bytes],
-            k_pk_sender_bytes: bytes) -> List[ZethNote]:
+            addrs_and_ciphertexts: List[Tuple[int, bytes]],
+            k_pk_sender: PublicKey) -> List[Tuple[int, ZethNote]]:
         new_notes_iter = joinsplit.receive_notes(
-            ciphertexts, k_pk_sender_bytes, self.k_sk_receiver)
+            addrs_and_ciphertexts, k_pk_sender, self.k_sk_receiver)
         new_notes = []
-        for note in new_notes_iter:
-            print(f"[INFO] {self.username} received payment: {note}")
+        for addr, note in new_notes_iter:
+            print(
+                f"[INFO] {self.username} received payment: {note} (addr: {addr})")
             self._write_note(note)
-            new_notes.append(note)
+            new_notes.append((addr, note))
         return new_notes
 
     def _write_note(self, note: ZethNote) -> None:

--- a/pyClient/zeth/wallet.py
+++ b/pyClient/zeth/wallet.py
@@ -10,18 +10,19 @@ import json
 
 
 class Wallet:
-    def __init__(self, username: str, wallet_dir: str, sk_receiver: PrivateKey):
+    def __init__(self, username: str, wallet_dir: str, k_sk_receiver: PrivateKey):
         self.username = username
         self.wallet_dir = wallet_dir
-        self.sk_receiver = sk_receiver
-        self.sk_receiver_enc = sk_receiver.encode(encoder=encoding.RawEncoder)
+        self.k_sk_receiver = k_sk_receiver
+        self.k_sk_receiver_bytes = \
+            k_sk_receiver.encode(encoder=encoding.RawEncoder)
 
     def receive_notes(
             self,
             ciphertexts: List[bytes],
-            pk_sender_enc: bytes) -> List[ZethNote]:
+            k_pk_sender_bytes: bytes) -> List[ZethNote]:
         new_notes_iter = joinsplit.receive_notes(
-            ciphertexts, pk_sender_enc, self.sk_receiver)
+            ciphertexts, k_pk_sender_bytes, self.k_sk_receiver)
         new_notes = []
         for note in new_notes_iter:
             print(f"[INFO] {self.username} received payment: {note}")

--- a/pyClient/zeth/zksnark.py
+++ b/pyClient/zeth/zksnark.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+
+"""
+zk-SNARK abstraction
+"""
+
+from zeth.utils import hex_to_int
+import zeth.constants as constants
+from api.prover_pb2 import VerificationKey, ExtendedProof
+from api.util_pb2 import HexPointBaseGroup1Affine, HexPointBaseGroup2Affine
+
+import json
+from abc import (ABC, abstractmethod)
+from typing import Dict, List, Tuple, Any
+# pylint: disable=unnecessary-pass
+
+# Dictionary representing a VerificationKey from any supported snark
+GenericVerificationKey = Dict[str, Any]
+
+# Dictionary representing a Proof from any supported snark
+GenericProof = Dict[str, Any]
+
+
+class IZKSnarkProvider(ABC):
+    """
+    Interface to be implemented by specific zk-snark providers. Ideally, the
+    rest of the logic should deal only with this interface and have no
+    understanding of the underlying mechanisms.
+    """
+
+    @staticmethod
+    @abstractmethod
+    def get_contract_names() -> Tuple[str, str]:
+        """
+        Get the verifier and mixer contracts for this SNARK.
+        """
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def verifier_constructor_parameters(
+            vk: GenericVerificationKey) -> Dict[str, List[int]]:
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def parse_verification_key(
+            vk_obj: VerificationKey) -> GenericVerificationKey:
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def parse_proof(proof_obj: ExtendedProof) -> GenericProof:
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def mixer_proof_parameters(parsed_proof: GenericProof) -> List[List[int]]:
+        """
+        Generate the leading parameters to the mix function for this SNARK, from a
+        GenericProof object.
+        """
+        pass
+
+
+class Groth16SnarkProvider(IZKSnarkProvider):
+
+    @staticmethod
+    def get_contract_names() -> Tuple[str, str]:
+        return (
+            constants.GROTH16_VERIFIER_CONTRACT, constants.GROTH16_MIXER_CONTRACT)
+
+    @staticmethod
+    def verifier_constructor_parameters(
+            vk: GenericVerificationKey) -> Dict[str, List[int]]:
+        return {
+            "Alpha": hex_to_int(vk["alpha_g1"]),
+            "Beta1": hex_to_int(vk["beta_g2"][0]),
+            "Beta2": hex_to_int(vk["beta_g2"][1]),
+            "Delta1": hex_to_int(vk["delta_g2"][0]),
+            "Delta2": hex_to_int(vk["delta_g2"][1]),
+            "ABC_coords": hex_to_int(sum(vk["abc_g1"], [])),
+        }
+
+    @staticmethod
+    def parse_verification_key(
+            vk_obj: VerificationKey) -> GenericVerificationKey:
+        vk = vk_obj.groth16_verification_key
+        return {
+            "alpha_g1": _parse_hex_point_base_group1_affine(vk.alpha_g1),
+            "beta_g2": _parse_hex_point_base_group2_affine(vk.beta_g2),
+            "delta_g2": _parse_hex_point_base_group2_affine(vk.delta_g2),
+            "abc_g1": json.loads(vk.abc_g1),
+        }
+
+    @staticmethod
+    def parse_proof(proof_obj: ExtendedProof) -> GenericProof:
+        proof = proof_obj.groth16_extended_proof
+        return {
+            "a": _parse_hex_point_base_group1_affine(proof.a),
+            "b": _parse_hex_point_base_group2_affine(proof.b),
+            "c": _parse_hex_point_base_group1_affine(proof.c),
+            "inputs": json.loads(proof.inputs),
+        }
+
+    @staticmethod
+    def mixer_proof_parameters(parsed_proof: GenericProof) -> List[List[Any]]:
+        return [
+            hex_to_int(parsed_proof["a"]),
+            [hex_to_int(parsed_proof["b"][0]),
+             hex_to_int(parsed_proof["b"][1])],
+            hex_to_int(parsed_proof["c"])]
+
+
+class PGHR13SnarkProvider(IZKSnarkProvider):
+
+    @staticmethod
+    def get_contract_names() -> Tuple[str, str]:
+        return (
+            constants.PGHR13_VERIFIER_CONTRACT, constants.PGHR13_MIXER_CONTRACT)
+
+    @staticmethod
+    def verifier_constructor_parameters(
+            vk: GenericVerificationKey) -> Dict[str, List[int]]:
+        return {
+            "A1": hex_to_int(vk["a"][0]),
+            "A2": hex_to_int(vk["a"][1]),
+            "B": hex_to_int(vk["b"]),
+            "C1": hex_to_int(vk["c"][0]),
+            "C2": hex_to_int(vk["c"][1]),
+            "gamma1": hex_to_int(vk["g"][0]),
+            "gamma2": hex_to_int(vk["g"][1]),
+            "gammaBeta1": hex_to_int(vk["gb1"]),
+            "gammaBeta2_1": hex_to_int(vk["gb2"][0]),
+            "gammaBeta2_2": hex_to_int(vk["gb2"][1]),
+            "Z1": hex_to_int(vk["z"][0]),
+            "Z2": hex_to_int(vk["z"][1]),
+            "IC_coefficients": hex_to_int(sum(vk["IC"], [])),
+        }
+
+    @staticmethod
+    def parse_verification_key(vk_obj: VerificationKey) -> GenericVerificationKey:
+        vk = vk_obj.pghr13_verification_key
+        return {
+            "a": _parse_hex_point_base_group2_affine(vk.a),
+            "b": _parse_hex_point_base_group1_affine(vk.b),
+            "c": _parse_hex_point_base_group2_affine(vk.c),
+            "g": _parse_hex_point_base_group2_affine(vk.gamma),
+            "gb1": _parse_hex_point_base_group1_affine(vk.gamma_beta_g1),
+            "gb2": _parse_hex_point_base_group2_affine(vk.gamma_beta_g2),
+            "z": _parse_hex_point_base_group2_affine(vk.z),
+            "IC": json.loads(vk.ic),
+        }
+
+    @staticmethod
+    def parse_proof(proof_obj: ExtendedProof) -> GenericProof:
+        proof = proof_obj.pghr13_extended_proof
+        return {
+            "a": _parse_hex_point_base_group1_affine(proof.a),
+            "a_p": _parse_hex_point_base_group1_affine(proof.a_p),
+            "b": _parse_hex_point_base_group2_affine(proof.b),
+            "b_p": _parse_hex_point_base_group1_affine(proof.b_p),
+            "c": _parse_hex_point_base_group1_affine(proof.c),
+            "c_p": _parse_hex_point_base_group1_affine(proof.c_p),
+            "h": _parse_hex_point_base_group1_affine(proof.h),
+            "k": _parse_hex_point_base_group1_affine(proof.k),
+            "inputs": json.loads(proof.inputs),
+        }
+
+    @staticmethod
+    def mixer_proof_parameters(parsed_proof: GenericProof) -> List[List[Any]]:
+        return [
+            hex_to_int(parsed_proof["a"]) +
+            hex_to_int(parsed_proof["a_p"]),
+            [hex_to_int(parsed_proof["b"][0]),
+             hex_to_int(parsed_proof["b"][1])],
+            hex_to_int(parsed_proof["b_p"]),
+            hex_to_int(parsed_proof["c"]),
+            hex_to_int(parsed_proof["c_p"]),
+            hex_to_int(parsed_proof["h"]),
+            hex_to_int(parsed_proof["k"])]
+
+
+def get_zksnark_provider(zksnark_name: str) -> IZKSnarkProvider:
+    if zksnark_name == constants.PGHR13_ZKSNARK:
+        return PGHR13SnarkProvider()
+    if zksnark_name == constants.GROTH16_ZKSNARK:
+        return Groth16SnarkProvider()
+    raise Exception(f"unknown zk-SNARK name: {zksnark_name}")
+
+
+def _parse_hex_point_base_group1_affine(
+        point: HexPointBaseGroup1Affine) -> Tuple[str, str]:
+    return (point.x_coord, point.y_coord)
+
+
+def _parse_hex_point_base_group2_affine(
+        point: HexPointBaseGroup2Affine
+) -> Tuple[Tuple[str, str], Tuple[str, str]]:
+    return (
+        (point.x_c1_coord, point.x_c0_coord),
+        (point.y_c1_coord, point.y_c0_coord))


### PR DESCRIPTION
Preparation for exposing zeth functionality as CLI tools.
- Big refactor of tests into calls to a single "joinsplit()' operation.
- Stricter types.
- Some naming more consistent with Zet paper

The cli tools are not complete, but this is a good place to merge, to avoid branches diverging too much.