### PR TITLE
Updating comm to blake % r

### DIFF
--- a/libzeth/circuits/commitments/commitment.hpp
+++ b/libzeth/circuits/commitments/commitment.hpp
@@ -60,11 +60,15 @@ private:
     // intermediary results
     std::shared_ptr<libsnark::digest_variable<FieldT>> inner_k;
     std::shared_ptr<libsnark::digest_variable<FieldT>> outer_k;
+    std::shared_ptr<libsnark::digest_variable<FieldT>> final_k;
 
     // Hash gadgets used as inner, outer and final commitments
     std::shared_ptr<COMM_gadget<FieldT, HashT>> inner_com_gadget;
     std::shared_ptr<COMM_gadget<FieldT, HashT>> outer_com_gadget;
     std::shared_ptr<COMM_gadget<FieldT, HashT>> final_com_gadget;
+
+    // Packing gadget to output field element
+    std::shared_ptr<libsnark::packing_gadget<FieldT>> bits_to_field;
 
 public:
     COMM_cm_gadget(
@@ -78,7 +82,7 @@ public:
         libsnark::pb_variable_array<FieldT> &trap_r,
         // ZethNote value 64 bits
         libsnark::pb_variable_array<FieldT> &value_v,
-        std::shared_ptr<libsnark::digest_variable<FieldT>> result,
+        libsnark::pb_variable<FieldT> result,
         const std::string &annotation_prefix = "COMM_cm_gadget");
 
     void generate_r1cs_constraints();

--- a/libzeth/circuits/joinsplit.tcc
+++ b/libzeth/circuits/joinsplit.tcc
@@ -36,33 +36,33 @@ private:
     // field elements to which are added the public value of size 64 bits
     const size_t length_bit_residual =
         2 * ZETH_V_SIZE +
-        digest_len_minus_field_cap * (NumInputs + NumOutputs + 1 + NumInputs);
+        digest_len_minus_field_cap * (1 + 2 * NumInputs);
     // Number of field elements needed to pack this number of bits
     const size_t nb_field_residual =
         libff::div_ceil(length_bit_residual, FieldT::capacity());
 
-    // Multipacking gadgets for the inputs (nullifierS, commitmentS, hsig,
-    // message authentication tags (h_is) and the residual bits (comprising the
+    // Multipacking gadgets for the inputs (nullifierS, hsig, message
+    // authentication tags (h_is) and the residual bits (comprising the
     // previous variables' bits not containable in a single field element as
-    // well as the public values) (the root is a field element) because we pack
-    // the nullifiers (Inputs of JS = NumInputs), the commitments (Output of JS
-    // = NumOutputs) AND the signature hash h_sig (+1) AND the message
-    // authentication tags h_iS (+ NumInputs) AND the residual field elements
+    // well as the public values) (the root and cms are field elements)
+    // because we pack the nullifiers (Inputs of JS = NumInputs),
+    // AND the signature hash h_sig (+1) AND the message authentication tags
+    // h_iS (+ NumInputs) AND the residual field elements
     // which aggregate the extra bits and public values (+1)
     std::array<
         libsnark::pb_variable_array<FieldT>,
-        NumInputs + NumOutputs + 1 + NumInputs + 1>
+        NumInputs + 1 + NumInputs + 1>
         packed_inputs;
     std::array<
         libsnark::pb_variable_array<FieldT>,
-        NumInputs + NumOutputs + 1 + NumInputs + 1>
+        NumInputs + 1 + NumInputs + 1>
         unpacked_inputs;
 
     // We use an array of multipackers here instead of a single packer that
     // packs everything.
     std::array<
         std::shared_ptr<libsnark::multipacking_gadget<FieldT>>,
-        NumInputs + NumOutputs + 1 + NumInputs + 1>
+        NumInputs + 1 + NumInputs + 1>
         packers;
 
     libsnark::pb_variable<FieldT> ZERO;
@@ -74,8 +74,7 @@ private:
     std::array<std::shared_ptr<libsnark::digest_variable<FieldT>>, NumInputs>
         input_nullifiers;
     // List of commitments generated for the new notes
-    std::array<std::shared_ptr<libsnark::digest_variable<FieldT>>, NumOutputs>
-        output_commitments;
+    libsnark::pb_variable_array<FieldT> output_commitments;
     // Public value that is put into the mix
     libsnark::pb_variable_array<FieldT> zk_vpub_in;
     // Value that is taken out of the mix
@@ -159,38 +158,32 @@ public:
             merkle_root->allocate(
                 pb, FMT(this->annotation_prefix, " merkle_root"));
 
-            // We allocate a field element for each of the input nullifiers and
-            // output commitments to pack their first FieldT::capacity() bits
+            output_commitments.allocate(pb, NumOutputs, " output_commitments");
+
+            // We allocate a field element for each of the input nullifiers
+            // to pack their first FieldT::capacity() bits
             for (size_t i = 0; i < NumInputs; i++) {
                 packed_inputs[i].allocate(
                     pb,
                     1,
                     FMT(this->annotation_prefix, " in_nullifier[%zu]", i));
             }
-            for (size_t i = NumInputs; i < NumInputs + NumOutputs; i++) {
-                packed_inputs[i].allocate(
-                    pb,
-                    1,
-                    FMT(this->annotation_prefix, " out_commitment[%zu]", i));
-            }
 
             // We allocate a field element for h_sig to pack its first
             // FieldT::capacity() bits
