### PR TITLE
Reversing primary inputs bit order

### DIFF
--- a/pyClient/test/test_contract_bytes.py
+++ b/pyClient/test/test_contract_bytes.py
@@ -59,12 +59,6 @@ def main() -> None:
         print("testSha256DigestFromFieldElements FAILS")
         result *= 0
 
-    print("--- testing ", "testSwapBitOrder")
-    test_swap_bit_order = bytes_instance.functions.testSwapBitOrder().call()
-    if not test_swap_bit_order:
-        print("testSwapBitOrder FAILS")
-        result *= 0
-
     if result:
         print("All Bytes tests PASS")
 

--- a/src/circuits/joinsplit.tcc
+++ b/src/circuits/joinsplit.tcc
@@ -241,8 +241,8 @@ public:
             for (size_t i = 0; i < NumInputs; i++) {
                 unpacked_inputs[i].insert(
                     unpacked_inputs[i].end(),
-                    input_nullifiers[i]->bits.begin(),
-                    input_nullifiers[i]->bits.begin() + FieldT::capacity());
+                    input_nullifiers[i]->bits.rbegin() + (HashT::get_digest_len() - FieldT::capacity()),
+                    input_nullifiers[i]->bits.rend());
             }
 
             // Initialize the unpacked input corresponding to the output
@@ -252,15 +252,15 @@ public:
                  i++, j++) {
                 unpacked_inputs[i].insert(
                     unpacked_inputs[i].end(),
-                    output_commitments[j]->bits.begin(),
-                    output_commitments[j]->bits.begin() + FieldT::capacity());
+                    output_commitments[j]->bits.rbegin() + (HashT::get_digest_len() - FieldT::capacity()),
+                    output_commitments[j]->bits.rend());
             }
 
             // Initialize the unpacked input corresponding to the h_sig
             unpacked_inputs[NumOutputs + NumInputs].insert(
                 unpacked_inputs[NumOutputs + NumInputs].end(),
-                h_sig->bits.begin(),
-                h_sig->bits.begin() + FieldT::capacity());
+                h_sig->bits.rbegin() + (HashT::get_digest_len() - FieldT::capacity()),
+                h_sig->bits.rend());
 
             // Initialize the unpacked input corresponding to the h_is
             for (size_t i = NumOutputs + NumInputs + 1, j = 0;
@@ -268,8 +268,8 @@ public:
                  i++, j++) {
                 unpacked_inputs[i].insert(
                     unpacked_inputs[i].end(),
-                    h_is[j]->bits.begin(),
-                    h_is[j]->bits.begin() + FieldT::capacity());
+                    h_is[j]->bits.rbegin() + (HashT::get_digest_len() - FieldT::capacity()),
+                    h_is[j]->bits.rend());
             }
 
             // Initialize the unpacked input corresponding to the variables of
@@ -287,9 +287,8 @@ public:
                             unpacked_inputs
                                 [NumOutputs + NumInputs + 1 + NumInputs]
                                     .end(),
-                            h_is[NumInputs - i - 1]->bits.begin() +
-                                FieldT::capacity(),
-                            h_is[NumInputs - i - 1]->bits.end());
+                            h_is[NumInputs - i - 1]->bits.rbegin(),
+                            h_is[NumInputs - i - 1]->bits.rbegin() + (HashT::get_digest_len() - FieldT::capacity()));
                 }
 
                 // Filling with the residual bits of the output CommitmentS
@@ -299,10 +298,8 @@ public:
                             unpacked_inputs
                                 [NumOutputs + NumInputs + 1 + NumInputs]
                                     .end(),
-                            output_commitments[NumOutputs - i - 1]
-                                    ->bits.begin() +
-                                FieldT::capacity(),
-                            output_commitments[NumOutputs - i - 1]->bits.end());
+                            output_commitments[NumOutputs - i - 1]->bits.rbegin(),
+                            output_commitments[NumOutputs - i - 1]->bits.rbegin() + (HashT::get_digest_len() - FieldT::capacity()));
                 }
 
                 // Filling with the residual bits of the input NullifierS
