### PR TITLE
Fix vout attack #160

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,6 @@ addons:
     apt:
         packages:
             - python3-virtualenv
-    homebrew:
-        packages:
-            - gmp
-            - grpc
-            - protobuf
-            - boost
-            - openssl
-            - cmake
-            - libtool
-            - autoconf
-            - automake
-            - python
-            # - llvm
 
 matrix:
     include:

--- a/pyClient/test_commands/scenario.py
+++ b/pyClient/test_commands/scenario.py
@@ -407,6 +407,35 @@ def charlie_corrupt_bob_deposit(
     assert(result_corrupt2 is None), \
         "Charlie managed to corrupt Bob's deposit the second time!"
 
+    # Case3: Charlie uses the correct mix data, but attempts to send the mix
+    # call from his own address (thereby receiving the output).
+    result_corrupt3 = None
+    try:
+        joinsplit_sig_bob = joinsplit.joinsplit_sign(
+            joinsplit_keypair,
+            bob_eth_address,
+            pk_sender,
+            ciphertexts,
+            proof_json)
+        tx_hash = zeth_client.mix(
+            pk_sender,
+            ciphertexts[0],
+            ciphertexts[1],
+            proof_json,
+            joinsplit_keypair.vk,
+            joinsplit_sig_bob,
+            charlie_eth_address,
+            Web3.toWei(BOB_DEPOSIT_ETH, 'ether'),
+            4000000)
+        result_corrupt3 = \
+            wait_for_tx_update_mk_tree(zeth_client, mk_tree, tx_hash)
+    except Exception as e:
+        print(
+            f"Charlie's third corruption attempt" +
+            f" successfully rejected! (msg: {e})"
+        )
+    assert(result_corrupt3 is None), \
+        "Charlie managed to corrupt Bob's deposit the third time!"
     # ### ATTACK BLOCK
 
     # Bob transaction is finally mined

--- a/pyClient/zeth/utils.py
+++ b/pyClient/zeth/utils.py
@@ -74,6 +74,14 @@ def encode_abi(type_names: List[str], data: List[bytes]) -> bytes:
     return eth_abi.encode_abi(type_names, data)  # type: ignore
 
 
+def encode_eth_address(eth_addr: str) -> bytes:
+    """
+    Binary encoding of ethereum address to 32 bytes
+    """
+    # Strip the leading '0x' and hex-decode.
+    return bytes.fromhex(hex_extend_32bytes(eth_addr[2:]))
+
+
 def encode_g1_to_bytes(group_el: G1) -> bytes:
     """
     Encode a group element into a byte string

--- a/scripts/ci
+++ b/scripts/ci
@@ -70,13 +70,14 @@ function build() {
     cxx_flags="-Werror"
 
     if [ "${platform}" == "Darwin" ] ; then
+        openssl_path=$(brew --prefix openssl)
         export PATH="/usr/local/opt/llvm/bin:/usr/local/bin:${PATH}"
-        export PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig"
-        export LIBRARY_PATH="/usr/local/opt/openssl/lib"
-        export LDFLAGS="-L/usr/local/lib"
-        export CPPFLAGS="-I/usr/local/include"
+        export PKG_CONFIG_PATH="${openssl_path}/lib/pkgconfig"
+        export LIBRARY_PATH="${openssl_path}/lib"
+        export LDFLAGS="-L/usr/local/lib -L${openssl_path}/lib"
+        export CPPFLAGS="-I/usr/local/include -I${openssl_path}/include"
 
-        cxx_flags="${cxx_flags} -I/usr/local/opt/openssl/include"
+        cxx_flags="${cxx_flags} -I${openssl_path}/include"
         cxx_flags="${cxx_flags} -Wno-deprecated-declarations"
     fi
 
@@ -103,11 +104,28 @@ function build() {
 
 function ci_setup() {
 
-    if ! [ "${platform}" == "Linux" ] ; then
-        return
+    if [ "${platform}" == "Darwin" ] ; then
+        # Some of these commands can fail (if packages are already installed,
+        # etc), hence the `|| echo`.
+        brew unlink python@2
+        brew update || echo
+        brew install \
+             gmp \
+             grpc \
+             protobuf \
+             boost \
+             openssl \
+             cmake \
+             libtool \
+             autoconf \
+             automake \
+             python \
+             || echo
     fi
 
-    sudo apt install -y python3-venv
+    if [ "${platform}" == "Linux" ] ; then
+        sudo apt install -y python3-venv
+    fi
 }
 
 

--- a/zeth-contracts/contracts/Groth16Mixer.sol
+++ b/zeth-contracts/contracts/Groth16Mixer.sol
@@ -86,6 +86,7 @@ contract Groth16Mixer is BaseMixer {
         // 2.a Verify the signature on the hash of data_to_be_signed
         bytes32 hash_to_be_signed = sha256(
             abi.encodePacked(
+                uint256(msg.sender),
                 pk_sender,
                 ciphertext0,
                 ciphertext1,


### PR DESCRIPTION
Fixes #160 

- client adds his Ethereum address to the data to be signed
- mixer contract uses eth.sender to reconstruct the data to be signed (rejecting the tx if the signature check fails, as now)