-            packed_inputs[NumInputs + NumOutputs].allocate(
+            packed_inputs[NumInputs].allocate(
                 pb, 1, FMT(this->annotation_prefix, " h_sig"));
 
             // We allocate a field element for each message authentication tags
             // h_iS to pack their first FieldT::capacity() bits
-            for (size_t i = NumInputs + NumOutputs + 1;
-                 i < NumInputs + NumOutputs + 1 + NumInputs;
-                 i++) {
+            for (size_t i = NumInputs + 1; i < NumInputs + 1 + NumInputs; i++) {
                 packed_inputs[i].allocate(
                     pb, 1, FMT(this->annotation_prefix, " h_i[%zu]", i));
             }
 
             // We allocate as many field elements as needed to pack the public
             // values and the hash digests' residual bits
-            packed_inputs[NumInputs + NumOutputs + 1 + NumInputs].allocate(
+            packed_inputs[NumInputs + 1 + NumInputs].allocate(
                 pb,
                 nb_field_residual,
                 FMT(this->annotation_prefix, " residual_bits"));
@@ -204,8 +197,8 @@ public:
             // and value_pub_out take `nb_field_residual` field element(s) to be
             // represented
             const size_t nb_packed_inputs =
-                NumInputs + NumOutputs + 1 + NumInputs + nb_field_residual;
-            const size_t nb_inputs = 1 + nb_packed_inputs;
+                2 * NumInputs + 1 + nb_field_residual;
+            const size_t nb_inputs = 1 + NumOutputs + nb_packed_inputs;
             pb.set_input_sizes(nb_inputs);
             // ---------------------------------------------------------------
 
@@ -235,13 +228,6 @@ public:
                     pb,
                     HashT::get_digest_len(),
                     FMT(this->annotation_prefix, " rho_is[%zu]", i)));
-                output_commitments[i].reset(
-                    new libsnark::digest_variable<FieldT>(
-                        pb,
-                        HashT::get_digest_len(),
-                        FMT(this->annotation_prefix,
-                            " output_commitments[%zu]",
-                            i)));
             }
 
             // Allocate the zk_vpub_in and zk_vpub_out
@@ -260,27 +246,15 @@ public:
                     input_nullifiers[i]->bits.rend());
             }
 
-            // Initialize the unpacked input corresponding to the output
-            // CommitmentS
-            for (size_t i = NumInputs, j = 0;
-                 i < NumOutputs + NumInputs && j < NumOutputs;
-                 i++, j++) {
-                unpacked_inputs[i].insert(
-                    unpacked_inputs[i].end(),
-                    output_commitments[j]->bits.rbegin() +
-                        digest_len_minus_field_cap,
-                    output_commitments[j]->bits.rend());
-            }
-
             // Initialize the unpacked input corresponding to the h_sig