@@ -312,31 +309,30 @@ public:
                             unpacked_inputs
                                 [NumOutputs + NumInputs + 1 + NumInputs]
                                     .end(),
-                            input_nullifiers[NumInputs - i - 1]->bits.begin() +
-                                FieldT::capacity(),
-                            input_nullifiers[NumInputs - i - 1]->bits.end());
+                            input_nullifiers[NumInputs - i - 1]->bits.rbegin(),
+                            input_nullifiers[NumInputs - i - 1]->bits.rbegin() + (HashT::get_digest_len() - FieldT::capacity()));
                 }
 
                 // Filling with the residual bits of the h_sig
                 unpacked_inputs[NumOutputs + NumInputs + 1 + NumInputs].insert(
                     unpacked_inputs[NumOutputs + NumInputs + 1 + NumInputs]
                         .end(),
-                    h_sig->bits.begin() + FieldT::capacity(),
-                    h_sig->bits.end());
+                    h_sig->bits.rbegin(),
+                    h_sig->bits.rbegin() + (HashT::get_digest_len() - FieldT::capacity()));
 
                 // Filling with the vpub_out (public value taken out of the mix)
                 unpacked_inputs[NumOutputs + NumInputs + 1 + NumInputs].insert(
                     unpacked_inputs[NumOutputs + NumInputs + 1 + NumInputs]
                         .end(),
-                    zk_vpub_out.begin(),
-                    zk_vpub_out.end());
+                    zk_vpub_out.rbegin(),
+                    zk_vpub_out.rend());
 
                 // Filling with the vpub_in (public value added to the mix)
                 unpacked_inputs[NumOutputs + NumInputs + 1 + NumInputs].insert(
                     unpacked_inputs[NumOutputs + NumInputs + 1 + NumInputs]
                         .end(),
-                    zk_vpub_in.begin(),
-                    zk_vpub_in.end());
+                    zk_vpub_in.rbegin(),
+                    zk_vpub_in.rend());
             }
 
             // [SANITY CHECK]

--- a/src/circuits/joinsplit.tcc
+++ b/src/circuits/joinsplit.tcc
@@ -241,7 +241,8 @@ public:
             for (size_t i = 0; i < NumInputs; i++) {
                 unpacked_inputs[i].insert(
                     unpacked_inputs[i].end(),
-                    input_nullifiers[i]->bits.rbegin() + (HashT::get_digest_len() - FieldT::capacity()),
+                    input_nullifiers[i]->bits.rbegin() +
+                        (HashT::get_digest_len() - FieldT::capacity()),
                     input_nullifiers[i]->bits.rend());
             }
 
@@ -252,14 +253,16 @@ public:
                  i++, j++) {
                 unpacked_inputs[i].insert(
                     unpacked_inputs[i].end(),
-                    output_commitments[j]->bits.rbegin() + (HashT::get_digest_len() - FieldT::capacity()),
+                    output_commitments[j]->bits.rbegin() +
+                        (HashT::get_digest_len() - FieldT::capacity()),
                     output_commitments[j]->bits.rend());
             }
 
             // Initialize the unpacked input corresponding to the h_sig
             unpacked_inputs[NumOutputs + NumInputs].insert(
                 unpacked_inputs[NumOutputs + NumInputs].end(),
-                h_sig->bits.rbegin() + (HashT::get_digest_len() - FieldT::capacity()),
+                h_sig->bits.rbegin() +
+                    (HashT::get_digest_len() - FieldT::capacity()),
                 h_sig->bits.rend());
 
             // Initialize the unpacked input corresponding to the h_is
@@ -268,7 +271,8 @@ public:
                  i++, j++) {
                 unpacked_inputs[i].insert(
                     unpacked_inputs[i].end(),
-                    h_is[j]->bits.rbegin() + (HashT::get_digest_len() - FieldT::capacity()),
+                    h_is[j]->bits.rbegin() +
+                        (HashT::get_digest_len() - FieldT::capacity()),
                     h_is[j]->bits.rend());
             }
 
@@ -288,7 +292,8 @@ public:
                                 [NumOutputs + NumInputs + 1 + NumInputs]
                                     .end(),
                             h_is[NumInputs - i - 1]->bits.rbegin(),
-                            h_is[NumInputs - i - 1]->bits.rbegin() + (HashT::get_digest_len() - FieldT::capacity()));
+                            h_is[NumInputs - i - 1]->bits.rbegin() +
+                                (HashT::get_digest_len() - FieldT::capacity()));
                 }
 
                 // Filling with the residual bits of the output CommitmentS
@@ -298,8 +303,11 @@ public:
                             unpacked_inputs
                                 [NumOutputs + NumInputs + 1 + NumInputs]
                                     .end(),
-                            output_commitments[NumOutputs - i - 1]->bits.rbegin(),
-                            output_commitments[NumOutputs - i - 1]->bits.rbegin() + (HashT::get_digest_len() - FieldT::capacity()));
+                            output_commitments[NumOutputs - i - 1]
+                                ->bits.rbegin(),
+                            output_commitments[NumOutputs - i - 1]
+                                    ->bits.rbegin() +
+                                (HashT::get_digest_len() - FieldT::capacity()));
                 }
 
                 // Filling with the residual bits of the input NullifierS
@@ -310,7 +318,8 @@ public:
                                 [NumOutputs + NumInputs + 1 + NumInputs]
                                     .end(),
                             input_nullifiers[NumInputs - i - 1]->bits.rbegin(),
-                            input_nullifiers[NumInputs - i - 1]->bits.rbegin() + (HashT::get_digest_len() - FieldT::capacity()));
+                            input_nullifiers[NumInputs - i - 1]->bits.rbegin() +
+                                (HashT::get_digest_len() - FieldT::capacity()));
                 }
 
                 // Filling with the residual bits of the h_sig
@@ -318,7 +327,8 @@ public:
                     unpacked_inputs[NumOutputs + NumInputs + 1 + NumInputs]
                         .end(),
                     h_sig->bits.rbegin(),