-            unpacked_inputs[NumOutputs + NumInputs].insert(
-                unpacked_inputs[NumOutputs + NumInputs].end(),
+            unpacked_inputs[NumInputs].insert(
+                unpacked_inputs[NumInputs].end(),
                 h_sig->bits.rbegin() + digest_len_minus_field_cap,
                 h_sig->bits.rend());
 
             // Initialize the unpacked input corresponding to the h_is
-            for (size_t i = NumOutputs + NumInputs + 1, j = 0;
-                 i < NumInputs + NumOutputs + 1 + NumInputs && j < NumInputs;
+            for (size_t i = NumInputs + 1, j = 0;
+                 i < NumInputs + 1 + NumInputs && j < NumInputs;
                  i++, j++) {
                 unpacked_inputs[i].insert(
                     unpacked_inputs[i].end(),
@@ -291,82 +265,54 @@ public:
             // Initialize the unpacked input corresponding to the variables of
             // size different to 253 (FieldT::capacity()) bits (smaller inputs
             // and residual bits). We obtain an unpacked value equal to v_in ||
-            // v_out || h_sig || nf_{1..NumInputs} || cm_{1..NumOutputs} ||
-            // h_i_{1..NumInput}. We fill them here in reverse order because of
-            // the use of .insert() function which adds a variable before a
+            // v_out || h_sig || nf_{1..NumInputs} || h_i_{1..NumInput}.
+            // We fill them here in reverse order because of the use of
+            // the .insert() function which adds a variable before a
             // given position
             {
                 // Filling with the residual bits of the h_is
                 for (size_t i = 0; i < NumInputs; i++) {
-                    unpacked_inputs[NumInputs + NumOutputs + 1 + NumInputs]
-                        .insert(
-                            unpacked_inputs
-                                [NumInputs + NumOutputs + 1 + NumInputs]
-                                    .end(),
-                            h_is[NumInputs - i - 1]->bits.rbegin(),
-                            h_is[NumInputs - i - 1]->bits.rbegin() +
-                                digest_len_minus_field_cap);
-                }
-
-                // Filling with the residual bits of the output CommitmentS
-                for (size_t i = 0; i < NumOutputs; i++) {
-                    unpacked_inputs[NumInputs + NumOutputs + 1 + NumInputs]
-                        .insert(
-                            unpacked_inputs
-                                [NumInputs + NumOutputs + 1 + NumInputs]
-                                    .end(),
-                            output_commitments[NumOutputs - i - 1]
-                                ->bits.rbegin(),
-                            output_commitments[NumOutputs - i - 1]
-                                    ->bits.rbegin() +
-                                digest_len_minus_field_cap);
+                    unpacked_inputs[NumInputs + 1 + NumInputs].insert(
+                        unpacked_inputs[NumInputs + 1 + NumInputs].end(),
+                        h_is[NumInputs - i - 1]->bits.rbegin(),
+                        h_is[NumInputs - i - 1]->bits.rbegin() +
+                            digest_len_minus_field_cap);
                 }
 
                 // Filling with the residual bits of the input NullifierS
                 for (size_t i = 0; i < NumInputs; i++) {
-                    unpacked_inputs[NumInputs + NumOutputs + 1 + NumInputs]
-                        .insert(
-                            unpacked_inputs
-                                [NumInputs + NumOutputs + 1 + NumInputs]
-                                    .end(),
-                            input_nullifiers[NumInputs - i - 1]->bits.rbegin(),
-                            input_nullifiers[NumInputs - i - 1]->bits.rbegin() +
-                                digest_len_minus_field_cap);
+                    unpacked_inputs[NumInputs + 1 + NumInputs].insert(
+                        unpacked_inputs[NumInputs + 1 + NumInputs].end(),
+                        input_nullifiers[NumInputs - i - 1]->bits.rbegin(),
+                        input_nullifiers[NumInputs - i - 1]->bits.rbegin() +
+                            digest_len_minus_field_cap);
                 }
 
                 // Filling with the residual bits of the h_sig
-                unpacked_inputs[NumInputs + NumOutputs + 1 + NumInputs].insert(
-                    unpacked_inputs[NumInputs + NumOutputs + 1 + NumInputs]
-                        .end(),
+                unpacked_inputs[NumInputs + 1 + NumInputs].insert(
+                    unpacked_inputs[NumInputs + 1 + NumInputs].end(),
                     h_sig->bits.rbegin(),
                     h_sig->bits.rbegin() + digest_len_minus_field_cap);
 
                 // Filling with the vpub_out (public value taken out of the mix)
-                unpacked_inputs[NumInputs + NumOutputs + 1 + NumInputs].insert(
-                    unpacked_inputs[NumInputs + NumOutputs + 1 + NumInputs]
-                        .end(),
+                unpacked_inputs[NumInputs + 1 + NumInputs].insert(
+                    unpacked_inputs[NumInputs + 1 + NumInputs].end(),
                     zk_vpub_out.rbegin(),
                     zk_vpub_out.rend());
 
                 // Filling with the vpub_in (public value added to the mix)
-                unpacked_inputs[NumInputs + NumOutputs + 1 + NumInputs].insert(
-                    unpacked_inputs[NumInputs + NumOutputs + 1 + NumInputs]
-                        .end(),
+                unpacked_inputs[NumInputs + 1 + NumInputs].insert(
+                    unpacked_inputs[NumInputs + 1 + NumInputs].end(),
                     zk_vpub_in.rbegin(),
                     zk_vpub_in.rend());
             }
 
             // [SANITY CHECK]
-            // The root is a FieldT, hence is not packed
-            // The size of the packed inputs should be NumInputs + NumOutputs
-            // + 1 + NumInputs + 1 since we are packing all the inputs
-            // nullifiers
-            // + all the output commitments + the h_sig + the h_iS + the
-            // residual bits of the previous variables and of the two public
-            // values v_pub_in and v_pub_out
-            assert(
-                packed_inputs.size() ==
-                NumInputs + NumOutputs + 1 + NumInputs + 1);
+            // The root is a FieldT, hence is not packed, likewise for the cms.
+            // The size of the packed inputs should be 2*NumInputs + 1 + 1
+            // since we are packing all the inputs nullifiers + the h_is +
+            // + the h_sig + the residual bits
+            assert(packed_inputs.size() == NumInputs + 1 + NumInputs + 1);
             assert(nb_packed_inputs == [this]() {
                 size_t sum = 0;
                 for (const auto &i : packed_inputs) {
@@ -378,8 +324,7 @@ public:
 
             // [SANITY CHECK] Total size of unpacked inputs
             size_t total_size_unpacked_inputs = 0;
-            for (size_t i = 0; i < NumInputs + NumOutputs + 1 + NumInputs + 1;
-                 i++) {
+            for (size_t i = 0; i < NumInputs + 1 + NumInputs + 1; i++) {
                 total_size_unpacked_inputs += unpacked_inputs[i].size();
             }
             assert(
@@ -401,31 +346,16 @@ public:
                         i)));
             }
 
-            // 2. Pack the output commitments
-            for (size_t i = NumInputs; i < NumOutputs + NumInputs; i++) {
-                packers[i].reset(new libsnark::multipacking_gadget<FieldT>(
-                    pb,
-                    unpacked_inputs[i],
-                    packed_inputs[i],
-                    FieldT::capacity(),
-                    FMT(this->annotation_prefix,
-                        " packer_output_commitments[%zu]",
-                        i)));
-            }
+            // 2. Pack the h_sig
+            packers[NumInputs].reset(new libsnark::multipacking_gadget<FieldT>(
+                pb,
+                unpacked_inputs[NumInputs],
+                packed_inputs[NumInputs],
+                FieldT::capacity(),
+                FMT(this->annotation_prefix, " packer_h_sig")));
 
-            // 3. Pack the h_sig
-            packers[NumInputs + NumOutputs].reset(
-                new libsnark::multipacking_gadget<FieldT>(
-                    pb,
-                    unpacked_inputs[NumInputs + NumOutputs],
-                    packed_inputs[NumInputs + NumOutputs],
-                    FieldT::capacity(),
-                    FMT(this->annotation_prefix, " packer_h_sig")));
-
-            // 4. Pack the h_iS
-            for (size_t i = NumInputs + NumOutputs + 1;
-                 i < NumInputs + NumOutputs + 1 + NumInputs;
-                 i++) {
+            // 3. Pack the h_iS
+            for (size_t i = NumInputs + 1; i < NumInputs + 1 + NumInputs; i++) {
                 packers[i].reset(new libsnark::multipacking_gadget<FieldT>(
                     pb,
                     unpacked_inputs[i],
@@ -434,12 +364,12 @@ public:
                     FMT(this->annotation_prefix, " packer_h_i[%zu]", i)));
             }
 
-            // 5. Pack the other values and residual bits
-            packers[NumInputs + NumOutputs + 1 + NumInputs].reset(
+            // 4. Pack the other values and residual bits
+            packers[NumInputs + 1 + NumInputs].reset(
                 new libsnark::multipacking_gadget<FieldT>(
                     pb,
-                    unpacked_inputs[NumInputs + NumOutputs + 1 + NumInputs],
-                    packed_inputs[NumInputs + NumOutputs + 1 + NumInputs],
+                    unpacked_inputs[NumInputs + 1 + NumInputs],
+                    packed_inputs[NumInputs + 1 + NumInputs],
                     FieldT::capacity(),
                     FMT(this->annotation_prefix, " packer_residual_bits")));
 
@@ -591,13 +521,13 @@ public:
 
         {
             // Witness total_uint64 bits
-            // We add binary numbers here
-            // see:
+            // We add binary numbers here see:
             // https://stackoverflow.com/questions/13282825/adding-binary-numbers-in-c
+            // To check left_side_acc < 2^64, we set the function's bool to true
             bits64 left_side_acc = vpub_in;
             for (size_t i = 0; i < NumInputs; i++) {
                 left_side_acc = binary_addition<ZETH_V_SIZE>(
-                    left_side_acc, inputs[i].note.value());
+                    left_side_acc, inputs[i].note.value(), true);
             }
 
             zk_total_uint64.fill_with_bits(
@@ -636,13 +566,13 @@ public:
         // Bit-length of the Merkle Root
         acc += FieldT::capacity();
 
-        // Bit-length of the NullifierS
-        for (size_t i = 0; i < NumInputs; i++) {
-            acc += HashT::get_digest_len();
-        }
-
         // Bit-length of the CommitmentS
         for (size_t i = 0; i < NumOutputs; i++) {
+            acc += FieldT::capacity();
+        }
+
+        // Bit-length of the NullifierS
+        for (size_t i = 0; i < NumInputs; i++) {
             acc += HashT::get_digest_len();
         }
 
@@ -666,10 +596,10 @@ public:
     // Computes the total bit-length of the unpacked primary inputs
     static size_t get_unpacked_inputs_bit_size()
     {
-        // The Merkle root is not in the `unpacked_inputs` so we subtract its
-        // bit-length to get the total bit-length of the primary inputs in
-        // `unpacked_inputs`
-        return get_inputs_bit_size() - FieldT::capacity();
+        // The Merkle root and commitments are not in the `unpacked_inputs`
+        // so we subtract their bit-length to get the total bit-length of
+        // the primary inputs in `unpacked_inputs`
+        return get_inputs_bit_size() - (1 + NumOutputs) * FieldT::capacity();
     }
 
     // Computes the number of field elements in the primary inputs
@@ -681,17 +611,16 @@ public:
         // FieldT::capacity())
         nb_elements += 1;
 
+        // Each commitment is represented by 1 field element (bit_length(cm) =
+        // FieldT::capacity())
+        for (size_t i = 0; i < NumOutputs; i++) {
+            nb_elements += 1;
+        }
+
         // Each nullifier is represented by 1 field element and
         // (HashT::get_digest_len() - FieldT::capacity()) bits we aggregate in
         // the residual field element(s) later on (c.f. last incrementation)
         for (size_t i = 0; i < NumInputs; i++) {
-            nb_elements += 1;
-        }
-
-        // Each commitment is represented by 1 field element and
-        // (HashT::get_digest_len() - FieldT::capacity()) bits we aggregate in
-        // the residual field element(s) later on (c.f. last incrementation)
-        for (size_t i = 0; i < NumOutputs; i++) {
             nb_elements += 1;
         }
 
@@ -712,7 +641,7 @@ public:
         nb_elements += libff::div_ceil(
             2 * ZETH_V_SIZE +
                 safe_subtraction(HashT::get_digest_len(), FieldT::capacity()) *
-                    (NumInputs + NumOutputs + 1 + NumInputs),
+                    (1 + 2 * NumInputs),
             FieldT::capacity());
 
         return nb_elements;

--- a/libzeth/circuits/joinsplit.tcc
+++ b/libzeth/circuits/joinsplit.tcc
@@ -35,8 +35,7 @@ private:
     // Number of residual bits from packing of hash digests into smaller
     // field elements to which are added the public value of size 64 bits
     const size_t length_bit_residual =
-        2 * ZETH_V_SIZE +
-        digest_len_minus_field_cap * (1 + 2 * NumInputs);
+        2 * ZETH_V_SIZE + digest_len_minus_field_cap * (1 + 2 * NumInputs);
     // Number of field elements needed to pack this number of bits
     const size_t nb_field_residual =
         libff::div_ceil(length_bit_residual, FieldT::capacity());

--- a/libzeth/circuits/notes/note.hpp
+++ b/libzeth/circuits/notes/note.hpp
@@ -53,12 +53,8 @@ private:
     libsnark::pb_variable_array<FieldT> rho;
 
     std::shared_ptr<COMM_cm_gadget<FieldT, HashT>> commit_to_inputs_cm;
-    // Note commitment (bits), output of COMMIT gadget
-    std::shared_ptr<libsnark::digest_variable<FieldT>> commitment;
-    // Packing gadget to pack commitment from bits to field elements
-    std::shared_ptr<libsnark::packing_gadget<FieldT>> bits_to_field;
-    // Note commitment (field), input of Merkle Tree gadget
-    std::shared_ptr<libsnark::pb_variable<FieldT>> field_cm;
+    // Note commitment (bits), output of COMM gadget
+    libsnark::pb_variable<FieldT> commitment;
 
     // Bit that checks whether the commitment (leaf) has to be found in the
     // merkle tree (Necessary to support dummy notes of value 0)
@@ -116,7 +112,7 @@ public:
         libsnark::protoboard<FieldT> &pb,
         const libsnark::pb_variable<FieldT> &ZERO,
         std::shared_ptr<libsnark::digest_variable<FieldT>> rho,
-        std::shared_ptr<libsnark::digest_variable<FieldT>> commitment,
+        libsnark::pb_variable<FieldT> cm,
         const std::string &annotation_prefix = "output_note_gadget");
 
     // Check the booleaness of the a_pk

--- a/libzeth/test/commitments_test.cpp
+++ b/libzeth/test/commitments_test.cpp
@@ -183,15 +183,12 @@ TEST(TestCOMMs, TestCOMMGadget)
 
     bits384 trap_r_bits384 = hex_value_to_bits384(
         "0F000000000000FF00000000000000FF00000000000000FF00000000000000FF00"
-        "000000000000FF00000000000000FF"));
-    bits64 value_bits64 =
-        get_bits64_from_vector(hex_to_binary_vector("2F0000000000000F"));
-    bits256 rho_bits256 = get_bits256_from_vector(
-        hex_digest_to_binary_vector("FFFF000000000000000000000000000000"
-                                    "000000000000000000000000009009"));
-    bits256 a_pk_bits256 = get_bits256_from_vector(
-        hex_digest_to_binary_vector("5c36fea42b82800d74304aa4f875142b42"
-                                    "1b4f2847e7c41c1077fbbcfd63f886"));
+        "000000000000FF00000000000000FF");
+    bits64 value_bits64 = hex_value_to_bits64("2F0000000000000F");
+    bits256 rho_bits256 = hex_digest_to_bits256("FFFF000000000000000000000000000000"
+                                    "000000000000000000000000009009");
+    bits256 a_pk_bits256 = hex_digest_to_bits256("5c36fea42b82800d74304aa4f875142b42"
+                                    "1b4f2847e7c41c1077fbbcfd63f886");
     FieldT cm_field = FieldT("2155258442620509676458556185366050817769574716974"
                              "5897618121094192716929220955");
 

--- a/libzeth/test/commitments_test.cpp
+++ b/libzeth/test/commitments_test.cpp
@@ -185,10 +185,12 @@ TEST(TestCOMMs, TestCOMMGadget)
         "0F000000000000FF00000000000000FF00000000000000FF00000000000000FF00"
         "000000000000FF00000000000000FF");
     bits64 value_bits64 = hex_value_to_bits64("2F0000000000000F");
-    bits256 rho_bits256 = hex_digest_to_bits256("FFFF000000000000000000000000000000"
-                                    "000000000000000000000000009009");
-    bits256 a_pk_bits256 = hex_digest_to_bits256("5c36fea42b82800d74304aa4f875142b42"
-                                    "1b4f2847e7c41c1077fbbcfd63f886");
+    bits256 rho_bits256 =
+        hex_digest_to_bits256("FFFF000000000000000000000000000000"
+                              "000000000000000000000000009009");
+    bits256 a_pk_bits256 =
+        hex_digest_to_bits256("5c36fea42b82800d74304aa4f875142b42"
+                              "1b4f2847e7c41c1077fbbcfd63f886");
     FieldT cm_field = FieldT("2155258442620509676458556185366050817769574716974"
                              "5897618121094192716929220955");
 

--- a/libzeth/test/commitments_test.cpp
+++ b/libzeth/test/commitments_test.cpp
@@ -183,14 +183,17 @@ TEST(TestCOMMs, TestCOMMGadget)
 
     bits384 trap_r_bits384 = hex_value_to_bits384(
         "0F000000000000FF00000000000000FF00000000000000FF00000000000000FF00"
-        "000000000000FF00000000000000FF");
-    bits64 value_bits64 = hex_value_to_bits64("2F0000000000000F");
-    bits256 rho_bits256 = hex_digest_to_bits256(
-        "FFFF000000000000000000000000000000000000000000000000000000009009");
-    bits256 a_pk_bits256 = hex_digest_to_bits256(
-        "5c36fea42b82800d74304aa4f875142b421b4f2847e7c41c1077fbbcfd63f886");
-    bits256 cm_bits256 = hex_digest_to_bits256(
-        "f1378e66b0037337743d1ca5c83ed28c4e873c3fb242dcef3ff0db4ebe82c15f");
+        "000000000000FF00000000000000FF"));
+    bits64 value_bits64 =
+        get_bits64_from_vector(hex_to_binary_vector("2F0000000000000F"));
+    bits256 rho_bits256 = get_bits256_from_vector(
+        hex_digest_to_binary_vector("FFFF000000000000000000000000000000"
+                                    "000000000000000000000000009009"));
+    bits256 a_pk_bits256 = get_bits256_from_vector(
+        hex_digest_to_binary_vector("5c36fea42b82800d74304aa4f875142b42"
+                                    "1b4f2847e7c41c1077fbbcfd63f886"));
+    FieldT cm_field = FieldT("2155258442620509676458556185366050817769574716974"
+                             "5897618121094192716929220955");
 
     // hex: 0xAF000000000000FF00000000000000FF00000000000000FF00000000000000FF
     libsnark::pb_variable_array<FieldT> a_pk;
@@ -209,9 +212,8 @@ TEST(TestCOMMs, TestCOMMGadget)
     v.allocate(pb, ZETH_V_SIZE, "v");
     v.fill_with_bits(pb, get_vector_from_bits64(value_bits64));
 
-    std::shared_ptr<libsnark::digest_variable<FieldT>> result;
-    result.reset(new libsnark::digest_variable<FieldT>(
-        pb, HashT::get_digest_len(), "result"));
+    libsnark::pb_variable<FieldT> result;
+    result.allocate(pb, " result");
 
     std::shared_ptr<COMM_cm_gadget<FieldT, HashT>> comm_cm_gadget;
     comm_cm_gadget.reset(
@@ -222,7 +224,7 @@ TEST(TestCOMMs, TestCOMMGadget)
     bool is_valid_witness = pb.is_satisfied();
     ASSERT_TRUE(is_valid_witness);
 
-    ASSERT_EQ(result->get_digest(), get_vector_from_bits256(cm_bits256));
+    ASSERT_EQ(pb.val(result), cm_field);
 };
 
 } // namespace

--- a/libzeth/test/note_test.cpp
+++ b/libzeth/test/note_test.cpp
@@ -85,10 +85,7 @@ TEST(TestNoteCircuits, TestInputNoteGadget)
     //
     // inner_k = blake2sCompress(a_pk || rho)
     // outer_k = blake2sCompress(r || [inner_commitment]_128)
-    // cm = blake2sCompress(outer_k || 0^192 || value_v)
-    // Converted from old hex string
-    // "c8095fff642b3eba57f195ef3e27dcf424b470a22a3bb05704836cda21249d66"
-    // (big-endian)
+    // cm_field = int(blake2sCompress(outer_k || 0^192 || value_v))% r
     FieldT cm_field = FieldT("9047913389147464750130699723564635396506448356890"
                              "6678810249472230384841563494");
     libff::leave_block(
@@ -184,9 +181,9 @@ TEST(TestNoteCircuits, TestOutputNoteGadget)
     //
     // inner_k = blake2sCompress(a_pk || rho)
     // outer_k = blake2sCompress(r || [inner_commitment]_128)
-    // cm = blake2sCompress(outer_k || 0^192 || value_v)
-    bits256 cm_bits256 = hex_digest_to_bits256(
-        "626876b3e2747325f469df067b1f86c8474ffe85e97f56f273c5798dcfccd925");
+    // cm = int(blake2sCompress(outer_k || 0^192 || value_v)) % r
+    FieldT cm = FieldT("7347447679663648782381558941340994878602749621591600723"
+                       "22531099530620623139");
     libff::leave_block(
         "Initialize the output coins' data (a_pk, cm, rho)", true);
 
@@ -199,9 +196,8 @@ TEST(TestNoteCircuits, TestOutputNoteGadget)
     rho_digest->generate_r1cs_witness(
         libff::bit_vector(get_vector_from_bits256(rho_bits256)));
 
-    std::shared_ptr<libsnark::digest_variable<FieldT>> commitment;
-    commitment.reset(new libsnark::digest_variable<FieldT>(
-        pb, HashT::get_digest_len(), "root_digest"));
+    libsnark::pb_variable<FieldT> commitment;
+    commitment.allocate(pb, "commitment");
     std::shared_ptr<output_note_gadget<FieldT, HashT>> output_note_g =
         std::shared_ptr<output_note_gadget<FieldT, HashT>>(
             new output_note_gadget<FieldT, HashT>(
@@ -221,10 +217,7 @@ TEST(TestNoteCircuits, TestOutputNoteGadget)
     ASSERT_TRUE(is_valid_witness);
 
     // Last check to make sure the commitment computed is the expected one
-    libff::bit_vector obtained_digest = commitment->get_digest();
-    libff::bit_vector expected_digest =
-        libff::bit_vector(get_vector_from_bits256(cm_bits256));
-    ASSERT_EQ(obtained_digest, expected_digest);
+    ASSERT_EQ(pb.val(commitment), cm);
 };
 
 } // namespace

--- a/pyClient/test/test_contract_base_mixer.py
+++ b/pyClient/test/test_contract_base_mixer.py
@@ -16,15 +16,15 @@ import test_commands.mock as mock
 # it is structured as follows,
 UNPACKED_PRIMARY_INPUTS = [
     0,  # rt
-    8,  # nf_0 = "...1 000"
-    9,  # nf_1 = "...1 001"
-    18,  # cm_0 = "...10 010"
-    19,  # cm_1 = "...10 011"
+    24,  # nf_0 = "0...01 1000"
+    33,  # nf_1 = "0...010 0001"
+    1,  # cm_0 = "0...01"
+    2,  # cm_1 = "0...010"
     2**PUBLIC_VALUE_LENGTH - 1,  # v_in = "1...1"
     0,  # v_out = "0...0"
-    31,  # h_sig = "...11 111"
-    36,  # htag_0 = "...100 100"
-    37  # htag_1 = "...100 101"
+    47,  # h_sig = "0...010 1111"
+    50,  # htag_0 = "0...011 0010"
+    59  # htag_1 = "0...011 1011"
 ]
 # The values were set so that the RESIDUAL_BITS are easily distinguishable.
 
@@ -32,48 +32,44 @@ UNPACKED_PRIMARY_INPUTS = [
 #   rt || {nf}_1,2 || {cm}_1,2 || h_sig || {h}_1,2 || RESIDUAL_BITS
 PACKED_PRIMARY_INPUTS = [
     0,  # root
-    1,  # nf_0
-    1,  # nf_1
-    2,  # cm_0
+    1,  # cm_0
     2,  # cm_1
-    3,  # h_sig
-    4,  # h_0
-    4,  # h_1
-    713623846352979940490457358497079434602616037] \
+    3,  # nf_0
+    4,  # nf_1
+    5,  # h_sig
+    6,  # h_0
+    7,  # h_1
+    11150372599265311570163396226516866165665875] \
         # pylint: disable=no-member,invalid-name
 
 # RESIDUAL_BITS =
-#   v_in || v_out || h_sig || {nf}_1,2  || {cm}_1,2  || {h}_1,2
+#   v_in || v_out || h_sig || {nf}_1,2 || {h}_1,2
 # We set dummy values for all variables. The residual_bits are as follows:
 # RESIDUAL_BITS = 713623846352979940490457358497079434602616037, or in bits
 # 1-4:   00000000 00000000 00000000 00000000
 # 5-8:   00000000 00000000 00000000 00000000
 # 9-12:  00000000 00000000 00000000 00000000
-# 13-16: 00000000 00011111 11111111 11111111
+# 13-16: 00000000 00000000 01111111 11111111
 # 17-20: 11111111 11111111 11111111 11111111
-# 21-24: 11111111 11100000 00000000 00000000
+# 21-24: 11111111 11111111 10000000 00000000
 # 25-28: 00000000 00000000 00000000 00000000
-# 29-32: 00000000 00011100 00010100 11100101
+# 29-32: 00000000 00000000 01110000 01010011
 # This corresponds to
 # v_in  = "0xFFFFFFFFFFFFFFFF" = 2**PUBLIC_VALUE_LENGTH - 1
 # v_out = "0x0000000000000000" = 0
 # h_sig = "111" = 7
 # nf_0  = "000" = 0
 # nf_1  = "001" = 1
-# cm_0  = "010" = 2
-# cm_1  = "011" = 3
-# h_0   = "100" = 4
-# h_1   = "101" = 5
+# h_0   = "010" = 2
+# h_1   = "011" = 3
 RESIDUAL_BITS = [
     2**PUBLIC_VALUE_LENGTH - 1,  # v_in
     0,  # v_out
     7,  # h_sig
     0,  # nf_0
     1,  # nf_1
-    2,  # cm_0
-    3,  # cm_1
-    4,  # h_0
-    5  # h_1
+    2,  # h_0
+    3  # h_1
     ]  # pylint: disable=no-member,invalid-name
 
 

--- a/pyClient/test/test_joinsplit.py
+++ b/pyClient/test/test_joinsplit.py
@@ -4,6 +4,8 @@
 
 from zeth.joinsplit import compute_commitment
 from api.util_pb2 import ZethNote
+import zeth.constants as constants
+
 from unittest import TestCase
 
 
@@ -19,10 +21,12 @@ class TestJoinsplit(TestCase):
         trap_r = \
             "1e3063320fd43f2d6c456d7f1ee11b7ab486308133e2a5afe916daa4ff5357f6" + \
             "b4c262c9732b6d4d6d10f493a5e77f8c"
-        cm_expect = \
-            "9b8c1cb39ae9da05b9be0d8538ca6ad83181ecbfad95105dd584200414122026"
+        cm_expect = int(
+            "9b8c1cb39ae9da05b9be0d8538ca6ad83181ecbfad95105dd584200414122026",
+            16)
+        cm_expect_field = cm_expect % constants.ZETH_PRIME
 
         note = ZethNote(apk=apk, value=value, rho=rho, trap_r=trap_r)
-        cm = compute_commitment(note)
+        cm = int.from_bytes(compute_commitment(note), byteorder="big")
 
-        self.assertEqual(cm_expect, cm.hex())
+        self.assertEqual(cm_expect_field, cm)

--- a/pyClient/test_commands/scenario.py
+++ b/pyClient/test_commands/scenario.py
@@ -172,8 +172,8 @@ def charlie_double_withdraw(
     # {0;1}^256 so that they appear different to the contract.
     # See: https://github.com/clearmatics/zeth/issues/38
 
-    attack_primary_input1: int = 0
-    attack_primary_input2: int = 0
+    attack_primary_input3: int = 0
+    attack_primary_input4: int = 0
 
     def compute_h_sig_attack_nf(
             nf0: bytes,
@@ -183,28 +183,28 @@ def charlie_double_withdraw(
         input_nullifier0 = nf0.hex()
         input_nullifier1 = nf1.hex()
         nf0_rev = "{0:0256b}".format(int(input_nullifier0, 16))
-        primary_input1_bits = nf0_rev[:FIELD_CAPACITY]
-        primary_input1_res_bits = nf0_rev[FIELD_CAPACITY:]
+        primary_input3_bits = nf0_rev[:FIELD_CAPACITY]
+        primary_input3_res_bits = nf0_rev[FIELD_CAPACITY:]
         nf1_rev = "{0:0256b}".format(int(input_nullifier1, 16))
-        primary_input2_bits = nf1_rev[:FIELD_CAPACITY]
-        primary_input2_res_bits = nf1_rev[FIELD_CAPACITY:]
+        primary_input4_bits = nf1_rev[:FIELD_CAPACITY]
+        primary_input4_res_bits = nf1_rev[FIELD_CAPACITY:]
 
         # We perform the attack, recoding the modified public input values
-        nonlocal attack_primary_input1
-        nonlocal attack_primary_input2
-        attack_primary_input1 = int(primary_input1_bits, 2) + ZETH_PRIME
-        attack_primary_input2 = int(primary_input2_bits, 2) + ZETH_PRIME
+        nonlocal attack_primary_input3
+        nonlocal attack_primary_input4
+        attack_primary_input3 = int(primary_input3_bits, 2) + ZETH_PRIME
+        attack_primary_input4 = int(primary_input4_bits, 2) + ZETH_PRIME
 
         # We reassemble the nfs
-        attack_primary_input1_bits = "{0:0256b}".format(attack_primary_input1)
-        attack_nf0_bits = attack_primary_input1_bits[
-            len(attack_primary_input1_bits) - FIELD_CAPACITY:] +\
-            primary_input1_res_bits
+        attack_primary_input3_bits = "{0:0256b}".format(attack_primary_input3)
+        attack_nf0_bits = attack_primary_input3_bits[
+            len(attack_primary_input3_bits) - FIELD_CAPACITY:] +\
+            primary_input3_res_bits
         attack_nf0 = "{0:064x}".format(int(attack_nf0_bits, 2))
-        attack_primary_input2_bits = "{0:0256b}".format(attack_primary_input2)
-        attack_nf1_bits = attack_primary_input2_bits[
-            len(attack_primary_input2_bits) - FIELD_CAPACITY:] +\
-            primary_input2_res_bits
+        attack_primary_input4_bits = "{0:0256b}".format(attack_primary_input4)
+        attack_nf1_bits = attack_primary_input4_bits[
+            len(attack_primary_input4_bits) - FIELD_CAPACITY:] +\
+            primary_input4_res_bits
         attack_nf1 = "{0:064x}".format(int(attack_nf1_bits, 2))
         return joinsplit.compute_h_sig(
             bytes.fromhex(attack_nf0), bytes.fromhex(attack_nf1), sign_vk)
@@ -226,14 +226,14 @@ def charlie_double_withdraw(
     # Update the primary inputs to the modified nullifiers, since libsnark
     # overwrites them with values in Z_p
 
-    assert attack_primary_input1 != 0
-    assert attack_primary_input2 != 0
+    assert attack_primary_input3 != 0
+    assert attack_primary_input4 != 0
 
     print("proof_json => ", proof_json)
-    print("proof_json[inputs][1] => ", proof_json["inputs"][1])
-    print("proof_json[inputs][2] => ", proof_json["inputs"][2])
-    proof_json["inputs"][1] = hex(attack_primary_input1)
-    proof_json["inputs"][2] = hex(attack_primary_input2)
+    print("proof_json[inputs][3] => ", proof_json["inputs"][3])
+    print("proof_json[inputs][4] => ", proof_json["inputs"][4])
+    proof_json["inputs"][3] = hex(attack_primary_input3)
+    proof_json["inputs"][4] = hex(attack_primary_input4)
     # ### ATTACK BLOCK
 
     # construct pk object from bytes

--- a/pyClient/zeth/contracts.py
+++ b/pyClient/zeth/contracts.py
@@ -184,6 +184,7 @@ def mix(
     pk_sender_encoded = encode_encryption_public_key(pk_sender)
     proof_params = zksnark.mixer_proof_parameters(parsed_proof)
     inputs = hex_to_int(parsed_proof["inputs"])
+
     tx_hash = mixer_instance.functions.mix(
         *proof_params,
         [int(vk.ppk[0]), int(vk.ppk[1]), int(vk.spk[0]), int(vk.spk[1])],

--- a/pyClient/zeth/joinsplit.py
+++ b/pyClient/zeth/joinsplit.py
@@ -269,7 +269,9 @@ def compute_commitment(zeth_note: ZethNote) -> bytes:
 
     # cm = blake2s(outer_k || zero_pad_64_to_256(value))
     cm = blake2s_compress_pad_right64(outer_k, bytes.fromhex(zeth_note.value))
-    return cm
+
+    cm_field = int.from_bytes(cm, byteorder="big") % constants.ZETH_PRIME
+    return cm_field.to_bytes(int(constants.DIGEST_LENGTH/8), byteorder="big")
 
 
 def compute_nullifier(

--- a/zeth-contracts/contracts/Groth16Mixer.sol
+++ b/zeth-contracts/contracts/Groth16Mixer.sol
@@ -108,7 +108,7 @@ contract Groth16Mixer is BaseMixer {
         );
 
         // 3. Append the commitments to the tree
-        assemble_commitments_and_append_to_state(input);
+        append_commitments_to_state(input);
 
         // 4. Get the public values in Wei and modify the state depending on
         // their values

--- a/zeth-contracts/contracts/Pghr13Mixer.sol
+++ b/zeth-contracts/contracts/Pghr13Mixer.sol
@@ -128,7 +128,7 @@ contract Pghr13Mixer is BaseMixer {
 
 
         // 3. Append the commitments to the tree
-        assemble_commitments_and_append_to_state(input);
+        append_commitments_to_state(input);
 
         // 4. get the public values in Wei and modify the state depending on
         // their values


### PR DESCRIPTION
PR to fix consistency in Zeth by having comm = blake2 % r.
This implies:
- changing the circuit to output cm = blake % r
- changing the client to reorder primary inputs
- changing the contracts to reorder primary inputs and simplify cm reassembly
- updating test values.