-                    h_sig->bits.rbegin() + (HashT::get_digest_len() - FieldT::capacity()));
+                    h_sig->bits.rbegin() +
+                        (HashT::get_digest_len() - FieldT::capacity()));
 
                 // Filling with the vpub_out (public value taken out of the mix)
                 unpacked_inputs[NumOutputs + NumInputs + 1 + NumInputs].insert(

--- a/zeth-contracts/contracts/BaseMixer.sol
+++ b/zeth-contracts/contracts/BaseMixer.sol
@@ -157,12 +157,12 @@ contract BaseMixer is MerkleTreeMiMC7, ERC223ReceivingContract {
 
         // We retrieve the public value in, remove any extra bits (due to the padding) and inverse the bit order
         bytes32 vpub_bytes = (bytes32(primary_inputs[1 + 1 + 2*jsIn + jsOut]) << padding) >> (digest_length-size_value);
-        vpub_bytes = Bytes.swap_bit_order(vpub_bytes) >> (digest_length-size_value);
+        vpub_bytes = vpub_bytes >> (digest_length-size_value);
         vpub_in = Bytes.get_int64_from_bytes8(Bytes.int256ToBytes8(uint(vpub_bytes)));
 
         // We retrieve the public value out, remove any extra bits (due to the padding) and inverse the bit order
         vpub_bytes = (bytes32(primary_inputs[1 + 1 + 2*jsIn + jsOut]) << (padding+size_value)) >> (digest_length-size_value);
-        vpub_bytes = Bytes.swap_bit_order(vpub_bytes) >> (digest_length-size_value);
+        vpub_bytes = vpub_bytes >> (digest_length-size_value);
         vpub_out = Bytes.get_int64_from_bytes8(Bytes.int256ToBytes8(uint(vpub_bytes)));
     }
 
@@ -183,7 +183,7 @@ contract BaseMixer is MerkleTreeMiMC7, ERC223ReceivingContract {
         bytes1 bits_input = Bytes.get_last_byte(hsig_bytes);
 
         // We reassemble the residual bits with the field element
-        hsig = Bytes.sha256_digest_from_field_elements(primary_inputs[1 + jsIn + jsOut], bits_input);
+        hsig = Bytes.sha256_digest_from_field_elements(primary_inputs[1 + jsIn + jsOut] << (digest_length - field_capacity), bits_input);
     }
 
     // This function is used to reassemble the nullifiers given the nullifier index [0, jsIn[ and the primary_inputs
@@ -217,7 +217,7 @@ contract BaseMixer is MerkleTreeMiMC7, ERC223ReceivingContract {
         bytes32 sn_bytes = (bytes32(primary_inputs[1 + 1 + 2*jsIn + jsOut]) << padding + sn_bit_index) >> field_capacity;
         bytes1 bits_input = Bytes.get_last_byte(sn_bytes);
         // We reassemble the residual bits with the field element
-        sn = Bytes.sha256_digest_from_field_elements(primary_inputs[nullifier_index], bits_input);
+        sn = Bytes.sha256_digest_from_field_elements(primary_inputs[nullifier_index] << (digest_length - field_capacity), bits_input);
     }
 
     // This function is used to reassemble the commitment given the commitment index [0, jsOut[ and the primary_inputs
@@ -252,7 +252,7 @@ contract BaseMixer is MerkleTreeMiMC7, ERC223ReceivingContract {
         bytes1 bits_input = Bytes.get_last_byte(cm_bytes);
 
         // We reassemble the residual bits with the field element
-        cm = Bytes.sha256_digest_from_field_elements(primary_inputs[commitment_index], bits_input);
+        cm = Bytes.sha256_digest_from_field_elements(primary_inputs[commitment_index] << (digest_length - field_capacity), bits_input);
     }
 
     // This function processes the primary inputs to append and check the root and nullifiers in the primary inputs (instance)

--- a/zeth-contracts/contracts/Bytes.sol
+++ b/zeth-contracts/contracts/Bytes.sol
@@ -11,50 +11,29 @@ library Bytes {
     function sha256_digest_from_field_elements(uint input, bytes1 bits) internal pure returns (bytes32) {
         // BECAUSE we know that `input` has only 253 bits from the digest we know that its last 3 bits are going to be zeroes
         // (we want to represent a 253-bit encoded element as a 256-bit digest)
-        // BECAUSE we know that `bits` has only 3 bits from the digest we know that its last 5 bits are going to be zeroes
+        // BECAUSE we know that `bits` has only 3 bits from the digest we know that its first 5 bits are going to be zeroes
         // (we want to represent a 3-bit encoded element as a 8-bit array)
         // Our goal is to recombine the last (256-253) meaningful bits of input with the 3 meaningful bit of bits
-        // NB. the formatting changed the endianness of the variables so we have to fix it when recombining them together/
 
-        // After fixing the endianess of `input`, the byte comprising the (256-253) meaningful bits and padding is the last one
-        bytes32 inverted_input = flip_endianness_bytes32(bytes32(input));
+        bytes32 input_bytes = bytes32(input);
+
         // If `bits` is 0, we do not need to recombine (the input's padding is equal to the value to recombine).
         if (uint8(bits) == 0) {
-            return inverted_input;
+            return input_bytes;
         }
         // Else, we continue
-        bytes1 last_byte_prefix = get_last_byte(inverted_input);
-
-        // We similarly inverse `bits` and we shift 5 times because we have something like:
-        // 0x4 initally, which is in reality 0x04 --> 0000 0100 (in binary).
-        // Only the last `100` bits represent meaningful data
-        // (the first 5 bit of value '0' are just here to fill the space in the byte).
-        // So when we reverse the byte, we have: 0000 0100 --> 0010 0000
-        // But again only 3 bits are meaningful in this case. This time the 5 last bits are padding.
-        // Thus we push the meaningful data to the right. Now we have something like: `0000 0001`.
-        // Note, we store the result of 2 ** n in uint8. However, if n is to big (ie: n > 8).
-        // This can overflow. Here this is fine as n is NOT a user input, and does not aim to be changed.
-        // Nevertheless we need to keep this in mind. As a consequence we add the "dummy" require below that
-        // should fail if we manually change the value of n to be > 8.
-        uint8 reversed = uint8(reverse_byte(uint8(bits)));
-        uint8 n = 5;
-        require(
-            n < 8,
-            "The number of right shifts should be inferior to 8"
-        );
-        bytes1 shifted_byte = bytes1(reversed) >> n;
+        bytes1 last_byte_prefix = get_last_byte(input_bytes);
 
         // We know that the last 3 bits of `input` are '0' bits that have been padded to create a byte32 out of a 253 bit string
         // Thus now, we have the last byte of `input` being something like XXXX X000 (where X represent meangful bits)
-        // And `reversed` (the only meaningful byte of this input) being in the form: 0000 0YYY (where Y represent
-        // meaningful data). The only thing we need to do to recompose the digest our of our 2 field elements, is to XOR
-        // the last bytes of each reverse input.
-        bytes1 res = last_byte_prefix ^ shifted_byte;
+        // And `bits` being in the form: 0000 0YYY (where Y represent meaningful data).
+        // The only thing we need to do to recompose the digest of 2 field elements, is to XOR the last bytes of each reverse input.
+        bytes1 res = last_byte_prefix ^ bits;
 
         // We now recombine the first 31 bytes of the flipped `input` with the recombine byte `res`
         bytes memory bytes_digest = new bytes(32);
         for (uint i = 0; i < 31; i++) {
-            bytes_digest[i] = inverted_input[i];
+            bytes_digest[i] = input_bytes[i];
         }
         bytes_digest[31] = res;
         bytes32 sha256_digest = bytes_to_bytes32(bytes_digest, 0);
@@ -84,19 +63,19 @@ library Bytes {
 
     function int256ToBytes8(uint256 input) internal pure returns (bytes8) {
         bytes memory inBytes = new bytes(32);
-        assembly { 
-            mstore(add(inBytes, 32), input) 
+        assembly {
+            mstore(add(inBytes, 32), input)
         }
-        
+
         bytes memory subBytes = subBytes(inBytes, 24, 32);
         bytes8 resBytes8;
         assembly {
             resBytes8 := mload(add(subBytes, 32))
         }
-        
+
         return resBytes8;
     }
-    
+
     function subBytes(bytes memory inBytes, uint startIndex, uint endIndex) internal pure returns (bytes memory) {
         bytes memory result = new bytes(endIndex-startIndex);
         for(uint i = startIndex; i < endIndex; i++) {
@@ -147,14 +126,4 @@ library Bytes {
             (( c >> (((a >> 4)&0xF)*8) + 4) & 0xF);
     }
 
-    function swap_bit_order(bytes32 input) internal pure returns (bytes32) {
-        bytes32 rev;
-        for (uint i = 0 ; i < 256 ; i++){
-            rev = rev << 1;
-            if (uint((input << (255-i)) >> 255) == 1) {
-                rev = rev ^ bytes32(0x0000000000000000000000000000000000000000000000000000000000000001);
-            }
-        }
-        return rev;
-    }
 }

--- a/zeth-contracts/contracts/Bytes_tests.sol
+++ b/zeth-contracts/contracts/Bytes_tests.sol
@@ -72,10 +72,9 @@ contract Bytes_tests {
     }
 
     function testSha256DigestFromFieldElements() public pure returns (bool) {
-        uint256[] memory test_input = new uint[](2);
-        test_input[0] = 0x16cc12975b9a52d97c6a5c0cc91b76b7432306724ed800ef1c29e86393b1e757;
-        test_input[1] = 0x4;
-        bytes32 test_res = Bytes.sha256_digest_from_field_elements(test_input);
+        uint test_input0 = 0x16cc12975b9a52d97c6a5c0cc91b76b7432306724ed800ef1c29e86393b1e757;
+        bytes1 test_input1 = bytes1(uint8(0x4));
+        bytes32 test_res = Bytes.sha256_digest_from_field_elements(test_input0, test_input1);
 
         bool ok = (test_res == bytes32(0xeae78dc9c6179438f7001b724e60c4c2ed6ed893303a563e9b4a59dae9483369));
         require(


### PR DESCRIPTION
This PR is to optimize the packing update by modifying the circuits to encode the primary inputs in big endian. This lead to a simplified re-assembly of the primary inputs on the contract and thus demand less gas.