### PR TITLE
Pyclient packaging and factoring for reuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # Ignore the build repo
 /build/
 
-# Ignore the coins we created
-/coinstore/
+# Ignore the notes we created
+/notestore/
 
 # Ignore the output of the trusted setup (ie: Proving and Verifying key)
 /trusted_setup/

--- a/pyClient/api/py.typed
+++ b/pyClient/api/py.typed
@@ -1,0 +1,5 @@
+# Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+#
+# SPDX-License-Identifier: LGPL-3.0+
+
+# Empty file, required for mypy.

--- a/pyClient/commands/constants.py
+++ b/pyClient/commands/constants.py
@@ -18,7 +18,5 @@ ADDRESS_FILE_DEFAULT = "zeth-address.json"
 INSTANCE_FILE_DEFAULT = "zeth-instance.json"
 ETH_ADDRESS_DEFAULT = "eth-address"
 
-WALLET_DIR_DEFAULT = "./notes"
+WALLET_DIR_DEFAULT = "./wallet"
 WALLET_USERNAME = "zeth"
-
-MERKLE_TREE_FILE_DEFAULT = "./merkle_tree.dat"

--- a/pyClient/commands/constants.py
+++ b/pyClient/commands/constants.py
@@ -7,10 +7,6 @@
 Constants and defaults specific to the CLI interface.
 """
 
-from zeth.constants import GROTH16_ZKSNARK
-
-
-ZKSNARK_DEFAULT = GROTH16_ZKSNARK
 ETH_RPC_ENDPOINT_DEFAULT = "http://localhost:8545"
 PROVER_SERVER_ENDPOINT_DEFAULT = "localhost:50051"
 

--- a/pyClient/commands/py.typed
+++ b/pyClient/commands/py.typed
@@ -1,0 +1,5 @@
+# Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+#
+# SPDX-License-Identifier: LGPL-3.0+
+
+# Empty file, required for mypy.

--- a/pyClient/commands/utils.py
+++ b/pyClient/commands/utils.py
@@ -4,16 +4,17 @@
 
 from __future__ import annotations
 from commands.constants import WALLET_USERNAME, ETH_ADDRESS_DEFAULT
-from zeth.contracts import InstanceDescription, get_block_number, get_mix_results
-from zeth.joinsplit import \
-    ZethAddressPub, ZethAddressPriv, ZethAddress, ZethClient, from_zeth_units
+from zeth.contracts import \
+    InstanceDescription, get_block_number, get_mix_results, compile_files
+from zeth.mixer_client import \
+    ZethAddressPub, ZethAddressPriv, ZethAddress, MixerClient
 from zeth.prover_client import ProverClient
-from zeth.utils import open_web3, short_commitment, EtherValue, get_zeth_dir
+from zeth.utils import \
+    open_web3, short_commitment, EtherValue, get_zeth_dir, from_zeth_units
 from zeth.wallet import ZethNoteDescription, Wallet
 from click import ClickException
 import json
 from os.path import exists, join
-from solcx import compile_files  # type: ignore
 from typing import Dict, Tuple, Optional, Callable, Any
 from web3 import Web3  # type: ignore
 
@@ -243,27 +244,27 @@ def find_pub_address_file(base_file: str) -> str:
     raise ClickException(f"No public key file {pub_addr_file} or {base_file}")
 
 
-def create_zeth_client(ctx: ClientContext) -> ZethClient:
+def create_mixer_client(ctx: ClientContext) -> MixerClient:
     """
-    Create a ZethClient for an existing deployment.
+    Create a MixerClient for an existing deployment.
     """
     web3 = open_web3_from_ctx(ctx)
     mixer_desc = load_mixer_description_from_ctx(ctx)
     mixer_instance = mixer_desc.mixer.instantiate(web3)
     prover_client = ctx.prover_client
-    return ZethClient.open(web3, prover_client, mixer_instance)
+    return MixerClient.open(web3, prover_client, mixer_instance)
 
 
 def create_zeth_client_and_mixer_desc(
-        ctx: ClientContext) -> Tuple[ZethClient, MixerDescription]:
+        ctx: ClientContext) -> Tuple[MixerClient, MixerDescription]:
     """
-    Create a ZethClient and MixerDescription object, for an existing deployment.
+    Create a MixerClient and MixerDescription object, for an existing deployment.
     """
     web3 = open_web3_from_ctx(ctx)
     mixer_desc = load_mixer_description_from_ctx(ctx)
     mixer_instance = mixer_desc.mixer.instantiate(web3)
     prover_client = ctx.prover_client
-    zeth_client = ZethClient.open(web3, prover_client, mixer_instance)
+    zeth_client = MixerClient.open(web3, prover_client, mixer_instance)
     return (zeth_client, mixer_desc)
 
 

--- a/pyClient/commands/utils.py
+++ b/pyClient/commands/utils.py
@@ -10,7 +10,6 @@ from zeth.joinsplit import \
 from zeth.prover_client import ProverClient
 from zeth.utils import open_web3, short_commitment, EtherValue, get_zeth_dir
 from zeth.wallet import ZethNoteDescription, Wallet
-from zeth.zksnark import get_zksnark_provider
 from click import ClickException
 import json
 from os.path import exists, join
@@ -27,13 +26,11 @@ class ClientContext:
             self,
             eth_rpc_endpoint: str,
             prover_server_endpoint: str,
-            zksnark_name: str,
             instance_file: str,
             address_file: str,
             wallet_dir: str):
         self.eth_rpc_endpoint = eth_rpc_endpoint
         self.prover_client = ProverClient(prover_server_endpoint)
-        self.zksnark = get_zksnark_provider(zksnark_name)
         self.instance_file = instance_file
         self.address_file = address_file
         self.wallet_dir = wallet_dir
@@ -254,8 +251,7 @@ def create_zeth_client(ctx: ClientContext) -> ZethClient:
     mixer_desc = load_mixer_description_from_ctx(ctx)
     mixer_instance = mixer_desc.mixer.instantiate(web3)
     prover_client = ctx.prover_client
-    zksnark = ctx.zksnark
-    return ZethClient.open(web3, prover_client, mixer_instance, zksnark)
+    return ZethClient.open(web3, prover_client, mixer_instance)
 
 
 def create_zeth_client_and_mixer_desc(
@@ -267,8 +263,7 @@ def create_zeth_client_and_mixer_desc(
     mixer_desc = load_mixer_description_from_ctx(ctx)
     mixer_instance = mixer_desc.mixer.instantiate(web3)
     prover_client = ctx.prover_client
-    zksnark = ctx.zksnark
-    zeth_client = ZethClient.open(web3, prover_client, mixer_instance, zksnark)
+    zeth_client = ZethClient.open(web3, prover_client, mixer_instance)
     return (zeth_client, mixer_desc)
 
 

--- a/pyClient/commands/utils.py
+++ b/pyClient/commands/utils.py
@@ -7,18 +7,40 @@ from commands.constants import WALLET_USERNAME, ETH_ADDRESS_DEFAULT
 from zeth.contracts import InstanceDescription, get_block_number, get_mix_results
 from zeth.joinsplit import \
     ZethAddressPub, ZethAddressPriv, ZethAddress, ZethClient, from_zeth_units
+from zeth.prover_client import ProverClient
 from zeth.utils import open_web3, short_commitment, EtherValue, get_zeth_dir
 from zeth.wallet import ZethNoteDescription, Wallet
-from click import ClickException, Context
+from zeth.zksnark import get_zksnark_provider
+from click import ClickException
 import json
 from os.path import exists, join
 from solcx import compile_files  # type: ignore
-from typing import Dict, Tuple, Optional, Any
+from typing import Dict, Tuple, Optional, Callable, Any
 from web3 import Web3  # type: ignore
 
 
-def open_web3_from_ctx(ctx: Context) -> Any:
-    return open_web3(ctx.obj["ETH_RPC"])
+class ClientContext:
+    """
+    Context for users of these client tools
+    """
+    def __init__(
+            self,
+            eth_rpc_endpoint: str,
+            prover_server_endpoint: str,
+            zksnark_name: str,
+            instance_file: str,
+            address_file: str,
+            wallet_dir: str):
+        self.eth_rpc_endpoint = eth_rpc_endpoint
+        self.prover_client = ProverClient(prover_server_endpoint)
+        self.zksnark = get_zksnark_provider(zksnark_name)
+        self.instance_file = instance_file
+        self.address_file = address_file
+        self.wallet_dir = wallet_dir
+
+
+def open_web3_from_ctx(ctx: ClientContext) -> Any:
+    return open_web3(ctx.eth_rpc_endpoint)
 
 
 class MixerDescription:
@@ -84,15 +106,15 @@ def load_mixer_description(mixer_description_file: str) -> MixerDescription:
         return MixerDescription.from_json(desc_f.read())
 
 
-def load_mixer_description_from_ctx(ctx: Context) -> MixerDescription:
-    return load_mixer_description(ctx.obj["INSTANCE_FILE"])
+def load_mixer_description_from_ctx(ctx: ClientContext) -> MixerDescription:
+    return load_mixer_description(ctx.instance_file)
 
 
-def get_zeth_address_file(ctx: Context) -> str:
-    return ctx.obj["ADDRESS_FILE"]
+def get_zeth_address_file(ctx: ClientContext) -> str:
+    return ctx.address_file
 
 
-def load_zeth_address_public(ctx: Context) -> ZethAddressPub:
+def load_zeth_address_public(ctx: ClientContext) -> ZethAddressPub:
     """
     Load a ZethAddressPub from a key file.
     """
@@ -111,7 +133,7 @@ def write_zeth_address_public(
         pub_addr_f.write(str(pub_addr))
 
 
-def load_zeth_address_secret(ctx: Context) -> ZethAddressPriv:
+def load_zeth_address_secret(ctx: ClientContext) -> ZethAddressPriv:
     """
     Read ZethAddressPriv
     """
@@ -129,7 +151,7 @@ def write_zeth_address_secret(
         addr_f.write(secret_addr.to_json())
 
 
-def load_zeth_address(ctx: Context) -> ZethAddress:
+def load_zeth_address(ctx: ClientContext) -> ZethAddress:
     """
     Load a ZethAddress secret from a file, and the associated public address,
     and return as a ZethAddress.
@@ -142,15 +164,19 @@ def load_zeth_address(ctx: Context) -> ZethAddress:
 def open_wallet(
         mixer_instance: Any,
         js_secret: ZethAddressPriv,
-        ctx: Context) -> Wallet:
+        ctx: ClientContext) -> Wallet:
     """
     Load a wallet using a secret key.
     """
-    wallet_dir = ctx.obj["WALLET_DIR"]
+    wallet_dir = ctx.wallet_dir
     return Wallet(mixer_instance, WALLET_USERNAME, wallet_dir, js_secret)
 
 
-def do_sync(web3: Any, wallet: Wallet, wait_tx: Optional[str]) -> int:
+def do_sync(
+        web3: Any,
+        wallet: Wallet,
+        wait_tx: Optional[str],
+        callback: Optional[Callable[[ZethNoteDescription], None]] = None) -> int:
     """
     Implementation of sync, reused by several commands.  Returns the
     block_number synced to.  Also updates and saves the MerkleTree.
@@ -169,7 +195,8 @@ def do_sync(web3: Any, wallet: Wallet, wait_tx: Optional[str]) -> int:
                 new_merkle_root = mix_result.new_merkle_root
                 for note_desc in wallet.receive_notes(
                         mix_result.output_events, mix_result.sender_k_pk):
-                    print(f" NEW NOTE: {zeth_note_short(note_desc)}")
+                    if callback:
+                        callback(note_desc)
 
                 spent_commits = wallet.mark_nullifiers_used(mix_result.nullifiers)
                 for commit in spent_commits:
@@ -219,28 +246,28 @@ def find_pub_address_file(base_file: str) -> str:
     raise ClickException(f"No public key file {pub_addr_file} or {base_file}")
 
 
-def create_zeth_client(ctx: Context) -> ZethClient:
+def create_zeth_client(ctx: ClientContext) -> ZethClient:
     """
     Create a ZethClient for an existing deployment.
     """
     web3 = open_web3_from_ctx(ctx)
     mixer_desc = load_mixer_description_from_ctx(ctx)
     mixer_instance = mixer_desc.mixer.instantiate(web3)
-    prover_client = ctx.obj["PROVER_CLIENT"]
-    zksnark = ctx.obj["ZKSNARK"]
+    prover_client = ctx.prover_client
+    zksnark = ctx.zksnark
     return ZethClient.open(web3, prover_client, mixer_instance, zksnark)
 
 
 def create_zeth_client_and_mixer_desc(
-        ctx: Context) -> Tuple[ZethClient, MixerDescription]:
+        ctx: ClientContext) -> Tuple[ZethClient, MixerDescription]:
     """
     Create a ZethClient and MixerDescription object, for an existing deployment.
     """
     web3 = open_web3_from_ctx(ctx)
     mixer_desc = load_mixer_description_from_ctx(ctx)
     mixer_instance = mixer_desc.mixer.instantiate(web3)
-    prover_client = ctx.obj["PROVER_CLIENT"]
-    zksnark = ctx.obj["ZKSNARK"]
+    prover_client = ctx.prover_client
+    zksnark = ctx.zksnark
     zeth_client = ZethClient.open(web3, prover_client, mixer_instance, zksnark)
     return (zeth_client, mixer_desc)
 
@@ -252,6 +279,10 @@ def zeth_note_short(note_desc: ZethNoteDescription) -> str:
     value = from_zeth_units(int(note_desc.note.value, 16)).ether()
     cm = short_commitment(note_desc.commitment)
     return f"{cm}: value={value} ETH, addr={note_desc.address}"
+
+
+def zeth_note_short_print(note_desc: ZethNoteDescription) -> None:
+    print(f" NEW NOTE: {zeth_note_short(note_desc)}")
 
 
 def parse_output(output_str: str) -> Tuple[ZethAddressPub, EtherValue]:

--- a/pyClient/commands/utils.py
+++ b/pyClient/commands/utils.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 from commands.constants import WALLET_USERNAME, ETH_ADDRESS_DEFAULT
+from zeth.zeth_address import ZethAddressPub, ZethAddressPriv, ZethAddress
 from zeth.contracts import \
     InstanceDescription, get_block_number, get_mix_results, compile_files
-from zeth.mixer_client import \
-    ZethAddressPub, ZethAddressPriv, ZethAddress, MixerClient
+from zeth.mixer_client import MixerClient
 from zeth.prover_client import ProverClient
 from zeth.utils import \
     open_web3, short_commitment, EtherValue, get_zeth_dir, from_zeth_units

--- a/pyClient/commands/zeth
+++ b/pyClient/commands/zeth
@@ -7,7 +7,7 @@
 from commands.constants import \
     PROVER_SERVER_ENDPOINT_DEFAULT, INSTANCE_FILE_DEFAULT, \
     ADDRESS_FILE_DEFAULT, WALLET_DIR_DEFAULT, ETH_RPC_ENDPOINT_DEFAULT
-from commands.utils import ClientContext
+from commands.utils import ClientConfig
 from commands.zeth_deploy import deploy
 from commands.zeth_gen_address import gen_address
 from commands.zeth_sync import sync
@@ -17,12 +17,12 @@ from commands.zeth_ls_commits import ls_commits
 from commands.zeth_token_approve import token_approve
 from click import group, command, option, pass_context, ClickException, Context
 from click_default_group import DefaultGroup
-from typing import Optional
+from typing import Optional, Any
 
 
 @command()
 @pass_context
-def help(ctx) -> None:
+def help(ctx: Any) -> None:
     """
     Print help and exit
     """
@@ -64,7 +64,7 @@ def zeth(
     if ctx.invoked_subcommand == "help":
         ctx.invoke(help)
     ctx.ensure_object(dict)
-    ctx.obj = ClientContext(
+    ctx.obj = ClientConfig(
         eth_rpc_endpoint=eth_rpc,
         prover_server_endpoint=prover_server,
         instance_file=instance_file,

--- a/pyClient/commands/zeth
+++ b/pyClient/commands/zeth
@@ -4,9 +4,8 @@
 #
 # SPDX-License-Identifier: LGPL-3.0+
 
-from zeth.zksnark import get_zksnark_provider
 from commands.constants import \
-    ZKSNARK_DEFAULT, PROVER_SERVER_ENDPOINT_DEFAULT, INSTANCE_FILE_DEFAULT, \
+    PROVER_SERVER_ENDPOINT_DEFAULT, INSTANCE_FILE_DEFAULT, \
     ADDRESS_FILE_DEFAULT, WALLET_DIR_DEFAULT, ETH_RPC_ENDPOINT_DEFAULT
 from commands.utils import ClientContext
 from commands.zeth_deploy import deploy
@@ -43,11 +42,6 @@ def help(ctx) -> None:
     default=PROVER_SERVER_ENDPOINT_DEFAULT,
     help=f"Prover server endpoint (default={PROVER_SERVER_ENDPOINT_DEFAULT})")
 @option(
-    "--zksnark",
-    "zksnark_name",
-    default=ZKSNARK_DEFAULT,
-    help="GROTH16 or PGHR13 (default=GROTH16)")
-@option(
     "--instance-file",
     default=INSTANCE_FILE_DEFAULT,
     help=f"Instance file (default={INSTANCE_FILE_DEFAULT})")
@@ -64,7 +58,6 @@ def zeth(
         ctx: Context,
         eth_rpc: Optional[str],
         prover_server: str,
-        zksnark_name: str,
         instance_file: str,
         address_file: str,
         wallet_dir: str) -> None:
@@ -74,7 +67,6 @@ def zeth(
     ctx.obj = ClientContext(
         eth_rpc_endpoint=eth_rpc,
         prover_server_endpoint=prover_server,
-        zksnark_name=zksnark_name,
         instance_file=instance_file,
         address_file=address_file,
         wallet_dir=wallet_dir)

--- a/pyClient/commands/zeth
+++ b/pyClient/commands/zeth
@@ -22,7 +22,7 @@ from typing import Optional, Any
 
 @command()
 @pass_context
-def help(ctx: Any) -> None:
+def help(ctx: Context) -> None:
     """
     Print help and exit
     """

--- a/pyClient/commands/zeth
+++ b/pyClient/commands/zeth
@@ -5,10 +5,10 @@
 # SPDX-License-Identifier: LGPL-3.0+
 
 from zeth.zksnark import get_zksnark_provider
-from zeth.prover_client import ProverClient
 from commands.constants import \
     ZKSNARK_DEFAULT, PROVER_SERVER_ENDPOINT_DEFAULT, INSTANCE_FILE_DEFAULT, \
     ADDRESS_FILE_DEFAULT, WALLET_DIR_DEFAULT, ETH_RPC_ENDPOINT_DEFAULT
+from commands.utils import ClientContext
 from commands.zeth_deploy import deploy
 from commands.zeth_gen_address import gen_address
 from commands.zeth_sync import sync
@@ -71,12 +71,13 @@ def zeth(
     if ctx.invoked_subcommand == "help":
         ctx.invoke(help)
     ctx.ensure_object(dict)
-    ctx.obj["ETH_RPC"] = eth_rpc
-    ctx.obj["PROVER_CLIENT"] = ProverClient(prover_server)
-    ctx.obj["ZKSNARK"] = get_zksnark_provider(zksnark_name)
-    ctx.obj["INSTANCE_FILE"] = instance_file
-    ctx.obj["ADDRESS_FILE"] = address_file
-    ctx.obj["WALLET_DIR"] = wallet_dir
+    ctx.obj = ClientContext(
+        eth_rpc_endpoint=eth_rpc,
+        prover_server_endpoint=prover_server,
+        zksnark_name=zksnark_name,
+        instance_file=instance_file,
+        address_file=address_file,
+        wallet_dir=wallet_dir)
 
 
 zeth.add_command(deploy)

--- a/pyClient/commands/zeth
+++ b/pyClient/commands/zeth
@@ -8,8 +8,7 @@ from zeth.zksnark import get_zksnark_provider
 from zeth.prover_client import ProverClient
 from commands.constants import \
     ZKSNARK_DEFAULT, PROVER_SERVER_ENDPOINT_DEFAULT, INSTANCE_FILE_DEFAULT, \
-    ADDRESS_FILE_DEFAULT, WALLET_DIR_DEFAULT, ETH_RPC_ENDPOINT_DEFAULT, \
-    MERKLE_TREE_FILE_DEFAULT
+    ADDRESS_FILE_DEFAULT, WALLET_DIR_DEFAULT, ETH_RPC_ENDPOINT_DEFAULT
 from commands.zeth_deploy import deploy
 from commands.zeth_gen_address import gen_address
 from commands.zeth_sync import sync
@@ -60,10 +59,6 @@ def help(ctx) -> None:
     "--wallet-dir",
     default=WALLET_DIR_DEFAULT,
     help=f"Wallet directory (default={WALLET_DIR_DEFAULT})")
-@option(
-    "--merkle-tree-file",
-    default=MERKLE_TREE_FILE_DEFAULT,
-    help=f"Merkle tree file (default={MERKLE_TREE_FILE_DEFAULT})")
 @pass_context
 def zeth(
         ctx: Context,
@@ -72,8 +67,7 @@ def zeth(
         zksnark_name: str,
         instance_file: str,
         address_file: str,
-        wallet_dir: str,
-        merkle_tree_file: str) -> None:
+        wallet_dir: str) -> None:
     if ctx.invoked_subcommand == "help":
         ctx.invoke(help)
     ctx.ensure_object(dict)
@@ -83,7 +77,6 @@ def zeth(
     ctx.obj["INSTANCE_FILE"] = instance_file
     ctx.obj["ADDRESS_FILE"] = address_file
     ctx.obj["WALLET_DIR"] = wallet_dir
-    ctx.obj["MERKLE_TREE_FILE"] = merkle_tree_file
 
 
 zeth.add_command(deploy)

--- a/pyClient/commands/zeth_deploy.py
+++ b/pyClient/commands/zeth_deploy.py
@@ -7,7 +7,7 @@ from commands.utils import \
     open_web3_from_ctx, get_erc20_instance_description, load_eth_address, \
     write_mixer_description, MixerDescription
 from zeth.contracts import InstanceDescription
-from zeth.joinsplit import ZethClient
+from zeth.mixer_client import MixerClient
 from zeth.utils import EtherValue
 from click import Context, command, option, pass_context
 from typing import Optional
@@ -43,7 +43,7 @@ def deploy(
     token_instance_desc = get_erc20_instance_description(token_address) \
         if token_address else None
 
-    zeth_client = ZethClient.deploy(
+    zeth_client = MixerClient.deploy(
         web3,
         client_ctx.prover_client,
         eth_address,

--- a/pyClient/commands/zeth_deploy.py
+++ b/pyClient/commands/zeth_deploy.py
@@ -45,7 +45,7 @@ def deploy(
 
     zeth_client = MixerClient.deploy(
         web3,
-        client_ctx.prover_client,
+        client_ctx.prover_server_endpoint,
         eth_address,
         token_address,
         deploy_gas_value)

--- a/pyClient/commands/zeth_deploy.py
+++ b/pyClient/commands/zeth_deploy.py
@@ -6,7 +6,6 @@ from commands.constants import INSTANCE_FILE_DEFAULT
 from commands.utils import \
     open_web3_from_ctx, get_erc20_instance_description, load_eth_address, \
     write_mixer_description, MixerDescription
-from zeth.constants import ZETH_MERKLE_TREE_DEPTH
 from zeth.contracts import InstanceDescription
 from zeth.joinsplit import ZethClient
 from zeth.utils import EtherValue
@@ -47,9 +46,7 @@ def deploy(
     zeth_client = ZethClient.deploy(
         web3,
         client_ctx.prover_client,
-        ZETH_MERKLE_TREE_DEPTH,
         eth_address,
-        client_ctx.zksnark,
         token_address,
         deploy_gas_value)
 

--- a/pyClient/commands/zeth_deploy.py
+++ b/pyClient/commands/zeth_deploy.py
@@ -8,10 +8,8 @@ from commands.utils import \
     write_mixer_description, MixerDescription
 from zeth.constants import ZETH_MERKLE_TREE_DEPTH
 from zeth.contracts import InstanceDescription
-from zeth.prover_client import ProverClient
 from zeth.joinsplit import ZethClient
 from zeth.utils import EtherValue
-from zeth.zksnark import IZKSnarkProvider
 from click import Context, command, option, pass_context
 from typing import Optional
 
@@ -35,7 +33,8 @@ def deploy(
     Deploy the zeth contracts and record the instantiation details.
     """
     eth_address = load_eth_address(eth_addr)
-    web3 = open_web3_from_ctx(ctx)
+    client_ctx = ctx.obj
+    web3 = open_web3_from_ctx(client_ctx)
     deploy_gas_value = EtherValue(deploy_gas, 'wei') if deploy_gas else None
 
     print(f"deploy: eth_address={eth_address}")
@@ -45,14 +44,12 @@ def deploy(
     token_instance_desc = get_erc20_instance_description(token_address) \
         if token_address else None
 
-    prover_client: ProverClient = ctx.obj["PROVER_CLIENT"]
-    zksnark: IZKSnarkProvider = ctx.obj["ZKSNARK"]
     zeth_client = ZethClient.deploy(
         web3,
-        prover_client,
+        client_ctx.prover_client,
         ZETH_MERKLE_TREE_DEPTH,
         eth_address,
-        zksnark,
+        client_ctx.zksnark,
         token_address,
         deploy_gas_value)
 

--- a/pyClient/commands/zeth_gen_address.py
+++ b/pyClient/commands/zeth_gen_address.py
@@ -15,7 +15,8 @@ def gen_address(ctx: Context) -> None:
     """
     Generate a new Zeth secret key and public address
     """
-    addr_file = get_zeth_address_file(ctx)
+    client_ctx = ctx.obj
+    addr_file = get_zeth_address_file(client_ctx)
     if exists(addr_file):
         raise ClickException(f"ZethAddress file {addr_file} exists")
 

--- a/pyClient/commands/zeth_gen_address.py
+++ b/pyClient/commands/zeth_gen_address.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LGPL-3.0+
 
-from zeth.joinsplit import generate_zeth_address
+from zeth.mixer_client import generate_zeth_address
 from commands.utils import get_zeth_address_file, pub_address_file, \
     write_zeth_address_secret, write_zeth_address_public
 from click import command, pass_context, ClickException, Context

--- a/pyClient/commands/zeth_gen_address.py
+++ b/pyClient/commands/zeth_gen_address.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LGPL-3.0+
 
-from zeth.mixer_client import generate_zeth_address
+from zeth.zeth_address import generate_zeth_address
 from commands.utils import get_zeth_address_file, pub_address_file, \
     write_zeth_address_secret, write_zeth_address_public
 from click import command, pass_context, ClickException, Context

--- a/pyClient/commands/zeth_ls_commits.py
+++ b/pyClient/commands/zeth_ls_commits.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: LGPL-3.0+
 
-from commands.utils import open_merkle_tree
+from commands.utils import \
+    create_zeth_client_and_mixer_desc, load_zeth_address, open_wallet
 from zeth.utils import short_commitment
 from click import Context, command, pass_context
 
@@ -13,7 +14,9 @@ def ls_commits(ctx: Context) -> None:
     """
     List all commitments in the joinsplit contract
     """
-    merkle_tree = open_merkle_tree(ctx)
+    zeth_client, _mixer_desc = create_zeth_client_and_mixer_desc(ctx)
+    zeth_address = load_zeth_address(ctx)
+    wallet = open_wallet(zeth_client.mixer_instance, zeth_address.addr_sk, ctx)
     print("COMMITMENTS:")
-    for commit in merkle_tree.get_leaves():
+    for commit in wallet.merkle_tree.get_leaves():
         print(f"  {short_commitment(commit)}")

--- a/pyClient/commands/zeth_ls_commits.py
+++ b/pyClient/commands/zeth_ls_commits.py
@@ -14,9 +14,11 @@ def ls_commits(ctx: Context) -> None:
     """
     List all commitments in the joinsplit contract
     """
-    zeth_client, _mixer_desc = create_zeth_client_and_mixer_desc(ctx)
-    zeth_address = load_zeth_address(ctx)
-    wallet = open_wallet(zeth_client.mixer_instance, zeth_address.addr_sk, ctx)
+    client_ctx = ctx.obj
+    zeth_client, _mixer_desc = create_zeth_client_and_mixer_desc(client_ctx)
+    zeth_address = load_zeth_address(client_ctx)
+    wallet = open_wallet(
+        zeth_client.mixer_instance, zeth_address.addr_sk, client_ctx)
     print("COMMITMENTS:")
     for commit in wallet.merkle_tree.get_leaves():
         print(f"  {short_commitment(commit)}")

--- a/pyClient/commands/zeth_ls_notes.py
+++ b/pyClient/commands/zeth_ls_notes.py
@@ -16,11 +16,12 @@ def ls_notes(ctx: Context, balance: bool, spent: bool) -> None:
     """
     List the set of notes owned by this wallet
     """
-    web3 = open_web3_from_ctx(ctx)
-    mixer_desc = load_mixer_description_from_ctx(ctx)
+    client_ctx = ctx.obj
+    web3 = open_web3_from_ctx(client_ctx)
+    mixer_desc = load_mixer_description_from_ctx(client_ctx)
     mixer_instance = mixer_desc.mixer.instantiate(web3)
-    js_secret = load_zeth_address_secret(ctx)
-    wallet = open_wallet(mixer_instance, js_secret, ctx)
+    js_secret = load_zeth_address_secret(client_ctx)
+    wallet = open_wallet(mixer_instance, js_secret, client_ctx)
 
     total = EtherValue(0)
     for addr, short_commit, value in wallet.note_summaries():

--- a/pyClient/commands/zeth_mix.py
+++ b/pyClient/commands/zeth_mix.py
@@ -43,9 +43,11 @@ def mix(
 
     vin_pub = EtherValue(vin)
     vout_pub = EtherValue(vout)
-    zeth_client, mixer_desc = create_zeth_client_and_mixer_desc(ctx)
-    zeth_address = load_zeth_address(ctx)
-    wallet = open_wallet(zeth_client.mixer_instance, zeth_address.addr_sk, ctx)
+    client_ctx = ctx.obj
+    zeth_client, mixer_desc = create_zeth_client_and_mixer_desc(client_ctx)
+    zeth_address = load_zeth_address(client_ctx)
+    wallet = open_wallet(
+        zeth_client.mixer_instance, zeth_address.addr_sk, client_ctx)
 
     inputs: List[Tuple[int, ZethNote]] = [
         wallet.find_note(note_id).as_input() for note_id in input_notes]

--- a/pyClient/commands/zeth_mix.py
+++ b/pyClient/commands/zeth_mix.py
@@ -5,9 +5,8 @@
 from commands.utils import create_zeth_client_and_mixer_desc, \
     load_zeth_address, open_wallet, parse_output, do_sync, load_eth_address
 from zeth.constants import JS_INPUTS, JS_OUTPUTS
-from zeth.joinsplit import ZethAddressPub
-from zeth.joinsplit import from_zeth_units
-from zeth.utils import EtherValue
+from zeth.mixer_client import ZethAddressPub
+from zeth.utils import EtherValue, from_zeth_units
 from api.util_pb2 import ZethNote
 from click import command, option, pass_context, ClickException, Context
 from typing import List, Tuple, Optional

--- a/pyClient/commands/zeth_mix.py
+++ b/pyClient/commands/zeth_mix.py
@@ -3,8 +3,7 @@
 # SPDX-License-Identifier: LGPL-3.0+
 
 from commands.utils import create_zeth_client_and_mixer_desc, \
-    load_zeth_address, open_wallet, parse_output, do_sync, load_eth_address, \
-    open_merkle_tree
+    load_zeth_address, open_wallet, parse_output, do_sync, load_eth_address
 from zeth.constants import JS_INPUTS, JS_OUTPUTS
 from zeth.joinsplit import ZethAddressPub
 from zeth.joinsplit import from_zeth_units
@@ -47,7 +46,6 @@ def mix(
     zeth_client, mixer_desc = create_zeth_client_and_mixer_desc(ctx)
     zeth_address = load_zeth_address(ctx)
     wallet = open_wallet(zeth_client.mixer_instance, zeth_address.addr_sk, ctx)
-    merkle_tree = open_merkle_tree(ctx)
 
     inputs: List[Tuple[int, ZethNote]] = [
         wallet.find_note(note_id).as_input() for note_id in input_notes]
@@ -69,7 +67,7 @@ def mix(
         tx_value = EtherValue(0)
 
     tx_hash = zeth_client.joinsplit(
-        merkle_tree,
+        wallet.merkle_tree,
         zeth_address.ownership_keypair(),
         eth_address,
         inputs,
@@ -79,6 +77,6 @@ def mix(
         tx_value)
 
     if wait:
-        do_sync(zeth_client.web3, wallet, merkle_tree, tx_hash)
+        do_sync(zeth_client.web3, wallet, tx_hash)
     else:
         print(tx_hash)

--- a/pyClient/commands/zeth_sync.py
+++ b/pyClient/commands/zeth_sync.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: LGPL-3.0+
 
 from commands.utils import open_web3_from_ctx, load_zeth_address_secret, \
-    open_wallet, do_sync, load_mixer_description_from_ctx, open_merkle_tree
+    open_wallet, do_sync, load_mixer_description_from_ctx
 from click import command, option, pass_context, Context
 from typing import Optional
 
@@ -20,6 +20,5 @@ def sync(ctx: Context, wait_tx: Optional[str]) -> None:
     mixer_instance = mixer_desc.mixer.instantiate(web3)
     js_secret = load_zeth_address_secret(ctx)
     wallet = open_wallet(mixer_instance, js_secret, ctx)
-    merkle_tree = open_merkle_tree(ctx)
-    chain_block_number = do_sync(web3, wallet, merkle_tree, wait_tx)
+    chain_block_number = do_sync(web3, wallet, wait_tx)
     print(f"SYNCED to {chain_block_number}")

--- a/pyClient/commands/zeth_sync.py
+++ b/pyClient/commands/zeth_sync.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: LGPL-3.0+
 
 from commands.utils import open_web3_from_ctx, load_zeth_address_secret, \
-    open_wallet, do_sync, load_mixer_description_from_ctx
+    open_wallet, do_sync, load_mixer_description_from_ctx, zeth_note_short_print
 from click import command, option, pass_context, Context
 from typing import Optional
 
@@ -15,10 +15,11 @@ def sync(ctx: Context, wait_tx: Optional[str]) -> None:
     """
     Attempt to retrieve new notes for the key in <key-file>
     """
-    web3 = open_web3_from_ctx(ctx)
-    mixer_desc = load_mixer_description_from_ctx(ctx)
+    client_ctx = ctx.obj
+    web3 = open_web3_from_ctx(client_ctx)
+    mixer_desc = load_mixer_description_from_ctx(client_ctx)
     mixer_instance = mixer_desc.mixer.instantiate(web3)
-    js_secret = load_zeth_address_secret(ctx)
-    wallet = open_wallet(mixer_instance, js_secret, ctx)
-    chain_block_number = do_sync(web3, wallet, wait_tx)
+    js_secret = load_zeth_address_secret(client_ctx)
+    wallet = open_wallet(mixer_instance, js_secret, client_ctx)
+    chain_block_number = do_sync(web3, wallet, wait_tx, zeth_note_short_print)
     print(f"SYNCED to {chain_block_number}")

--- a/pyClient/commands/zeth_token_approve.py
+++ b/pyClient/commands/zeth_token_approve.py
@@ -18,8 +18,9 @@ def token_approve(ctx: Context, tokens: str, eth_addr: str, wait: bool) -> None:
     """
     approve_value = EtherValue(tokens)
     eth_addr = load_eth_address(eth_addr)
-    web3 = open_web3_from_ctx(ctx)
-    mixer_desc = load_mixer_description_from_ctx(ctx)
+    client_ctx = ctx.obj
+    web3 = open_web3_from_ctx(client_ctx)
+    mixer_desc = load_mixer_description_from_ctx(client_ctx)
     if not mixer_desc.token:
         raise ClickException("no token for mixer {mixer_desc.mixer.address}")
 

--- a/pyClient/py.typed
+++ b/pyClient/py.typed
@@ -1,0 +1,5 @@
+# Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+#
+# SPDX-License-Identifier: LGPL-3.0+
+
+# Empty file, required for mypy.

--- a/pyClient/test/test_contract_base_mixer.py
+++ b/pyClient/test/test_contract_base_mixer.py
@@ -141,8 +141,8 @@ def main() -> None:
     # Ethereum addresses
     deployer_eth_address = eth.accounts[0]
 
-    prover_client = mock.open_test_prover_client()
-    zeth_client = MixerClient.deploy(web3, prover_client, deployer_eth_address)
+    zeth_client = MixerClient.deploy(
+        web3, mock.TEST_PROVER_SERVER_ENDPOINT, deployer_eth_address)
 
     mixer_instance = zeth_client.mixer_instance
 

--- a/pyClient/test/test_contract_base_mixer.py
+++ b/pyClient/test/test_contract_base_mixer.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: LGPL-3.0+
 
 from zeth.constants import JS_INPUTS, JS_OUTPUTS, PUBLIC_VALUE_LENGTH
-from zeth.joinsplit import ZethClient
+from zeth.mixer_client import MixerClient
 from typing import Any
 import test_commands.mock as mock
 
@@ -142,7 +142,7 @@ def main() -> None:
     deployer_eth_address = eth.accounts[0]
 
     prover_client = mock.open_test_prover_client()
-    zeth_client = ZethClient.deploy(web3, prover_client, deployer_eth_address)
+    zeth_client = MixerClient.deploy(web3, prover_client, deployer_eth_address)
 
     mixer_instance = zeth_client.mixer_instance
 

--- a/pyClient/test/test_contract_base_mixer.py
+++ b/pyClient/test/test_contract_base_mixer.py
@@ -4,10 +4,8 @@
 #
 # SPDX-License-Identifier: LGPL-3.0+
 
-from zeth.constants import JS_INPUTS, JS_OUTPUTS, ZETH_MERKLE_TREE_DEPTH,\
-    PUBLIC_VALUE_LENGTH
+from zeth.constants import JS_INPUTS, JS_OUTPUTS, PUBLIC_VALUE_LENGTH
 from zeth.joinsplit import ZethClient
-from zeth.zksnark import get_zksnark_provider
 from typing import Any
 import test_commands.mock as mock
 
@@ -143,14 +141,8 @@ def main() -> None:
     # Ethereum addresses
     deployer_eth_address = eth.accounts[0]
 
-    zksnark = get_zksnark_provider("GROTH16")
     prover_client = mock.open_test_prover_client()
-    zeth_client = ZethClient.deploy(
-        web3,
-        prover_client,
-        ZETH_MERKLE_TREE_DEPTH,
-        deployer_eth_address,
-        zksnark)
+    zeth_client = ZethClient.deploy(web3, prover_client, deployer_eth_address)
 
     mixer_instance = zeth_client.mixer_instance
 

--- a/pyClient/test/test_contracts.py
+++ b/pyClient/test/test_contracts.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+#
+# SPDX-License-Identifier: LGPL-3.0+
+
+"""
+Tests for zeth.contracts module
+"""
+
+from zeth.contracts import MixParameters
+from zeth.encryption import generate_encryption_keypair, encrypt
+from zeth.signing import gen_signing_keypair, sign, encode_vk_to_bytes
+from unittest import TestCase
+
+
+class TestContracts(TestCase):
+
+    def test_mix_parameters(self) -> None:
+
+        ext_proof = {
+            "a": ["1234", "2345"],
+            "b": [["3456", "4567"], ["5678", "6789"]],
+            "c": ["789a", "89ab"],
+            "inputs": [
+                "9abc",
+                "abcd",
+                "bcde",
+                "cdef",
+            ],
+        }
+        sig_keypair = gen_signing_keypair()
+        sig_vk = sig_keypair.vk
+        sig = sign(sig_keypair.sk, bytes.fromhex("00112233"))
+        receiver_enc_keypair = generate_encryption_keypair()
+        enc_keypair = generate_encryption_keypair()
+        enc_pk = enc_keypair.k_pk
+        ciphertexts = [
+            encrypt("asdf", receiver_enc_keypair.k_pk, enc_keypair.k_sk),
+            encrypt("qwer", receiver_enc_keypair.k_pk, enc_keypair.k_sk),
+        ]
+
+        mix_params = MixParameters(ext_proof, sig_vk, sig, enc_pk, ciphertexts)
+
+        mix_params_json = mix_params.to_json()
+        mix_params_2 = MixParameters.from_json(mix_params_json)
+
+        self.assertEqual(mix_params.extended_proof, mix_params_2.extended_proof)
+        self.assertEqual(
+            encode_vk_to_bytes(mix_params.signature_vk),
+            encode_vk_to_bytes(mix_params_2.signature_vk))
+        self.assertEqual(mix_params.signature, mix_params_2.signature)
+        self.assertEqual(mix_params.pk_sender, mix_params_2.pk_sender)
+        self.assertEqual(mix_params.ciphertexts, mix_params_2.ciphertexts)

--- a/pyClient/test/test_ethervalue.py
+++ b/pyClient/test/test_ethervalue.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+#
+# SPDX-License-Identifier: LGPL-3.0+
+
+from zeth.utils import EtherValue
+from unittest import TestCase
+
+
+class TestEthereValue(TestCase):
+
+    def test_conversion(self) -> None:
+        aval = EtherValue(75641320, 'wei')
+        aval_eth = aval.ether()
+        bval = EtherValue(aval_eth, 'ether')
+        self.assertEqual(aval.wei, bval.wei)
+        self.assertEqual(aval.ether(), bval.ether())
+
+    def test_equality(self) -> None:
+        aval = EtherValue(1.2)
+        aval_same = EtherValue(1.2)
+        bval = EtherValue(0.8)
+
+        self.assertEqual(aval, aval)
+        self.assertEqual(aval, aval_same)
+        self.assertNotEqual(aval, bval)
+
+    def test_arithmetic(self) -> None:
+        aval = EtherValue(1.2)
+        bval = EtherValue(0.8)
+        cval = EtherValue(0.4)
+
+        self.assertEqual(aval, bval + cval)
+        self.assertEqual(bval, aval - cval)
+
+    def test_comparison(self) -> None:
+        big = EtherValue(1.2)
+        small = EtherValue(0.8)
+        small_same = EtherValue(0.8)
+
+        self.assertTrue(small < big)
+        self.assertTrue(small <= big)
+        self.assertTrue(big > small)
+        self.assertTrue(big >= small)
+        self.assertTrue(small_same >= small)
+        self.assertTrue(small_same <= small)
+
+        self.assertFalse(small > big)
+        self.assertFalse(small >= big)
+        self.assertFalse(big < small)
+        self.assertFalse(big <= small)
+        self.assertFalse(small_same > small)
+        self.assertFalse(small_same < small)
+
+    def test_bool(self) -> None:
+        zero = EtherValue(0)
+        self.assertFalse(zero)
+        self.assertTrue(not zero)
+
+        non_zero = EtherValue(0.1)
+        self.assertTrue(non_zero)
+        self.assertFalse(not non_zero)

--- a/pyClient/test/test_joinsplit.py
+++ b/pyClient/test/test_joinsplit.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LGPL-3.0+
 
-from zeth.joinsplit import compute_commitment
+from zeth.mixer_client import compute_commitment
 from api.util_pb2 import ZethNote
 import zeth.constants as constants
 

--- a/pyClient/test/test_signing.py
+++ b/pyClient/test/test_signing.py
@@ -12,15 +12,16 @@ from os import urandom
 
 class TestSigning(TestCase):
 
+    keypair = signing.gen_signing_keypair()
+
     def test_sign_verify(self) -> None:
         """
         Test the correct signing-verification flow:
         verify(vk, sign(sk,m), m) = 1
         """
         m = sha256("clearmatics".encode()).digest()
-        keypair = signing.gen_signing_keypair()
-        sigma = signing.sign(keypair.sk, m)
-        self.assertTrue(signing.verify(keypair.vk, m, sigma))
+        sigma = signing.sign(self.keypair.sk, m)
+        self.assertTrue(signing.verify(self.keypair.vk, m, sigma))
 
         keypair2 = signing.gen_signing_keypair()
         self.assertFalse(signing.verify(keypair2.vk, m, sigma))
@@ -31,9 +32,18 @@ class TestSigning(TestCase):
         verify(vk, sign(sk,m), m) = 1
         """
         m = urandom(32)
-        keypair = signing.gen_signing_keypair()
-        sigma = signing.sign(keypair.sk, m)
-        self.assertTrue(signing.verify(keypair.vk, m, sigma))
+        sigma = signing.sign(self.keypair.sk, m)
+        self.assertTrue(signing.verify(self.keypair.vk, m, sigma))
 
         keypair2 = signing.gen_signing_keypair()
         self.assertFalse(signing.verify(keypair2.vk, m, sigma))
+
+    def test_signature_encoding(self) -> None:
+        """
+        Test encoding and decoding of signatures.
+        """
+        m = sha256("clearmatics".encode()).digest()
+        sig = signing.sign(self.keypair.sk, m)
+        sig_encoded = signing.encode_signature_to_bytes(sig)
+        sig_decoded = signing.decode_signature_from_bytes(sig_encoded)
+        self.assertEqual(sig, sig_decoded)

--- a/pyClient/test/test_zeth_constants.py
+++ b/pyClient/test/test_zeth_constants.py
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: LGPL-3.0+
 
-import zeth.utils
+import zeth.encryption as encryption
 from . import test_utils
 from unittest import TestCase
 
@@ -19,24 +19,24 @@ class TestZethConstants(TestCase):
 
         keypair_alice_bytes, keypair_bob_bytes, _ = test_utils.gen_keys_utility()
 
-        pk_alice = zeth.utils.get_public_key_from_bytes(keypair_alice_bytes[0])
-        sk_alice = zeth.utils.get_private_key_from_bytes(keypair_alice_bytes[1])
+        pk_alice = encryption.decode_encryption_public_key(keypair_alice_bytes[0])
+        sk_alice = encryption.decode_encryption_secret_key(keypair_alice_bytes[1])
 
-        pk_bob = zeth.utils.get_public_key_from_bytes(keypair_bob_bytes[0])
-        sk_bob = zeth.utils.get_private_key_from_bytes(keypair_bob_bytes[1])
+        pk_bob = encryption.decode_encryption_public_key(keypair_bob_bytes[0])
+        sk_bob = encryption.decode_encryption_secret_key(keypair_bob_bytes[1])
 
         # Subtest 1: Alice to Alice
-        ciphertext_alice_alice = zeth.utils.encrypt(message, pk_alice, sk_alice)
-        plaintext_alice_alice = zeth.utils.decrypt(
+        ciphertext_alice_alice = encryption.encrypt(message, pk_alice, sk_alice)
+        plaintext_alice_alice = encryption.decrypt(
             ciphertext_alice_alice, pk_alice, sk_alice)
         self.assertEqual(plaintext_alice_alice, message)
 
         # Subest 2: Bob to Alice
-        ciphertext_bob_alice = zeth.utils.encrypt(message, pk_alice, sk_bob)
-        plaintext_bob_alice = zeth.utils.decrypt(
+        ciphertext_bob_alice = encryption.encrypt(message, pk_alice, sk_bob)
+        plaintext_bob_alice = encryption.decrypt(
             ciphertext_bob_alice, pk_alice, sk_bob)
         self.assertEqual(plaintext_bob_alice, message)
 
-        plaintext_bob_alice = zeth.utils.decrypt(
+        plaintext_bob_alice = encryption.decrypt(
             ciphertext_bob_alice, pk_bob, sk_alice)
         self.assertEqual(plaintext_bob_alice, message)

--- a/pyClient/test_commands/mock.py
+++ b/pyClient/test_commands/mock.py
@@ -7,7 +7,6 @@
 from zeth.zeth_address import ZethAddress
 from zeth.encryption import EncryptionKeyPair
 from zeth.ownership import gen_ownership_keypair
-from zeth.prover_client import ProverClient
 from zeth.utils import get_contracts_dir, get_private_key_from_bytes, \
     get_public_key_from_bytes, open_web3
 from os.path import join
@@ -24,10 +23,6 @@ KeyStore = Dict[str, ZethAddress]
 def open_test_web3() -> Tuple[Any, Any]:
     web3 = open_web3(TEST_WEB3_PROVIDER_ENDPOINT)
     return web3, web3.eth  # pylint: disable=no-member # type: ignore
-
-
-def open_test_prover_client() -> ProverClient:
-    return ProverClient(TEST_PROVER_SERVER_ENDPOINT)
 
 
 def init_test_keystore() -> KeyStore:

--- a/pyClient/test_commands/mock.py
+++ b/pyClient/test_commands/mock.py
@@ -4,7 +4,8 @@
 #
 # SPDX-License-Identifier: LGPL-3.0+
 
-from zeth.mixer_client import EncryptionKeyPair, ZethAddress
+from zeth.zeth_address import ZethAddress
+from zeth.encryption import EncryptionKeyPair
 from zeth.ownership import gen_ownership_keypair
 from zeth.prover_client import ProverClient
 from zeth.utils import get_contracts_dir, get_private_key_from_bytes, \

--- a/pyClient/test_commands/mock.py
+++ b/pyClient/test_commands/mock.py
@@ -5,10 +5,10 @@
 # SPDX-License-Identifier: LGPL-3.0+
 
 from zeth.zeth_address import ZethAddress
-from zeth.encryption import EncryptionKeyPair
+from zeth.encryption import EncryptionKeyPair, decode_encryption_secret_key, \
+    decode_encryption_public_key
 from zeth.ownership import gen_ownership_keypair
-from zeth.utils import get_contracts_dir, get_private_key_from_bytes, \
-    get_public_key_from_bytes, open_web3
+from zeth.utils import get_contracts_dir, open_web3
 from os.path import join
 from solcx import compile_files  # type: ignore
 from typing import Dict, List, Tuple, Optional, Any
@@ -53,20 +53,20 @@ def init_test_keystore() -> KeyStore:
     # Alice credentials in the zeth abstraction
     alice_ownership = gen_ownership_keypair()
     alice_encryption = EncryptionKeyPair(
-        get_private_key_from_bytes(alice_25519_enc_private_key),
-        get_public_key_from_bytes(alice_25519_enc_public_key))
+        decode_encryption_secret_key(alice_25519_enc_private_key),
+        decode_encryption_public_key(alice_25519_enc_public_key))
 
     # Bob credentials in the zeth abstraction
     bob_ownership = gen_ownership_keypair()
     bob_encryption = EncryptionKeyPair(
-        get_private_key_from_bytes(bob_25519_enc_private_key),
-        get_public_key_from_bytes(bob_25519_enc_public_key))
+        decode_encryption_secret_key(bob_25519_enc_private_key),
+        decode_encryption_public_key(bob_25519_enc_public_key))
 
     # Charlie credentials in the zeth abstraction
     charlie_ownership = gen_ownership_keypair()
     charlie_encryption = EncryptionKeyPair(
-        get_private_key_from_bytes(charlie_25519_enc_private_key),
-        get_public_key_from_bytes(charlie_25519_enc_public_key))
+        decode_encryption_secret_key(charlie_25519_enc_private_key),
+        decode_encryption_public_key(charlie_25519_enc_public_key))
 
     return {
         "Alice": ZethAddress.from_key_pairs(

--- a/pyClient/test_commands/mock.py
+++ b/pyClient/test_commands/mock.py
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: LGPL-3.0+
 
-from zeth.joinsplit import EncryptionKeyPair, ZethAddress
+from zeth.mixer_client import EncryptionKeyPair, ZethAddress
 from zeth.ownership import gen_ownership_keypair
 from zeth.prover_client import ProverClient
 from zeth.utils import get_contracts_dir, get_private_key_from_bytes, \

--- a/pyClient/test_commands/scenario.py
+++ b/pyClient/test_commands/scenario.py
@@ -254,8 +254,7 @@ def charlie_double_withdraw(
 
     tx_hash = zeth_client.mix(
         sender_eph_pk,
-        ciphertexts[0],
-        ciphertexts[1],
+        ciphertexts,
         proof_json,
         signing_keypair.vk,
         joinsplit_sig_charlie,
@@ -355,8 +354,7 @@ def charlie_corrupt_bob_deposit(
             proof_json)
         tx_hash = zeth_client.mix(
             sender_eph_pk,
-            fake_ciphertext0,
-            fake_ciphertext1,
+            [fake_ciphertext0, fake_ciphertext1],
             proof_json,
             joinsplit_keypair.vk,
             joinsplit_sig_charlie,
@@ -393,8 +391,7 @@ def charlie_corrupt_bob_deposit(
             proof_json)
         tx_hash = zeth_client.mix(
             sender_eph_pk,
-            fake_ciphertext0,
-            fake_ciphertext1,
+            [fake_ciphertext0, fake_ciphertext1],
             proof_json,
             new_joinsplit_keypair.vk,
             joinsplit_sig_charlie,
@@ -423,8 +420,7 @@ def charlie_corrupt_bob_deposit(
             proof_json)
         tx_hash = zeth_client.mix(
             sender_eph_pk,
-            ciphertexts[0],
-            ciphertexts[1],
+            ciphertexts,
             proof_json,
             joinsplit_keypair.vk,
             joinsplit_sig_bob,
@@ -451,8 +447,7 @@ def charlie_corrupt_bob_deposit(
         proof_json)
     tx_hash = zeth_client.mix(
         sender_eph_pk,
-        ciphertexts[0],
-        ciphertexts[1],
+        ciphertexts,
         proof_json,
         joinsplit_keypair.vk,
         joinsplit_sig_bob,

--- a/pyClient/test_commands/scenario.py
+++ b/pyClient/test_commands/scenario.py
@@ -254,12 +254,15 @@ def charlie_double_withdraw(
         ciphertexts,
         proof_json)
 
-    tx_hash = zeth_client.mix(
-        sender_eph_pk,
-        ciphertexts,
+    mix_params = contracts.MixParameters(
         proof_json,
         signing_keypair.vk,
         joinsplit_sig_charlie,
+        sender_eph_pk,
+        ciphertexts)
+
+    tx_hash = zeth_client.mix(
+        mix_params,
         charlie_eth_address,
         # Pay an arbitrary amount (1 wei here) that will be refunded since the
         # `mix` function is payable
@@ -354,12 +357,15 @@ def charlie_corrupt_bob_deposit(
             sender_eph_pk,
             ciphertexts,
             proof_json)
-        tx_hash = zeth_client.mix(
-            sender_eph_pk,
-            [fake_ciphertext0, fake_ciphertext1],
+
+        mix_params = contracts.MixParameters(
             proof_json,
             joinsplit_keypair.vk,
             joinsplit_sig_charlie,
+            sender_eph_pk,
+            [fake_ciphertext0, fake_ciphertext1])
+        tx_hash = zeth_client.mix(
+            mix_params,
             charlie_eth_address,
             Web3.toWei(BOB_DEPOSIT_ETH, 'ether'),
             DEFAULT_MIX_GAS_WEI)
@@ -391,12 +397,14 @@ def charlie_corrupt_bob_deposit(
             sender_eph_pk,
             [fake_ciphertext0, fake_ciphertext1],
             proof_json)
-        tx_hash = zeth_client.mix(
-            sender_eph_pk,
-            [fake_ciphertext0, fake_ciphertext1],
+        mix_params = contracts.MixParameters(
             proof_json,
             new_joinsplit_keypair.vk,
             joinsplit_sig_charlie,
+            sender_eph_pk,
+            [fake_ciphertext0, fake_ciphertext1])
+        tx_hash = zeth_client.mix(
+            mix_params,
             charlie_eth_address,
             Web3.toWei(BOB_DEPOSIT_ETH, 'ether'),
             DEFAULT_MIX_GAS_WEI)
@@ -420,12 +428,14 @@ def charlie_corrupt_bob_deposit(
             sender_eph_pk,
             ciphertexts,
             proof_json)
-        tx_hash = zeth_client.mix(
-            sender_eph_pk,
-            ciphertexts,
+        mix_params = contracts.MixParameters(
             proof_json,
             joinsplit_keypair.vk,
             joinsplit_sig_bob,
+            sender_eph_pk,
+            ciphertexts)
+        tx_hash = zeth_client.mix(
+            mix_params,
             charlie_eth_address,
             Web3.toWei(BOB_DEPOSIT_ETH, 'ether'),
             4000000)
@@ -447,12 +457,14 @@ def charlie_corrupt_bob_deposit(
         sender_eph_pk,
         ciphertexts,
         proof_json)
-    tx_hash = zeth_client.mix(
-        sender_eph_pk,
-        ciphertexts,
+    mix_params = contracts.MixParameters(
         proof_json,
         joinsplit_keypair.vk,
         joinsplit_sig_bob,
+        sender_eph_pk,
+        ciphertexts)
+    tx_hash = zeth_client.mix(
+        mix_params,
         bob_eth_address,
         Web3.toWei(BOB_DEPOSIT_ETH, 'ether'),
         DEFAULT_MIX_GAS_WEI)

--- a/pyClient/test_commands/test_erc_token_mixing.py
+++ b/pyClient/test_commands/test_erc_token_mixing.py
@@ -4,13 +4,12 @@
 #
 # SPDX-License-Identifier: LGPL-3.0+
 
-import zeth.joinsplit
 import zeth.merkle_tree
 import zeth.utils
 import zeth.constants as constants
 from zeth.contracts import MixOutputEvents
 from zeth.encryption import EncryptionPublicKey
-from zeth.joinsplit import ZethAddressPriv
+from zeth.mixer_client import MixerClient, ZethAddressPriv
 from zeth.wallet import Wallet, ZethNoteDescription
 import test_commands.mock as mock
 import test_commands.scenario as scenario
@@ -75,7 +74,7 @@ def main() -> None:
 
     # Deploy Zeth contracts
     tree_depth = constants.ZETH_MERKLE_TREE_DEPTH
-    zeth_client = zeth.joinsplit.ZethClient.deploy(
+    zeth_client = MixerClient.deploy(
         web3,
         prover_client,
         deployer_eth_address,

--- a/pyClient/test_commands/test_erc_token_mixing.py
+++ b/pyClient/test_commands/test_erc_token_mixing.py
@@ -7,15 +7,20 @@
 import zeth.joinsplit
 import zeth.merkle_tree
 import zeth.zksnark
-from zeth.wallet import Wallet
 import zeth.utils
 import zeth.constants as constants
+from zeth.contracts import MixOutputEvents
+from zeth.encryption import EncryptionPublicKey
+from zeth.joinsplit import ZethAddressPriv
+from zeth.wallet import Wallet, ZethNoteDescription
 import test_commands.mock as mock
 import test_commands.scenario as scenario
 from test_commands.deploy_test_token import deploy_token, mint_token
 import os
+from os.path import join, exists
+import shutil
 from web3 import Web3  # type: ignore
-from typing import Any
+from typing import Dict, List, Any
 
 
 def print_token_balances(
@@ -79,16 +84,38 @@ def main() -> None:
         zksnark,
         token_instance.address)
     mk_tree = zeth.merkle_tree.MerkleTree.empty_with_depth(tree_depth)
+    mixer_instance = zeth_client.mixer_instance
 
     # Keys and wallets
+    def _mk_wallet(name: str, sk: ZethAddressPriv) -> Wallet:
+        wallet_dir = join(coinstore_dir, name + "-erc")
+        if exists(wallet_dir):
+            shutil.rmtree(wallet_dir)
+        return Wallet(mixer_instance, name, wallet_dir, sk)
     sk_alice = keystore["Alice"].addr_sk
     sk_bob = keystore["Bob"].addr_sk
     sk_charlie = keystore["Charlie"].addr_sk
+    alice_wallet = _mk_wallet('alice', sk_alice)
+    bob_wallet = _mk_wallet('bob', sk_bob)
+    charlie_wallet = _mk_wallet('charlie', sk_charlie)
+    block_num = 1
 
-    mixer_instance = zeth_client.mixer_instance
-    alice_wallet = Wallet(mixer_instance, "alice", coinstore_dir, sk_alice)
-    bob_wallet = Wallet(mixer_instance, "bob", coinstore_dir, sk_bob)
-    charlie_wallet = Wallet(mixer_instance, "charlie", coinstore_dir, sk_charlie)
+    # Universal update function
+    def _receive_notes(
+            out_ev: List[MixOutputEvents],
+            sender_k_pk: EncryptionPublicKey) \
+            -> Dict[str, List[ZethNoteDescription]]:
+        nonlocal block_num
+        notes = {
+            'alice': alice_wallet.receive_notes(out_ev, sender_k_pk),
+            'bob': bob_wallet.receive_notes(out_ev, sender_k_pk),
+            'charlie': charlie_wallet.receive_notes(out_ev, sender_k_pk),
+        }
+        alice_wallet.update_and_save_state(block_num)
+        bob_wallet.update_and_save_state(block_num)
+        charlie_wallet.update_and_save_state(block_num)
+        block_num = block_num + 1
+        return notes
 
     print("[INFO] 4. Running tests (asset mixed: ERC20 token)...")
     # We assign ETHToken to Bob
@@ -150,9 +177,10 @@ def main() -> None:
 
     # Alice sees a deposit and tries to decrypt the ciphertexts to see if she
     # was the recipient, but Bob was the recipient so Alice fails to decrypt
-    recovered_notes_alice = alice_wallet.receive_notes(
+    received_notes = _receive_notes(
         result_deposit_bob_to_bob.output_events,
         result_deposit_bob_to_bob.sender_k_pk)
+    recovered_notes_alice = received_notes['alice']
     assert(len(recovered_notes_alice) == 0), \
         "Alice decrypted a ciphertext that was not encrypted with her key!"
 
@@ -160,14 +188,10 @@ def main() -> None:
 
     # Bob decrypts one of the note he previously received (useless here but
     # useful if the payment came from someone else)
-    recovered_notes_bob = bob_wallet.receive_notes(
-        result_deposit_bob_to_bob.output_events,
-        result_deposit_bob_to_bob.sender_k_pk)
+    recovered_notes_bob = received_notes['bob']
     assert(len(recovered_notes_bob) == 2), \
         f"Bob recovered {len(recovered_notes_bob)} notes from deposit, expected 2"
     input_bob_to_charlie = recovered_notes_bob[0].as_input()
-    assert input_bob_to_charlie[0] == \
-        result_deposit_bob_to_bob.output_events[0].commitment_address
 
     # Execution of the transfer
     result_transfer_bob_to_charlie = scenario.bob_to_charlie(
@@ -200,13 +224,12 @@ def main() -> None:
     )
 
     # Charlie tries to decrypt the notes from Bob's previous transaction.
-    note_descs_charlie = charlie_wallet.receive_notes(
+    received_notes = _receive_notes(
         result_transfer_bob_to_charlie.output_events,
         result_transfer_bob_to_charlie.sender_k_pk)
+    note_descs_charlie = received_notes['charlie']
     assert(len(note_descs_charlie) == 1), \
         f"Charlie decrypted {len(note_descs_charlie)}.  Expected 1!"
-    assert note_descs_charlie[0].address == \
-        result_transfer_bob_to_charlie.output_events[1].commitment_address
 
     _ = scenario.charlie_withdraw(
         zeth_client,
@@ -274,9 +297,10 @@ def main() -> None:
 
     # Bob decrypts one of the note he previously received (should fail if
     # Charlie's attack succeeded)
-    recovered_notes_bob = bob_wallet.receive_notes(
+    received_notes = _receive_notes(
         result_deposit_bob_to_bob.output_events,
         result_deposit_bob_to_bob.sender_k_pk)
+    recovered_notes_bob = received_notes['bob']
     assert(len(recovered_notes_bob) == 2), \
         f"Bob recovered {len(recovered_notes_bob)} notes from deposit, expected 2"
 

--- a/pyClient/test_commands/test_erc_token_mixing.py
+++ b/pyClient/test_commands/test_erc_token_mixing.py
@@ -66,8 +66,6 @@ def main() -> None:
     # Zeth addresses
     keystore = mock.init_test_keystore()
 
-    prover_client = mock.open_test_prover_client()
-
     coinstore_dir = os.environ['ZETH_COINSTORE']
 
     # Deploy the token contract
@@ -77,7 +75,7 @@ def main() -> None:
     tree_depth = constants.ZETH_MERKLE_TREE_DEPTH
     zeth_client = MixerClient.deploy(
         web3,
-        prover_client,
+        mock.TEST_PROVER_SERVER_ENDPOINT,
         deployer_eth_address,
         token_instance.address,
         None,

--- a/pyClient/test_commands/test_erc_token_mixing.py
+++ b/pyClient/test_commands/test_erc_token_mixing.py
@@ -6,7 +6,6 @@
 
 import zeth.joinsplit
 import zeth.merkle_tree
-import zeth.zksnark
 import zeth.utils
 import zeth.constants as constants
 from zeth.contracts import MixOutputEvents
@@ -79,10 +78,10 @@ def main() -> None:
     zeth_client = zeth.joinsplit.ZethClient.deploy(
         web3,
         prover_client,
-        tree_depth,
         deployer_eth_address,
-        zksnark,
-        token_instance.address)
+        token_instance.address,
+        None,
+        zksnark)
     mk_tree = zeth.merkle_tree.MerkleTree.empty_with_depth(tree_depth)
     mixer_instance = zeth_client.mixer_instance
 

--- a/pyClient/test_commands/test_erc_token_mixing.py
+++ b/pyClient/test_commands/test_erc_token_mixing.py
@@ -7,9 +7,10 @@
 import zeth.merkle_tree
 import zeth.utils
 import zeth.constants as constants
+from zeth.zeth_address import ZethAddressPriv
 from zeth.contracts import MixOutputEvents
 from zeth.encryption import EncryptionPublicKey
-from zeth.mixer_client import MixerClient, ZethAddressPriv
+from zeth.mixer_client import MixerClient
 from zeth.wallet import Wallet, ZethNoteDescription
 import test_commands.mock as mock
 import test_commands.scenario as scenario

--- a/pyClient/test_commands/test_erc_token_mixing.py
+++ b/pyClient/test_commands/test_erc_token_mixing.py
@@ -66,7 +66,7 @@ def main() -> None:
     # Zeth addresses
     keystore = mock.init_test_keystore()
 
-    coinstore_dir = os.environ['ZETH_COINSTORE']
+    notestore_dir = os.environ['ZETH_NOTESTORE']
 
     # Deploy the token contract
     token_instance = deploy_token(eth, deployer_eth_address, 4000000)
@@ -85,7 +85,7 @@ def main() -> None:
 
     # Keys and wallets
     def _mk_wallet(name: str, sk: ZethAddressPriv) -> Wallet:
-        wallet_dir = join(coinstore_dir, name + "-erc")
+        wallet_dir = join(notestore_dir, name + "-erc")
         if exists(wallet_dir):
             shutil.rmtree(wallet_dir)
         return Wallet(mixer_instance, name, wallet_dir, sk)

--- a/pyClient/test_commands/test_erc_token_mixing.py
+++ b/pyClient/test_commands/test_erc_token_mixing.py
@@ -87,6 +87,8 @@ def main() -> None:
     def _mk_wallet(name: str, sk: ZethAddressPriv) -> Wallet:
         wallet_dir = join(notestore_dir, name + "-erc")
         if exists(wallet_dir):
+            # Note: symlink-attack resistance
+            #   https://docs.python.org/3/library/shutil.html#shutil.rmtree.avoids_symlink_attacks
             shutil.rmtree(wallet_dir)
         return Wallet(mixer_instance, name, wallet_dir, sk)
     sk_alice = keystore["Alice"].addr_sk

--- a/pyClient/test_commands/test_ether_mixing.py
+++ b/pyClient/test_commands/test_ether_mixing.py
@@ -53,6 +53,12 @@ def main() -> None:
         tree_depth,
         deployer_eth_address,
         zksnark)
+
+    # Set up Merkle tree and Wallets. Note that each wallet holds an internal
+    # Merkle Tree, unused in this test. Instead, we instantiate an in-memory
+    # version shared by all virtual users. This avoids having to pass all mix
+    # results to all wallets.
+
     mk_tree = zeth.merkle_tree.MerkleTree.empty_with_depth(tree_depth)
 
     # Keys and wallets

--- a/pyClient/test_commands/test_ether_mixing.py
+++ b/pyClient/test_commands/test_ether_mixing.py
@@ -9,9 +9,10 @@ import zeth.contracts
 import zeth.merkle_tree
 import zeth.utils
 import zeth.zksnark
+from zeth.zeth_address import ZethAddressPriv
 from zeth.contracts import MixOutputEvents
 from zeth.encryption import EncryptionPublicKey
-from zeth.mixer_client import ZethAddressPriv, MixerClient
+from zeth.mixer_client import MixerClient
 from zeth.wallet import Wallet, ZethNoteDescription
 import test_commands.mock as mock
 import test_commands.scenario as scenario

--- a/pyClient/test_commands/test_ether_mixing.py
+++ b/pyClient/test_commands/test_ether_mixing.py
@@ -46,7 +46,7 @@ def main() -> None:
     alice_eth_address = eth.accounts[2]
     charlie_eth_address = eth.accounts[3]
 
-    coinstore_dir = os.environ['ZETH_COINSTORE']
+    notestore_dir = os.environ['ZETH_NOTESTORE']
 
     # Deploy Zeth contracts
     tree_depth = zeth.constants.ZETH_MERKLE_TREE_DEPTH
@@ -68,7 +68,7 @@ def main() -> None:
 
     # Keys and wallets
     def _mk_wallet(name: str, sk: ZethAddressPriv) -> Wallet:
-        wallet_dir = join(coinstore_dir, name + "-eth")
+        wallet_dir = join(notestore_dir, name + "-eth")
         if exists(wallet_dir):
             shutil.rmtree(wallet_dir)
         return Wallet(mixer_instance, name, wallet_dir, sk)

--- a/pyClient/test_commands/test_ether_mixing.py
+++ b/pyClient/test_commands/test_ether_mixing.py
@@ -4,15 +4,14 @@
 #
 # SPDX-License-Identifier: LGPL-3.0+
 
+import zeth.constants
 import zeth.contracts
-import zeth.joinsplit
 import zeth.merkle_tree
-import zeth.zksnark
 import zeth.utils
-import zeth.constants as constants
+import zeth.zksnark
 from zeth.contracts import MixOutputEvents
 from zeth.encryption import EncryptionPublicKey
-from zeth.joinsplit import ZethAddressPriv
+from zeth.mixer_client import ZethAddressPriv, MixerClient
 from zeth.wallet import Wallet, ZethNoteDescription
 import test_commands.mock as mock
 import test_commands.scenario as scenario
@@ -51,8 +50,8 @@ def main() -> None:
     coinstore_dir = os.environ['ZETH_COINSTORE']
 
     # Deploy Zeth contracts
-    tree_depth = constants.ZETH_MERKLE_TREE_DEPTH
-    zeth_client = zeth.joinsplit.ZethClient.deploy(
+    tree_depth = zeth.constants.ZETH_MERKLE_TREE_DEPTH
+    zeth_client = MixerClient.deploy(
         web3,
         prover_client,
         deployer_eth_address,

--- a/pyClient/test_commands/test_ether_mixing.py
+++ b/pyClient/test_commands/test_ether_mixing.py
@@ -10,12 +10,17 @@ import zeth.merkle_tree
 import zeth.zksnark
 import zeth.utils
 import zeth.constants as constants
+from zeth.contracts import MixOutputEvents
+from zeth.encryption import EncryptionPublicKey
+from zeth.joinsplit import ZethAddressPriv
+from zeth.wallet import Wallet, ZethNoteDescription
 import test_commands.mock as mock
 import test_commands.scenario as scenario
-from zeth.wallet import Wallet
 
 import os
-from typing import Any
+from os.path import join, exists
+import shutil
+from typing import Dict, List, Any
 # from web3 import Web3, HTTPProvider  # type: ignore
 
 
@@ -55,21 +60,43 @@ def main() -> None:
         zksnark)
 
     # Set up Merkle tree and Wallets. Note that each wallet holds an internal
-    # Merkle Tree, unused in this test. Instead, we instantiate an in-memory
-    # version shared by all virtual users. This avoids having to pass all mix
-    # results to all wallets.
-
+    # Merkle Tree, unused in this test. Instead, we keep an in-memory version
+    # shared by all virtual users. This avoids having to pass all mix results
+    # to all wallets, and allows some of the methods in the scenario module,
+    # which must update the tree directly.
     mk_tree = zeth.merkle_tree.MerkleTree.empty_with_depth(tree_depth)
+    mixer_instance = zeth_client.mixer_instance
 
     # Keys and wallets
-    sk_alice = keystore["Alice"].addr_sk
-    sk_bob = keystore["Bob"].addr_sk
-    sk_charlie = keystore["Charlie"].addr_sk
+    def _mk_wallet(name: str, sk: ZethAddressPriv) -> Wallet:
+        wallet_dir = join(coinstore_dir, name + "-eth")
+        if exists(wallet_dir):
+            shutil.rmtree(wallet_dir)
+        return Wallet(mixer_instance, name, wallet_dir, sk)
+    sk_alice = keystore['Alice'].addr_sk
+    sk_bob = keystore['Bob'].addr_sk
+    sk_charlie = keystore['Charlie'].addr_sk
+    alice_wallet = _mk_wallet('alice', sk_alice)
+    bob_wallet = _mk_wallet('bob', sk_bob)
+    charlie_wallet = _mk_wallet('charlie', sk_charlie)
+    block_num = 1
 
-    mixer_instance = zeth_client.mixer_instance
-    alice_wallet = Wallet(mixer_instance, "alice", coinstore_dir, sk_alice)
-    bob_wallet = Wallet(mixer_instance, "bob", coinstore_dir, sk_bob)
-    charlie_wallet = Wallet(mixer_instance, "charlie", coinstore_dir, sk_charlie)
+    # Universal update function
+    def _receive_notes(
+            out_ev: List[MixOutputEvents],
+            sender_k_pk: EncryptionPublicKey) \
+            -> Dict[str, List[ZethNoteDescription]]:
+        nonlocal block_num
+        notes = {
+            'alice': alice_wallet.receive_notes(out_ev, sender_k_pk),
+            'bob': bob_wallet.receive_notes(out_ev, sender_k_pk),
+            'charlie': charlie_wallet.receive_notes(out_ev, sender_k_pk),
+        }
+        alice_wallet.update_and_save_state(block_num)
+        bob_wallet.update_and_save_state(block_num)
+        charlie_wallet.update_and_save_state(block_num)
+        block_num = block_num + 1
+        return notes
 
     print("[INFO] 4. Running tests (asset mixed: Ether)...")
     print("- Initial balances: ")
@@ -99,27 +126,24 @@ def main() -> None:
     # Alice sees a deposit and tries to decrypt the ciphertexts to see if she
     # was the recipient but she wasn't the recipient (Bob was), so she fails to
     # decrypt
-    recovered_notes_alice = alice_wallet.receive_notes(
+    recovered_notes = _receive_notes(
         result_deposit_bob_to_bob.output_events,
         result_deposit_bob_to_bob.sender_k_pk)
-    assert(len(recovered_notes_alice) == 0), \
+    assert(len(recovered_notes['alice']) == 0), \
         "Alice decrypted a ciphertext that was not encrypted with her key!"
 
     # Bob does a transfer to Charlie on the mixer
 
     # Bob decrypts one of the note he previously received (useless here but
     # useful if the payment came from someone else)
-    recovered_notes_bob = bob_wallet.receive_notes(
-        result_deposit_bob_to_bob.output_events,
-        result_deposit_bob_to_bob.sender_k_pk)
-    assert(len(recovered_notes_bob) == 2), \
-        f"Bob recovered {len(recovered_notes_bob)} notes from deposit, expected 2"
+    assert(len(recovered_notes['bob']) == 2), \
+        f"Bob recovered {len(recovered_notes['bob'])} notes, expected 2"
 
     # Execution of the transfer
     result_transfer_bob_to_charlie = scenario.bob_to_charlie(
         zeth_client,
         mk_tree,
-        recovered_notes_bob[0].as_input(),
+        recovered_notes['bob'][0].as_input(),
         bob_eth_address,
         keystore)
 
@@ -129,7 +153,7 @@ def main() -> None:
         result_double_spending = scenario.bob_to_charlie(
             zeth_client,
             mk_tree,
-            recovered_notes_bob[0].as_input(),
+            recovered_notes['bob'][0].as_input(),
             bob_eth_address,
             keystore)
     except Exception as e:
@@ -147,15 +171,14 @@ def main() -> None:
     )
 
     # Charlie recovers his notes and attempts to withdraw them.
-    notes_charlie = charlie_wallet.receive_notes(
+    recovered_notes = _receive_notes(
         result_transfer_bob_to_charlie.output_events,
         result_transfer_bob_to_charlie.sender_k_pk)
+    notes_charlie = recovered_notes['charlie']
     assert(len(notes_charlie) == 1), \
         f"Charlie decrypted {len(notes_charlie)}.  Expected 1!"
 
     input_charlie_withdraw = notes_charlie[0]
-    assert notes_charlie[0].address == \
-        result_transfer_bob_to_charlie.output_events[1].commitment_address
 
     _ = scenario.charlie_withdraw(
         zeth_client,
@@ -205,11 +228,11 @@ def main() -> None:
 
     # Bob decrypts one of the note he previously received (should fail if
     # Charlie's attack succeeded)
-    recovered_notes_bob = bob_wallet.receive_notes(
+    recovered_notes = _receive_notes(
         result_deposit_bob_to_bob.output_events,
         result_deposit_bob_to_bob.sender_k_pk)
-    assert(len(recovered_notes_bob) == 2), \
-        f"Bob recovered {len(recovered_notes_bob)} notes from deposit, expected 2"
+    assert(len(recovered_notes['bob']) == 2), \
+        f"Bob recovered {len(recovered_notes['bob'])} notes, expected 2"
 
     print("- Balances after Bob's last deposit: ")
     print_balances(

--- a/pyClient/test_commands/test_ether_mixing.py
+++ b/pyClient/test_commands/test_ether_mixing.py
@@ -55,8 +55,9 @@ def main() -> None:
     zeth_client = zeth.joinsplit.ZethClient.deploy(
         web3,
         prover_client,
-        tree_depth,
         deployer_eth_address,
+        None,
+        None,
         zksnark)
 
     # Set up Merkle tree and Wallets. Note that each wallet holds an internal

--- a/pyClient/test_commands/test_ether_mixing.py
+++ b/pyClient/test_commands/test_ether_mixing.py
@@ -70,6 +70,8 @@ def main() -> None:
     def _mk_wallet(name: str, sk: ZethAddressPriv) -> Wallet:
         wallet_dir = join(notestore_dir, name + "-eth")
         if exists(wallet_dir):
+            # Note: symlink-attack resistance
+            #   https://docs.python.org/3/library/shutil.html#shutil.rmtree.avoids_symlink_attacks
             shutil.rmtree(wallet_dir)
         return Wallet(mixer_instance, name, wallet_dir, sk)
     sk_alice = keystore['Alice'].addr_sk

--- a/pyClient/test_commands/test_ether_mixing.py
+++ b/pyClient/test_commands/test_ether_mixing.py
@@ -46,15 +46,13 @@ def main() -> None:
     alice_eth_address = eth.accounts[2]
     charlie_eth_address = eth.accounts[3]
 
-    prover_client = mock.open_test_prover_client()
-
     coinstore_dir = os.environ['ZETH_COINSTORE']
 
     # Deploy Zeth contracts
     tree_depth = zeth.constants.ZETH_MERKLE_TREE_DEPTH
     zeth_client = MixerClient.deploy(
         web3,
-        prover_client,
+        mock.TEST_PROVER_SERVER_ENDPOINT,
         deployer_eth_address,
         None,
         None,

--- a/pyClient/zeth/constants.py
+++ b/pyClient/zeth/constants.py
@@ -54,3 +54,9 @@ SOL_COMPILER_VERSION = 'v0.5.16'
 
 # Seed for MIMC
 MIMC_MT_SEED: str = "clearmatics_mt_seed"
+
+# Units for vpub_in and vpub_out, given in Wei. i.e.
+#   Value (in Wei) = vpub_{in,out} * ZETH_PUBLIC_UNIT_VALUE
+ZETH_PUBLIC_UNIT_VALUE = 1000000000000  # 1 Szabo (10^12 Wei).
+
+COMMITMENT_VALUE_PADDING = bytes(int(192/8))

--- a/pyClient/zeth/constants.py
+++ b/pyClient/zeth/constants.py
@@ -17,6 +17,9 @@ PGHR13_MIXER_CONTRACT: str = "Pghr13Mixer"
 # Set of valid snarks
 VALID_ZKSNARKS: List[str] = [GROTH16_ZKSNARK, PGHR13_ZKSNARK]
 
+# Default zk-snark
+ZKSNARK_DEFAULT = GROTH16_ZKSNARK
+
 # Merkle tree depth
 ZETH_MERKLE_TREE_DEPTH: int = 32
 

--- a/pyClient/zeth/constants.py
+++ b/pyClient/zeth/constants.py
@@ -49,6 +49,31 @@ DIGEST_LENGTH: int = 256
 # Public value length (v_pub_in and v_pub_out)
 PUBLIC_VALUE_LENGTH: int = 64
 
+# Number of residual bits when encoding digests into field values
+DIGEST_RESIDUAL_BITS = max(0, DIGEST_LENGTH - FIELD_CAPACITY)
+
+# Bits per public value (embedded into the 'residual bits" public input)
+PUBLIC_VALUE_BITS = 64
+PUBLIC_VALUE_BYTES = PUBLIC_VALUE_BITS >> 3
+PUBLIC_VALUE_MASK = (1 << PUBLIC_VALUE_BITS) - 1
+
+# Public inputs are (see BaseMixer.sol):
+#   [0                 ] - 1     x merkle root
+#   [1                 ] - jsOut x commitment
+#   [1 + jsOut         ] - jsIn  x nullifier (partial)
+#   [1 + jsOut + jsIn  ] - 1     x hsig (partial)
+#   [2 + jsOut + jsIn  ] - JsIn  x message auth tags (partial)
+#   [2 + jsOut + 2*jsIn] - 1     x residual bits, v_in, v_out
+
+# Index (in public inputs) of residual bits
+RESIDUAL_BITS_INDEX = (2 * JS_INPUTS) + JS_OUTPUTS + 2
+
+# Number of full-length digests to be encoded in public inputs
+NUM_INPUT_DIGESTS = (2 * JS_INPUTS) + 1
+
+# Total number of residual bits corresponding to digests in public inputs
+TOTAL_DIGEST_RESIDUAL_BITS = NUM_INPUT_DIGESTS * DIGEST_RESIDUAL_BITS
+
 # Solidity compiler version
 SOL_COMPILER_VERSION = 'v0.5.16'
 

--- a/pyClient/zeth/contracts.py
+++ b/pyClient/zeth/contracts.py
@@ -169,8 +169,7 @@ def deploy_tree_contract(
 def mix(
         mixer_instance: Any,
         pk_sender: EncryptionPublicKey,
-        ciphertext1: bytes,
-        ciphertext2: bytes,
+        ciphertexts: List[bytes],
         parsed_proof: GenericProof,
         vk: SigningVerificationKey,
         sigma: int,
@@ -191,8 +190,7 @@ def mix(
         sigma,
         inputs,
         pk_sender_encoded,
-        ciphertext1,
-        ciphertext2,
+        ciphertexts
     ).transact({'from': sender_address, 'value': wei_pub_value, 'gas': call_gas})
     return tx_hash.hex()
 

--- a/pyClient/zeth/contracts.py
+++ b/pyClient/zeth/contracts.py
@@ -6,12 +6,15 @@
 
 from __future__ import annotations
 from zeth.encryption import EncryptionPublicKey, encode_encryption_public_key
-from zeth.signing import SigningVerificationKey
+from zeth.signing import SigningVerificationKey, Signature, \
+    verification_key_as_mix_parameter, verification_key_from_mix_parameter, \
+    signature_as_mix_parameter, signature_from_mix_parameter
 from zeth.zksnark import IZKSnarkProvider, GenericProof, GenericVerificationKey
 from zeth.utils import get_contracts_dir, hex_to_int, get_public_key_from_bytes
 from zeth.constants import SOL_COMPILER_VERSION
 
 import os
+import json
 import solcx
 from typing import Dict, List, Iterator, Optional, Any
 
@@ -19,6 +22,57 @@ from typing import Dict, List, Iterator, Optional, Any
 SYNC_BLOCKS_PER_BATCH = 10
 
 Interface = Dict[str, Any]
+
+
+class MixParameters:
+    """
+    Arguments to the mix call.
+    """
+    def __init__(
+            self,
+            extended_proof: GenericProof,
+            signature_vk: SigningVerificationKey,
+            signature: Signature,
+            pk_sender: EncryptionPublicKey,
+            ciphertexts: List[bytes]):
+        self.extended_proof = extended_proof
+        self.signature_vk = signature_vk
+        self.signature = signature
+        self.pk_sender = pk_sender
+        self.ciphertexts = ciphertexts
+
+    @staticmethod
+    def from_json(params_json: str) -> MixParameters:
+        return MixParameters._from_json_dict(json.loads(params_json))
+
+    def to_json(self) -> str:
+        return json.dumps(self._to_json_dict())
+
+    def _to_json_dict(self) -> Dict[str, Any]:
+        signature_vk_json = [
+            str(x) for x in verification_key_as_mix_parameter(self.signature_vk)]
+        signature_json = str(signature_as_mix_parameter(self.signature))
+        pk_sender_json = encode_encryption_public_key(self.pk_sender).hex()
+        ciphertexts_json = [x.hex() for x in self.ciphertexts]
+        return {
+            "extended_proof": self.extended_proof,
+            "signature_vk": signature_vk_json,
+            "signature": signature_json,
+            "pk_sender": pk_sender_json,
+            "ciphertexts": ciphertexts_json,
+        }
+
+    @staticmethod
+    def _from_json_dict(json_dict: Dict[str, Any]) -> MixParameters:
+        ext_proof = json_dict["extended_proof"]
+        signature_pk_param = [int(x) for x in json_dict["signature_vk"]]
+        signature_pk = verification_key_from_mix_parameter(signature_pk_param)
+        signature = signature_from_mix_parameter(int(json_dict["signature"]))
+        pk_sender = decode_encryption_public_key(
+            bytes.fromhex(json_dict["pk_sender"]))
+        ciphertexts = [bytes.fromhex(x) for x in json_dict["ciphertexts"]]
+        return MixParameters(
+            ext_proof, signature_pk, signature, pk_sender, ciphertexts)
 
 
 class MixOutputEvents:
@@ -177,30 +231,29 @@ def deploy_tree_contract(
 
 
 def mix(
+        zksnark: IZKSnarkProvider,
         mixer_instance: Any,
-        pk_sender: EncryptionPublicKey,
-        ciphertexts: List[bytes],
-        parsed_proof: GenericProof,
-        vk: SigningVerificationKey,
-        sigma: int,
+        mix_parameters: MixParameters,
         sender_address: str,
         wei_pub_value: int,
-        call_gas: int,
-        zksnark: IZKSnarkProvider) -> str:
+        call_gas: int) -> str:
     """
     Run the mixer
     """
-    pk_sender_encoded = encode_encryption_public_key(pk_sender)
-    proof_params = zksnark.mixer_proof_parameters(parsed_proof)
-    inputs = hex_to_int(parsed_proof["inputs"])
-
+    # Convert all params to the correct form for calling the mix method.
+    proof_param = zksnark.mixer_proof_parameters(mix_parameters.extended_proof)
+    proof_inputs_param = hex_to_int(mix_parameters.extended_proof["inputs"])
+    vk_param = verification_key_as_mix_parameter(mix_parameters.signature_vk)
+    signature_param = signature_as_mix_parameter(mix_parameters.signature)
+    pk_sender_param = encode_encryption_public_key(mix_parameters.pk_sender)
+    ciphertexts_param = mix_parameters.ciphertexts
     tx_hash = mixer_instance.functions.mix(
-        *proof_params,
-        [int(vk.ppk[0]), int(vk.ppk[1]), int(vk.spk[0]), int(vk.spk[1])],
-        sigma,
-        inputs,
-        pk_sender_encoded,
-        ciphertexts
+        *proof_param,
+        vk_param,
+        signature_param,
+        proof_inputs_param,
+        pk_sender_param,
+        ciphertexts_param
     ).transact({'from': sender_address, 'value': wei_pub_value, 'gas': call_gas})
     return tx_hash.hex()
 

--- a/pyClient/zeth/contracts.py
+++ b/pyClient/zeth/contracts.py
@@ -13,7 +13,7 @@ from zeth.constants import SOL_COMPILER_VERSION
 
 import os
 import solcx
-from typing import Tuple, Dict, List, Iterator, Optional, Any
+from typing import Dict, List, Iterator, Optional, Any
 
 # Avoid trying to read too much data into memory
 SYNC_BLOCKS_PER_BATCH = 10
@@ -124,7 +124,7 @@ def deploy_mixer(
         deployer_address: str,
         deployment_gas: int,
         token_address: str,
-        zksnark: IZKSnarkProvider) -> Tuple[Any, bytes]:
+        zksnark: IZKSnarkProvider) -> Any:
     """
     Common function to deploy a mixer contract. Returns the mixer and the
     initial merkle root of the commitment tree

--- a/pyClient/zeth/contracts.py
+++ b/pyClient/zeth/contracts.py
@@ -27,8 +27,7 @@ class MixOutputEvents:
     commitment and ciphertext.
     """
     def __init__(
-            self, commitment_address: int, commitment: bytes, ciphertext: bytes):
-        self.commitment_address = commitment_address
+            self, commitment: bytes, ciphertext: bytes):
         self.commitment = commitment
         self.ciphertext = ciphertext
 
@@ -50,9 +49,8 @@ class MixResult:
 
 
 def _event_args_to_mix_result(event_args: Any) -> MixResult:
-    mix_out_args = zip(
-        event_args.commAddrs, event_args.commitments, event_args.ciphertexts)
-    out_events = [MixOutputEvents(a, c, ciph) for (a, c, ciph) in mix_out_args]
+    mix_out_args = zip(event_args.commitments, event_args.ciphertexts)
+    out_events = [MixOutputEvents(c, ciph) for (c, ciph) in mix_out_args]
     sender_k_pk = get_public_key_from_bytes(event_args.pk_sender)
     return MixResult(
         new_merkle_root=event_args.root,
@@ -224,23 +222,6 @@ def _next_nullifier_or_none(nullifier_iter: Iterator[bytes]) -> Optional[Any]:
         return next(nullifier_iter)
     except StopIteration:
         return None
-
-
-def _next_commit_or_none(
-        commit_iter: Iterator[Optional[Any]],
-        ciphertext_iter: Iterator[Optional[Any]]
-) -> Tuple[Optional[Any], Optional[Any]]:
-    """
-    Zip the  address and ciphertext iterators.   Avoid StopIteration exceptions,
-    so the caller can rely on reading one entry ahead.
-    """
-    # Assume that the two input iterators are of the same length.
-    try:
-        addr_commit = next(commit_iter)
-    except StopIteration:
-        return None, None
-
-    return addr_commit, next(ciphertext_iter)
 
 
 def get_mix_results(

--- a/pyClient/zeth/contracts.py
+++ b/pyClient/zeth/contracts.py
@@ -5,12 +5,13 @@
 # SPDX-License-Identifier: LGPL-3.0+
 
 from __future__ import annotations
-from zeth.encryption import EncryptionPublicKey, encode_encryption_public_key
+from zeth.encryption import EncryptionPublicKey, encode_encryption_public_key, \
+    decode_encryption_public_key
 from zeth.signing import SigningVerificationKey, Signature, \
     verification_key_as_mix_parameter, verification_key_from_mix_parameter, \
     signature_as_mix_parameter, signature_from_mix_parameter
 from zeth.zksnark import IZKSnarkProvider, GenericProof, GenericVerificationKey
-from zeth.utils import get_contracts_dir, hex_to_int, get_public_key_from_bytes
+from zeth.utils import get_contracts_dir, hex_to_int
 from zeth.constants import SOL_COMPILER_VERSION
 
 import os
@@ -105,7 +106,7 @@ class MixResult:
 def _event_args_to_mix_result(event_args: Any) -> MixResult:
     mix_out_args = zip(event_args.commitments, event_args.ciphertexts)
     out_events = [MixOutputEvents(c, ciph) for (c, ciph) in mix_out_args]
-    sender_k_pk = get_public_key_from_bytes(event_args.pk_sender)
+    sender_k_pk = decode_encryption_public_key(event_args.pk_sender)
     return MixResult(
         new_merkle_root=event_args.root,
         nullifiers=event_args.nullifiers,

--- a/pyClient/zeth/encryption.py
+++ b/pyClient/zeth/encryption.py
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: LGPL-3.0+
 
-from nacl.public import PrivateKey, PublicKey  # type: ignore
+from nacl.public import PrivateKey, PublicKey, Box  # type: ignore
 import nacl.encoding  # type: ignore
 from typing import NewType
 
@@ -12,38 +12,37 @@ from typing import NewType
 # include much type information, so we try to enforce strict types.
 
 
-# Represents a PublicKey from
+# Represents a secret key for encryption
 EncryptionSecretKey = NewType('EncryptionSecretKey', object)
-
-
-# EncryptionPublicKey = PublicKey
-EncryptionPublicKey = NewType('EncryptionPublicKey', object)
-
-
-class EncryptionKeyPair:
-    """
-    Key-pair for encrypting joinsplit notes.
-    """
-    def __init__(self, k_sk: EncryptionSecretKey, k_pk: EncryptionPublicKey):
-        self.k_pk: EncryptionPublicKey = k_pk
-        self.k_sk: EncryptionSecretKey = k_sk
-
-
-def encode_encryption_public_key(pk: EncryptionPublicKey) -> bytes:
-    return pk.encode(encoder=nacl.encoding.RawEncoder)  # type: ignore
 
 
 def encode_encryption_secret_key(sk: EncryptionSecretKey) -> bytes:
     return sk.encode(encoder=nacl.encoding.RawEncoder)  # type: ignore
 
 
-def encryption_secret_key_as_hex(sk: EncryptionSecretKey) -> str:
-    return sk.encode(encoder=nacl.encoding.RawEncoder).hex()  # type: ignore
-
-
-def encryption_secret_key_from_hex(pk_str: str) -> EncryptionSecretKey:
+def decode_encryption_secret_key(sk_bytes: bytes) -> EncryptionSecretKey:
     return EncryptionSecretKey(
-        PrivateKey(bytes.fromhex(pk_str), encoder=nacl.encoding.RawEncoder))
+        PrivateKey(sk_bytes, encoder=nacl.encoding.RawEncoder))
+
+
+def encryption_secret_key_as_hex(sk: EncryptionSecretKey) -> str:
+    return encode_encryption_secret_key(sk).hex()
+
+
+def encryption_secret_key_from_hex(sk_hex: str) -> EncryptionSecretKey:
+    return decode_encryption_secret_key(bytes.fromhex(sk_hex))
+
+
+def generate_encryption_secret_key() -> EncryptionSecretKey:
+    return PrivateKey.generate()  # type: ignore
+
+
+# Public key for decryption
+EncryptionPublicKey = NewType('EncryptionPublicKey', object)
+
+
+def encode_encryption_public_key(pk: EncryptionPublicKey) -> bytes:
+    return pk.encode(encoder=nacl.encoding.RawEncoder)  # type: ignore
 
 
 def decode_encryption_public_key(pk_data: bytes) -> EncryptionPublicKey:
@@ -61,13 +60,63 @@ def encryption_public_key_from_hex(pk_str: str) -> EncryptionPublicKey:
 
 def get_encryption_public_key(
         enc_secret: EncryptionSecretKey) -> EncryptionPublicKey:
+    """
+    Derive the public key from the secret key
+    """
     return enc_secret.public_key  # type: ignore
 
 
-def generate_encryption_secret_key() -> EncryptionSecretKey:
-    return PrivateKey.generate()  # type: ignore
+class EncryptionKeyPair:
+    """
+    Key-pair for encrypting joinsplit notes.
+    """
+    def __init__(self, k_sk: EncryptionSecretKey, k_pk: EncryptionPublicKey):
+        self.k_pk: EncryptionPublicKey = k_pk
+        self.k_sk: EncryptionSecretKey = k_sk
 
 
 def generate_encryption_keypair() -> EncryptionKeyPair:
     sk = generate_encryption_secret_key()
     return EncryptionKeyPair(sk, get_encryption_public_key(sk))
+
+
+def encrypt(message: str, pk_receiver: PublicKey, sk_sender: PrivateKey) -> bytes:
+    """
+    Encrypts a string message by using valid ec25519 public key and
+    private key objects. See: https://pynacl.readthedocs.io/en/stable/public/
+    """
+    # Init encryption box instance
+    encryption_box = Box(sk_sender, pk_receiver)
+
+    # Encode str message to bytes
+    message_bytes = message.encode('utf-8')
+
+    # Encrypt the message. The nonce is chosen randomly.
+    encrypted = encryption_box.encrypt(
+        message_bytes,
+        encoder=nacl.encoding.RawEncoder)
+
+    # Need to cast to the parent class Bytes of nacl.utils.EncryptedMessage
+    # to make it accepted from `Mix` Solidity function
+    return bytes(encrypted)
+
+
+def decrypt(
+        encrypted_message: bytes,
+        pk_sender: PublicKey,
+        sk_receiver: PrivateKey) -> str:
+    """
+    Decrypts a string message by using valid ec25519 public key and private key
+    objects.  See: https://pynacl.readthedocs.io/en/stable/public/
+    """
+    assert(isinstance(pk_sender, PublicKey)), \
+        f"PublicKey: {pk_sender} ({type(pk_sender)})"
+    assert(isinstance(sk_receiver, PrivateKey)), \
+        f"PrivateKey: {sk_receiver} ({type(sk_receiver)})"
+
+    # Init encryption box instance
+    decryption_box = Box(sk_receiver, pk_sender)
+
+    # Check integrity of the ciphertext and decrypt it
+    message = decryption_box.decrypt(encrypted_message)
+    return str(message, encoding='utf-8')

--- a/pyClient/zeth/joinsplit.py
+++ b/pyClient/zeth/joinsplit.py
@@ -560,8 +560,7 @@ class ZethClient:
 
         return self.mix(
             sender_eph_pk,
-            ciphertexts[0],
-            ciphertexts[1],
+            ciphertexts,
             proof_json,
             signing_keypair.vk,
             signature,
@@ -572,8 +571,7 @@ class ZethClient:
     def mix(
             self,
             pk_sender: EncryptionPublicKey,
-            ciphertext1: bytes,
-            ciphertext2: bytes,
+            ciphertexts: List[bytes],
             parsed_proof: GenericProof,
             vk: JoinsplitSigVerificationKey,
             sigma: int,
@@ -583,8 +581,7 @@ class ZethClient:
         return contracts.mix(
             self.mixer_instance,
             pk_sender,
-            ciphertext1,
-            ciphertext2,
+            ciphertexts,
             parsed_proof,
             vk,
             sigma,

--- a/pyClient/zeth/joinsplit.py
+++ b/pyClient/zeth/joinsplit.py
@@ -659,7 +659,7 @@ def receive_note(
         out_ev: contracts.MixOutputEvents,
         sender_k_pk: EncryptionPublicKey,
         receiver_k_sk: EncryptionSecretKey
-) -> Optional[Tuple[int, bytes, ZethNote]]:
+) -> Optional[Tuple[bytes, ZethNote]]:
     """
     Given the receivers secret key, and the event data from a transaction
     (encrypted notes), decrypt any that are intended for the receiver. Return
@@ -670,7 +670,6 @@ def receive_note(
     try:
         plaintext = decrypt(out_ev.ciphertext, sender_k_pk, receiver_k_sk)
         return (
-            out_ev.commitment_address,
             out_ev.commitment,
             zeth_note_from_json_dict(json.loads(plaintext)))
     except Exception:

--- a/pyClient/zeth/mixer_client.py
+++ b/pyClient/zeth/mixer_client.py
@@ -7,14 +7,12 @@
 from __future__ import annotations
 import zeth.contracts as contracts
 import zeth.constants as constants
+from zeth.zeth_address import ZethAddressPub, ZethAddress
 from zeth.ownership import OwnershipPublicKey, OwnershipSecretKey, \
-    OwnershipKeyPair, ownership_key_as_hex, gen_ownership_keypair, \
-    ownership_public_key_from_hex, ownership_secret_key_from_hex
+    OwnershipKeyPair, ownership_key_as_hex
 from zeth.encryption import \
-    EncryptionKeyPair, EncryptionPublicKey, EncryptionSecretKey, \
-    generate_encryption_keypair, encode_encryption_public_key, \
-    encryption_public_key_as_hex, encryption_public_key_from_hex, \
-    encryption_secret_key_as_hex, encryption_secret_key_from_hex
+    EncryptionPublicKey, EncryptionSecretKey, \
+    generate_encryption_keypair, encode_encryption_public_key
 from zeth.merkle_tree import MerkleTree, compute_merkle_path
 import zeth.signing as signing
 from zeth.timer import Timer
@@ -71,104 +69,6 @@ def blake2s_compress_pad_right64(left256: bytes, right64: bytes) -> bytes:
     blake.update(constants.COMMITMENT_VALUE_PADDING)
     blake.update(right64)
     return blake.digest()
-
-
-class ZethAddressPub:
-    """
-    Public half of a zethAddress.  addr_pk = (a_pk and k_pk)
-    """
-    def __init__(self, a_pk: OwnershipPublicKey, k_pk: EncryptionPublicKey):
-        self.a_pk: OwnershipPublicKey = a_pk
-        self.k_pk: EncryptionPublicKey = k_pk
-
-    def __str__(self) -> str:
-        """
-        Write the address as "<ownership-key-hex>:<encryption_key_hex>".
-        (Technically the ":" is not required, since the first key is written
-        with fixed length, but a separator provides some limited sanity
-        checking).
-        """
-        a_pk_hex = ownership_key_as_hex(self.a_pk)
-        k_pk_hex = encryption_public_key_as_hex(self.k_pk)
-        return f"{a_pk_hex}:{k_pk_hex}"
-
-    @staticmethod
-    def parse(key_hex: str) -> ZethAddressPub:
-        owner_enc = key_hex.split(":")
-        if len(owner_enc) != 2:
-            raise Exception("invalid JoinSplitPublicKey format")
-        a_pk = ownership_public_key_from_hex(owner_enc[0])
-        k_pk = encryption_public_key_from_hex(owner_enc[1])
-        return ZethAddressPub(a_pk, k_pk)
-
-
-class ZethAddressPriv:
-    """
-    Secret addr_sk, consisting of a_sk and k_sk
-    """
-    def __init__(self, a_sk: OwnershipSecretKey, k_sk: EncryptionSecretKey):
-        self.a_sk: OwnershipSecretKey = a_sk
-        self.k_sk: EncryptionSecretKey = k_sk
-
-    def to_json(self) -> str:
-        return json.dumps(self._to_json_dict())
-
-    @staticmethod
-    def from_json(key_json: str) -> ZethAddressPriv:
-        return ZethAddressPriv._from_json_dict(json.loads(key_json))
-
-    def _to_json_dict(self) -> Dict[str, Any]:
-        return {
-            "a_sk": ownership_key_as_hex(self.a_sk),
-            "k_sk": encryption_secret_key_as_hex(self.k_sk),
-        }
-
-    @staticmethod
-    def _from_json_dict(key_dict: Dict[str, Any]) -> ZethAddressPriv:
-        return ZethAddressPriv(
-            ownership_secret_key_from_hex(key_dict["a_sk"]),
-            encryption_secret_key_from_hex(key_dict["k_sk"]))
-
-
-class ZethAddress:
-    """
-    Secret and public keys for both ownership and encryption (referrred to as
-    "zethAddress" in the paper).
-    """
-    def __init__(
-            self,
-            a_pk: OwnershipPublicKey,
-            k_pk: EncryptionPublicKey,
-            a_sk: OwnershipSecretKey,
-            k_sk: EncryptionSecretKey):
-        self.addr_pk = ZethAddressPub(a_pk, k_pk)
-        self.addr_sk = ZethAddressPriv(a_sk, k_sk)
-
-    @staticmethod
-    def from_key_pairs(
-            ownership: OwnershipKeyPair,
-            encryption: EncryptionKeyPair) -> ZethAddress:
-        return ZethAddress(
-            ownership.a_pk,
-            encryption.k_pk,
-            ownership.a_sk,
-            encryption.k_sk)
-
-    @staticmethod
-    def from_secret_public(
-            js_secret: ZethAddressPriv,
-            js_public: ZethAddressPub) -> ZethAddress:
-        return ZethAddress(
-            js_public.a_pk, js_public.k_pk, js_secret.a_sk, js_secret.k_sk)
-
-    def ownership_keypair(self) -> OwnershipKeyPair:
-        return OwnershipKeyPair(self.addr_sk.a_sk, self.addr_pk.a_pk)
-
-
-def generate_zeth_address() -> ZethAddress:
-    ownership_keypair = gen_ownership_keypair()
-    encryption_keypair = generate_encryption_keypair()
-    return ZethAddress.from_key_pairs(ownership_keypair, encryption_keypair)
 
 
 class JoinsplitInputNote:

--- a/pyClient/zeth/mixer_client.py
+++ b/pyClient/zeth/mixer_client.py
@@ -292,21 +292,21 @@ class MixerClient:
     @staticmethod
     def open(
             web3: Any,
-            prover_client: ProverClient,
+            prover_server_endpoint: str,
             mixer_instance: Any) -> MixerClient:
         """
         Create a client for an existing Zeth deployment.
         """
         return MixerClient(
             web3,
-            prover_client,
+            ProverClient(prover_server_endpoint),
             mixer_instance,
             get_zksnark_provider(constants.ZKSNARK_DEFAULT))
 
     @staticmethod
     def deploy(
             web3: Any,
-            prover_client: ProverClient,
+            prover_server_endpoint: str,
             deployer_eth_address: str,
             token_address: Optional[str] = None,
             deploy_gas: Optional[EtherValue] = None,
@@ -316,6 +316,7 @@ class MixerClient:
         """
         print("[INFO] 1. Fetching verification key from the proving server")
         zksnark = zksnark or get_zksnark_provider(constants.ZKSNARK_DEFAULT)
+        prover_client = ProverClient(prover_server_endpoint)
         vk_obj = prover_client.get_verification_key()
         vk_json = zksnark.parse_verification_key(vk_obj)
         deploy_gas = deploy_gas or \

--- a/pyClient/zeth/mixer_client.py
+++ b/pyClient/zeth/mixer_client.py
@@ -11,17 +11,16 @@ from zeth.zeth_address import ZethAddressPub, ZethAddress
 from zeth.ownership import OwnershipPublicKey, OwnershipSecretKey, \
     OwnershipKeyPair, ownership_key_as_hex
 from zeth.encryption import \
-    EncryptionPublicKey, EncryptionSecretKey, \
-    generate_encryption_keypair, encode_encryption_public_key
+    EncryptionPublicKey, EncryptionSecretKey, generate_encryption_keypair, \
+    encode_encryption_public_key, encrypt, decrypt
 from zeth.merkle_tree import MerkleTree, compute_merkle_path
 import zeth.signing as signing
 from zeth.timer import Timer
 from zeth.zksnark import \
     IZKSnarkProvider, get_zksnark_provider, GenericProof, GenericVerificationKey
 from zeth.utils import EtherValue, get_trusted_setup_dir, \
-    hex_digest_to_binary_string, digest_to_binary_string, encrypt, \
-    decrypt, int64_to_hex, encode_message_to_bytes, encode_eth_address, \
-    to_zeth_units
+    hex_digest_to_binary_string, digest_to_binary_string, int64_to_hex, \
+    encode_message_to_bytes, encode_eth_address, to_zeth_units
 from zeth.prover_client import ProverClient
 from api.util_pb2 import ZethNote, JoinsplitInput
 import api.prover_pb2 as prover_pb2

--- a/pyClient/zeth/mixer_client.py
+++ b/pyClient/zeth/mixer_client.py
@@ -20,7 +20,7 @@ from zeth.zksnark import \
     IZKSnarkProvider, get_zksnark_provider, GenericProof, GenericVerificationKey
 from zeth.utils import EtherValue, get_trusted_setup_dir, \
     hex_digest_to_binary_string, digest_to_binary_string, int64_to_hex, \
-    encode_message_to_bytes, encode_eth_address, to_zeth_units
+    message_to_bytes, eth_address_to_bytes, to_zeth_units
 from zeth.prover_client import ProverClient
 from api.util_pb2 import ZethNote, JoinsplitInput
 import api.prover_pb2 as prover_pb2
@@ -596,8 +596,8 @@ def _encode_proof_and_inputs(proof_json: GenericProof) -> Tuple[bytes, bytes]:
         if key != "inputs":
             proof_elements.extend(proof_json[key])
     return (
-        encode_message_to_bytes(proof_elements),
-        encode_message_to_bytes(proof_json["inputs"]))
+        message_to_bytes(proof_elements),
+        message_to_bytes(proof_json["inputs"]))
 
 
 def joinsplit_sign(
@@ -623,7 +623,7 @@ def joinsplit_sign(
     #   - proof elements
     #   - public input elements
     h = sha256()
-    h.update(encode_eth_address(sender_eth_address))
+    h.update(eth_address_to_bytes(sender_eth_address))
     h.update(encode_encryption_public_key(sender_eph_pk))
     for ciphertext in ciphertexts:
         h.update(ciphertext)

--- a/pyClient/zeth/mixer_client.py
+++ b/pyClient/zeth/mixer_client.py
@@ -485,6 +485,20 @@ class MixerClient:
             wei_pub_value,
             call_gas)
 
+    def mix_call(
+            self,
+            mix_params: contracts.MixParameters,
+            sender_eth_address: str,
+            wei_pub_value: int,
+            call_gas: int) -> bool:
+        return contracts.mix_call(
+            self._zksnark,
+            self.mixer_instance,
+            mix_params,
+            sender_eth_address,
+            wei_pub_value,
+            call_gas)
+
     def get_proof_joinsplit_2_by_2(
             self,
             mk_root: bytes,

--- a/pyClient/zeth/py.typed
+++ b/pyClient/zeth/py.typed
@@ -1,0 +1,5 @@
+# Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+#
+# SPDX-License-Identifier: LGPL-3.0+
+
+# Empty file, required for mypy.

--- a/pyClient/zeth/signing.py
+++ b/pyClient/zeth/signing.py
@@ -15,7 +15,7 @@ from math import ceil
 from os import urandom
 from hashlib import sha256
 from py_ecc import bn128 as ec
-from zeth.utils import FQ, G1, encode_g1_to_bytes
+from zeth.utils import FQ, G1, g1_to_bytes
 from zeth.constants import ZETH_PRIME
 from typing import List
 
@@ -72,8 +72,8 @@ def encode_vk_to_bytes(vk: SigningVerificationKey) -> bytes:
     We assume here the group prime $p$ is written in less than 256 bits
     to conform with Ethereum bytes32 type
     """
-    vk_byte = encode_g1_to_bytes(vk.ppk)
-    vk_byte += encode_g1_to_bytes(vk.spk)
+    vk_byte = g1_to_bytes(vk.ppk)
+    vk_byte += g1_to_bytes(vk.spk)
     return vk_byte
 
 
@@ -88,7 +88,7 @@ def sign(
     """
 
     # Encode and hash the verifying key and input hashes
-    challenge_to_hash = encode_g1_to_bytes(sk.ssk[1]) + m
+    challenge_to_hash = g1_to_bytes(sk.ssk[1]) + m
 
     # Convert the hex digest into a field element
     challenge = int(sha256(challenge_to_hash).hexdigest(), 16)
@@ -110,7 +110,7 @@ def verify(
     less than 256 bits to conform with Ethereum bytes32 type.
     """
     # Encode and hash the verifying key and input hashes
-    challenge_to_hash = encode_g1_to_bytes(vk.spk) + m
+    challenge_to_hash = g1_to_bytes(vk.spk) + m
 
     challenge = int(sha256(challenge_to_hash).hexdigest(), 16)
     challenge = challenge % ZETH_PRIME

--- a/pyClient/zeth/signing.py
+++ b/pyClient/zeth/signing.py
@@ -17,6 +17,7 @@ from hashlib import sha256
 from py_ecc import bn128 as ec
 from zeth.utils import FQ, G1, encode_g1_to_bytes
 from zeth.constants import ZETH_PRIME
+from typing import List
 
 
 class SigningVerificationKey:
@@ -45,6 +46,9 @@ class SigningKeyPair:
         # We include y_g1 in the signing key
         self.sk = SigningSecretKey(x, y, y_g1)
         self.vk = SigningVerificationKey(x_g1, y_g1)
+
+
+Signature = int
 
 
 def gen_signing_keypair() -> SigningKeyPair:
@@ -115,3 +119,36 @@ def verify(
     right_part = ec.add(vk.spk, ec.multiply(vk.ppk, FQ(challenge).n))
 
     return ec.eq(left_part, right_part)
+
+
+def verification_key_as_mix_parameter(vk: SigningVerificationKey) -> List[int]:
+    """
+    Transform a verification key to the format required by the mix function.
+    """
+    return [int(vk.ppk[0]), int(vk.ppk[1]), int(vk.spk[0]), int(vk.spk[1])]
+
+
+def verification_key_from_mix_parameter(
+        param: List[int]) -> SigningVerificationKey:
+    """
+    Transform mix function parameter to verification key.
+    """
+    return SigningVerificationKey(
+        (FQ(param[0]), FQ(param[1])),
+        (FQ(param[2]), FQ(param[3])))
+
+
+def signature_as_mix_parameter(signature: Signature) -> int:
+    """
+    Transform a signature to the format required by the mix function.
+    """
+    # This function happens to be the identity but in the general case some
+    # transform will be required.
+    return signature
+
+
+def signature_from_mix_parameter(param: int) -> Signature:
+    """
+    Transform mix function parameters to a signature.
+    """
+    return param

--- a/pyClient/zeth/signing.py
+++ b/pyClient/zeth/signing.py
@@ -77,9 +77,17 @@ def encode_vk_to_bytes(vk: SigningVerificationKey) -> bytes:
     return vk_byte
 
 
+def encode_signature_to_bytes(signature: Signature) -> bytes:
+    return signature.to_bytes(32, byteorder='big')
+
+
+def decode_signature_from_bytes(sig_bytes: bytes) -> Signature:
+    return int.from_bytes(sig_bytes, byteorder='big')
+
+
 def sign(
         sk: SigningSecretKey,
-        m: bytes) -> int:
+        m: bytes) -> Signature:
     """
     Generate a Schnorr signature on a message m.
     We assume here that the message fits in an Ethereum word (i.e. bit_len(m)

--- a/pyClient/zeth/utils.py
+++ b/pyClient/zeth/utils.py
@@ -91,6 +91,11 @@ def eth_address_to_bytes(eth_addr: str) -> bytes:
     return bytes.fromhex(hex_extend_32bytes(eth_addr[2:]))
 
 
+def eth_uint256_to_int(eth_uint256: str) -> int:
+    assert isinstance(eth_uint256, str)
+    return int.from_bytes(eth_address_to_bytes(eth_uint256), byteorder='big')
+
+
 def g1_to_bytes(group_el: G1) -> bytes:
     """
     Encode a group element into a byte string

--- a/pyClient/zeth/utils.py
+++ b/pyClient/zeth/utils.py
@@ -16,8 +16,6 @@ import os
 from os.path import join, dirname, normpath
 # Import Pynacl required modules
 import eth_abi
-import nacl.utils  # type: ignore
-from nacl.public import PrivateKey, PublicKey, Box  # type: ignore
 from web3 import Web3, HTTPProvider  # type: ignore
 from py_ecc import bn128 as ec
 from typing import List, Tuple, Union, Any, cast
@@ -151,64 +149,6 @@ def from_zeth_units(zeth_units: int) -> EtherValue:
     Convert a quantity of ether / token to Zeth units
     """
     return EtherValue(zeth_units * constants.ZETH_PUBLIC_UNIT_VALUE, "wei")
-
-
-def get_private_key_from_bytes(sk_bytes: bytes) -> PrivateKey:
-    """
-    Gets PrivateKey object from raw representation
-    (see: https://pynacl.readthedocs.io/en/stable/public/#nacl.public.PrivateKey)
-    """
-    return PrivateKey(sk_bytes, encoder=nacl.encoding.RawEncoder)
-
-
-def get_public_key_from_bytes(pk_bytes: bytes) -> PublicKey:
-    """
-    Gets PublicKey object from raw representation
-    (see: https://pynacl.readthedocs.io/en/stable/public/#nacl.public.PublicKey)
-    """
-    return PublicKey(pk_bytes, encoder=nacl.encoding.RawEncoder)
-
-
-def encrypt(message: str, pk_receiver: PublicKey, sk_sender: PrivateKey) -> bytes:
-    """
-    Encrypts a string message by using valid ec25519 public key and
-    private key objects. See: https://pynacl.readthedocs.io/en/stable/public/
-    """
-    # Init encryption box instance
-    encryption_box = Box(sk_sender, pk_receiver)
-
-    # Encode str message to bytes
-    message_bytes = message.encode('utf-8')
-
-    # Encrypt the message. The nonce is chosen randomly.
-    encrypted = encryption_box.encrypt(
-        message_bytes,
-        encoder=nacl.encoding.RawEncoder)
-
-    # Need to cast to the parent class Bytes of nacl.utils.EncryptedMessage
-    # to make it accepted from `Mix` Solidity function
-    return bytes(encrypted)
-
-
-def decrypt(
-        encrypted_message: bytes,
-        pk_sender: PublicKey,
-        sk_receiver: PrivateKey) -> str:
-    """
-    Decrypts a string message by using valid ec25519 public key and private key
-    objects.  See: https://pynacl.readthedocs.io/en/stable/public/
-    """
-    assert(isinstance(pk_sender, PublicKey)), \
-        f"PublicKey: {pk_sender} ({type(pk_sender)})"
-    assert(isinstance(sk_receiver, PrivateKey)), \
-        f"PrivateKey: {sk_receiver} ({type(sk_receiver)})"
-
-    # Init encryption box instance
-    decryption_box = Box(sk_receiver, pk_sender)
-
-    # Check integrity of the ciphertext and decrypt it
-    message = decryption_box.decrypt(encrypted_message)
-    return str(message, encoding='utf-8')
 
 
 def parse_zksnark_arg() -> str:

--- a/pyClient/zeth/utils.py
+++ b/pyClient/zeth/utils.py
@@ -82,15 +82,16 @@ def encode_abi(type_names: List[str], data: List[bytes]) -> bytes:
     return eth_abi.encode_abi(type_names, data)  # type: ignore
 
 
-def encode_eth_address(eth_addr: str) -> bytes:
+def eth_address_to_bytes(eth_addr: str) -> bytes:
     """
     Binary encoding of ethereum address to 32 bytes
     """
     # Strip the leading '0x' and hex-decode.
+    assert eth_addr.startswith("0x")
     return bytes.fromhex(hex_extend_32bytes(eth_addr[2:]))
 
 
-def encode_g1_to_bytes(group_el: G1) -> bytes:
+def g1_to_bytes(group_el: G1) -> bytes:
     """
     Encode a group element into a byte string
     We assume here the group prime $p$ is written in less than 256 bits
@@ -204,7 +205,7 @@ def string_list_flatten(
     return cast(List[str], strs_list)
 
 
-def encode_message_to_bytes(message_list: Any) -> bytes:
+def message_to_bytes(message_list: Any) -> bytes:
     # message_list: Union[List[str], List[Union[int, str, List[str]]]]) -> bytes:
     """
     Encode a list of variables, or list of lists of variables into a byte

--- a/pyClient/zeth/utils.py
+++ b/pyClient/zeth/utils.py
@@ -61,6 +61,9 @@ class EtherValue:
     def __ne__(self, other: Any) -> bool:
         return not self.__eq__(other)
 
+    def __bool__(self) -> bool:
+        return int(self.wei) != 0
+
     def ether(self) -> str:
         return str(Web3.fromWei(self.wei, 'ether'))
 

--- a/pyClient/zeth/utils.py
+++ b/pyClient/zeth/utils.py
@@ -53,6 +53,9 @@ class EtherValue:
     def __add__(self, other: EtherValue) -> EtherValue:
         return EtherValue(self.wei + other.wei, 'wei')
 
+    def __sub__(self, other: EtherValue) -> EtherValue:
+        return EtherValue(self.wei - other.wei, 'wei')
+
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, EtherValue):
             return False
@@ -60,6 +63,18 @@ class EtherValue:
 
     def __ne__(self, other: Any) -> bool:
         return not self.__eq__(other)
+
+    def __lt__(self, other: EtherValue) -> bool:
+        return self.wei < other.wei
+
+    def __le__(self, other: EtherValue) -> bool:
+        return self.wei <= other.wei
+
+    def __gt__(self, other: EtherValue) -> bool:
+        return self.wei > other.wei
+
+    def __ge__(self, other: EtherValue) -> bool:
+        return self.wei >= other.wei
 
     def __bool__(self) -> bool:
         return int(self.wei) != 0

--- a/pyClient/zeth/utils.py
+++ b/pyClient/zeth/utils.py
@@ -139,6 +139,20 @@ def hex_extend_32bytes(element: str) -> str:
     return extend_32bytes(bytes.fromhex(res)).hex()
 
 
+def to_zeth_units(value: EtherValue) -> int:
+    """
+    Convert a quantity of ether / token to Zeth units
+    """
+    return int(value.wei / constants.ZETH_PUBLIC_UNIT_VALUE)
+
+
+def from_zeth_units(zeth_units: int) -> EtherValue:
+    """
+    Convert a quantity of ether / token to Zeth units
+    """
+    return EtherValue(zeth_units * constants.ZETH_PUBLIC_UNIT_VALUE, "wei")
+
+
 def get_private_key_from_bytes(sk_bytes: bytes) -> PrivateKey:
     """
     Gets PrivateKey object from raw representation

--- a/pyClient/zeth/utils.py
+++ b/pyClient/zeth/utils.py
@@ -122,8 +122,12 @@ def g1_to_bytes(group_el: G1) -> bytes:
         int(group_el[1]).to_bytes(32, byteorder='big')
 
 
+def int64_to_bytes(number: int) -> bytes:
+    return number.to_bytes(8, 'big')
+
+
 def int64_to_hex(number: int) -> str:
-    return '{:016x}'.format(number)
+    return int64_to_bytes(number).hex()
 
 
 def hex_digest_to_binary_string(digest: str) -> str:

--- a/pyClient/zeth/wallet.py
+++ b/pyClient/zeth/wallet.py
@@ -5,8 +5,9 @@
 # SPDX-License-Identifier: LGPL-3.0+
 
 from __future__ import annotations
+from zeth.zeth_address import ZethAddressPriv
 from zeth.mixer_client import zeth_note_to_json_dict, zeth_note_from_json_dict, \
-    ZethAddressPriv, receive_note, compute_nullifier, compute_commitment
+    receive_note, compute_nullifier, compute_commitment
 from zeth.constants import ZETH_MERKLE_TREE_DEPTH
 from zeth.contracts import MixOutputEvents
 from zeth.encryption import EncryptionPublicKey

--- a/pyClient/zeth/zeth_address.py
+++ b/pyClient/zeth/zeth_address.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+#
+# SPDX-License-Identifier: LGPL-3.0+
+
+from __future__ import annotations
+from zeth.ownership import OwnershipPublicKey, OwnershipSecretKey, \
+    OwnershipKeyPair, ownership_key_as_hex, gen_ownership_keypair, \
+    ownership_public_key_from_hex, ownership_secret_key_from_hex
+from zeth.encryption import \
+    EncryptionKeyPair, EncryptionPublicKey, EncryptionSecretKey, \
+    generate_encryption_keypair, encryption_public_key_as_hex, \
+    encryption_public_key_from_hex, encryption_secret_key_as_hex, \
+    encryption_secret_key_from_hex
+import json
+from typing import Dict, Any
+
+
+class ZethAddressPub:
+    """
+    Public half of a zethAddress.  addr_pk = (a_pk and k_pk)
+    """
+    def __init__(self, a_pk: OwnershipPublicKey, k_pk: EncryptionPublicKey):
+        self.a_pk: OwnershipPublicKey = a_pk
+        self.k_pk: EncryptionPublicKey = k_pk
+
+    def __str__(self) -> str:
+        """
+        Write the address as "<ownership-key-hex>:<encryption_key_hex>".
+        (Technically the ":" is not required, since the first key is written
+        with fixed length, but a separator provides some limited sanity
+        checking).
+        """
+        a_pk_hex = ownership_key_as_hex(self.a_pk)
+        k_pk_hex = encryption_public_key_as_hex(self.k_pk)
+        return f"{a_pk_hex}:{k_pk_hex}"
+
+    @staticmethod
+    def parse(key_hex: str) -> ZethAddressPub:
+        owner_enc = key_hex.split(":")
+        if len(owner_enc) != 2:
+            raise Exception("invalid JoinSplitPublicKey format")
+        a_pk = ownership_public_key_from_hex(owner_enc[0])
+        k_pk = encryption_public_key_from_hex(owner_enc[1])
+        return ZethAddressPub(a_pk, k_pk)
+
+
+class ZethAddressPriv:
+    """
+    Secret half of a zethAddress. addr_sk = (a_sk and k_sk)
+    """
+    def __init__(self, a_sk: OwnershipSecretKey, k_sk: EncryptionSecretKey):
+        self.a_sk: OwnershipSecretKey = a_sk
+        self.k_sk: EncryptionSecretKey = k_sk
+
+    def to_json(self) -> str:
+        return json.dumps(self._to_json_dict())
+
+    @staticmethod
+    def from_json(key_json: str) -> ZethAddressPriv:
+        return ZethAddressPriv._from_json_dict(json.loads(key_json))
+
+    def _to_json_dict(self) -> Dict[str, Any]:
+        return {
+            "a_sk": ownership_key_as_hex(self.a_sk),
+            "k_sk": encryption_secret_key_as_hex(self.k_sk),
+        }
+
+    @staticmethod
+    def _from_json_dict(key_dict: Dict[str, Any]) -> ZethAddressPriv:
+        return ZethAddressPriv(
+            ownership_secret_key_from_hex(key_dict["a_sk"]),
+            encryption_secret_key_from_hex(key_dict["k_sk"]))
+
+
+class ZethAddress:
+    """
+    Secret and public keys for both ownership and encryption (referrred to as
+    "zethAddress" in the paper).
+    """
+    def __init__(
+            self,
+            a_pk: OwnershipPublicKey,
+            k_pk: EncryptionPublicKey,
+            a_sk: OwnershipSecretKey,
+            k_sk: EncryptionSecretKey):
+        self.addr_pk = ZethAddressPub(a_pk, k_pk)
+        self.addr_sk = ZethAddressPriv(a_sk, k_sk)
+
+    @staticmethod
+    def from_key_pairs(
+            ownership: OwnershipKeyPair,
+            encryption: EncryptionKeyPair) -> ZethAddress:
+        return ZethAddress(
+            ownership.a_pk,
+            encryption.k_pk,
+            ownership.a_sk,
+            encryption.k_sk)
+
+    @staticmethod
+    def from_secret_public(
+            js_secret: ZethAddressPriv,
+            js_public: ZethAddressPub) -> ZethAddress:
+        return ZethAddress(
+            js_public.a_pk, js_public.k_pk, js_secret.a_sk, js_secret.k_sk)
+
+    def ownership_keypair(self) -> OwnershipKeyPair:
+        return OwnershipKeyPair(self.addr_sk.a_sk, self.addr_pk.a_pk)
+
+
+def generate_zeth_address() -> ZethAddress:
+    ownership_keypair = gen_ownership_keypair()
+    encryption_keypair = generate_encryption_keypair()
+    return ZethAddress.from_key_pairs(ownership_keypair, encryption_keypair)

--- a/scripts/test_zeth_cli
+++ b/scripts/test_zeth_cli
@@ -3,49 +3,20 @@
 set -e
 set -x
 
-TRUFFLE_DIR=`pwd`/zeth-contracts
+. scripts/test_zeth_cli_common.sh
+
 BASE_DIR=_test_zeth_cli
 DEPLOYER_DIR=${BASE_DIR}/deployer
 ALICE_DIR=${BASE_DIR}/alice
 BOB_DIR=${BASE_DIR}/bob
 CHARLIE_DIR=${BASE_DIR}/charlie
 
-function run_truffle() {
-    pushd ${TRUFFLE_DIR}
-    eval truffle $@
-    popd
-}
-
-function run_as() {
-    pushd $1
-    shift
-    eval $@
-    popd
-}
-
-function show_balances() {
-    run_truffle exec ../scripts/test_zeth_cli_show_balances.js
-}
-
 # Setup addresses
 
 mkdir -p ${BASE_DIR}
 pushd ${BASE_DIR}
 
-if ! [ -e accounts ] ; then
-    (run_truffle exec ../scripts/test_zeth_cli_get_accounts.js) > accounts
-fi
-
-# 1 - name
-function setup_user() {
-    mkdir -p $1
-    pushd $1
-    ! [ -e eth-address ] && \
-        (grep $1 ../accounts | grep -oe '0x.*' > eth-address)
-    ! [ -e zeth-address.json ] && \
-        (zeth gen-address)
-    popd
-}
+get_accounts
 
 setup_user deployer
 setup_user alice
@@ -56,9 +27,9 @@ setup_user charlie
 ! [ -e deployer/zeth-instance.json ] && \
     run_as deployer zeth deploy
 
-cp deployer/zeth-instance.json alice
-cp deployer/zeth-instance.json bob
-cp deployer/zeth-instance.json charlie
+copy_deployment_info deployer alice
+copy_deployment_info deployer bob
+copy_deployment_info deployer charlie
 
 # Alice deposits 200 and sends 100 to Bob
 pushd alice

--- a/scripts/test_zeth_cli
+++ b/scripts/test_zeth_cli
@@ -116,3 +116,10 @@ echo BALANCES AFTER WITHDRAW
 show_balances
 
 popd # BASE_DIR
+
+set +x
+set +e
+
+echo "============================================================"
+echo "==                        PASSED                          =="
+echo "============================================================"

--- a/scripts/test_zeth_cli
+++ b/scripts/test_zeth_cli
@@ -70,7 +70,7 @@ zeth mix \
 popd # bob
 
 echo BALANCES FOR WITHDRAW
-show_balances
+show_balances_named
 
 # Charlie scans the chain and withdraws his 50 ETH
 pushd charlie
@@ -84,7 +84,7 @@ zeth mix \
 popd # charlie
 
 echo BALANCES AFTER WITHDRAW
-show_balances
+show_balances_named
 
 popd # BASE_DIR
 

--- a/scripts/test_zeth_cli_common.sh
+++ b/scripts/test_zeth_cli_common.sh
@@ -18,6 +18,19 @@ function show_balances() {
     run_truffle exec ../scripts/test_zeth_cli_show_balances.js
 }
 
+function show_balances_named() {
+    run_truffle exec ../scripts/test_zeth_cli_show_balances_named.js
+}
+
+function new_account() {
+    run_truffle exec ../scripts/test_zeth_cli_new_account.js | grep -e '^0x.*'
+}
+
+# 1 - Address to show balance for
+function show_balance() {
+    show_balances | grep $1 | sed -e 's/^'$1': //g'
+}
+
 # Record all Ethereum accounts in an 'accounts'
 function get_accounts() {
     if ! [ -e accounts ] ; then

--- a/scripts/test_zeth_cli_common.sh
+++ b/scripts/test_zeth_cli_common.sh
@@ -1,0 +1,43 @@
+
+TRUFFLE_DIR=`pwd`/zeth-contracts
+
+function run_truffle() {
+    pushd ${TRUFFLE_DIR}
+    eval truffle $@
+    popd
+}
+
+function run_as() {
+    pushd $1
+    shift
+    eval $@
+    popd
+}
+
+function show_balances() {
+    run_truffle exec ../scripts/test_zeth_cli_show_balances.js
+}
+
+# Record all Ethereum accounts in an 'accounts'
+function get_accounts() {
+    if ! [ -e accounts ] ; then
+        run_truffle exec ../scripts/test_zeth_cli_get_accounts.js > accounts
+    fi
+}
+
+# 1 - name
+function setup_user() {
+    mkdir -p $1
+    pushd $1
+    ! [ -e eth-address ] && \
+        (grep $1 ../accounts | grep -oe '0x.*' > eth-address)
+    ! [ -e zeth-address.json ] && \
+        (zeth gen-address)
+    popd
+}
+
+# 1 - deployer_name
+# 2 - user_name
+function copy_deployment_info() {
+    cp $1/zeth-instance.json $2
+}

--- a/scripts/test_zeth_cli_new_account.js
+++ b/scripts/test_zeth_cli_new_account.js
@@ -1,0 +1,7 @@
+module.exports = function(cb) {
+    newAccountA = web3.eth.personal.newAccount();
+    newAccountA.then(function (account) {
+        console.log(account);
+        cb();
+    });
+};

--- a/scripts/test_zeth_cli_show_balances.js
+++ b/scripts/test_zeth_cli_show_balances.js
@@ -1,17 +1,15 @@
 module.exports = function(cb) {
     var accountsA = web3.eth.getAccounts();
     accountsA.then(function(accounts) {
-        var shown = 0;
-        var on_balance = function(name) {
-            return function(bal) {
-                console.log(name + ": " + bal);
-                if (++shown == 4) { cb(); }
+        var num_accounts = accounts.length;
+        accounts.forEach(function (account) {
+            var on_balance = function(balance) {
+                console.log(account + ": " + balance);
+                if (--num_accounts == 0) {
+                    cb();
+                }
             };
-        };
-
-        web3.eth.getBalance(accounts[0]).then(on_balance("deployer "));
-        web3.eth.getBalance(accounts[1]).then(on_balance("alice    "));
-        web3.eth.getBalance(accounts[2]).then(on_balance("bob      "));
-        web3.eth.getBalance(accounts[3]).then(on_balance("charlie  "));
+            web3.eth.getBalance(account).then(on_balance);
+        });
     });
 }

--- a/scripts/test_zeth_cli_show_balances_named.js
+++ b/scripts/test_zeth_cli_show_balances_named.js
@@ -1,0 +1,17 @@
+module.exports = function(cb) {
+    var accountsA = web3.eth.getAccounts();
+    accountsA.then(function(accounts) {
+        var shown = 0;
+        var on_balance = function(name) {
+            return function(bal) {
+                console.log(name + ": " + bal);
+                if (++shown == 4) { cb(); }
+            };
+        };
+
+        web3.eth.getBalance(accounts[0]).then(on_balance("deployer "));
+        web3.eth.getBalance(accounts[1]).then(on_balance("alice    "));
+        web3.eth.getBalance(accounts[2]).then(on_balance("bob      "));
+        web3.eth.getBalance(accounts[3]).then(on_balance("charlie  "));
+    });
+}

--- a/scripts/test_zeth_cli_token
+++ b/scripts/test_zeth_cli_token
@@ -76,7 +76,7 @@ zeth mix \
 popd # bob
 
 echo BALANCES FOR WITHDRAW
-show_balances
+show_balances_named
 
 # Charlie scans the chain and withdraws his 50 ETH
 pushd charlie
@@ -90,6 +90,6 @@ zeth mix \
 popd # charlie
 
 echo BALANCES AFTER WITHDRAW
-show_balances
+show_balances_named
 
 popd # BASE_DIR

--- a/scripts/test_zeth_cli_token
+++ b/scripts/test_zeth_cli_token
@@ -3,55 +3,25 @@
 set -e
 set -x
 
-TRUFFLE_DIR=`pwd`/zeth-contracts
+. scripts/test_zeth_cli_common.sh
+
 BASE_DIR=_test_zeth_cli_token
 DEPLOYER_DIR=${BASE_DIR}/deployer
 ALICE_DIR=${BASE_DIR}/alice
 BOB_DIR=${BASE_DIR}/bob
 CHARLIE_DIR=${BASE_DIR}/charlie
 
-function run_truffle() {
-    pushd ${TRUFFLE_DIR}
-    eval truffle $@
-    popd
-}
-
-function run_as() {
-    pushd $1
-    shift
-    eval $@
-    popd
-}
-
-function show_balances() {
-    run_truffle exec ../scripts/test_zeth_cli_show_balances.js
-}
-
 # Setup addresss
 
 mkdir -p ${BASE_DIR}
 pushd ${BASE_DIR}
 
-if ! [ -e accounts ] ; then
-    (run_truffle exec ../scripts/test_zeth_cli_get_accounts.js) > accounts
-fi
-
-# 1 - name
-function setup_user() {
-    mkdir -p $1
-    pushd $1
-    ! [ -e eth-address ] && \
-        (grep $1 ../accounts | grep -oe '0x.*' > eth-address)
-    ! [ -e zeth-address.json ] && \
-        (zeth gen-address)
-    popd
-}
+get_accounts
 
 setup_user deployer
 setup_user alice
 setup_user bob
 setup_user charlie
-
 
 # Deploy
 pushd deployer
@@ -69,9 +39,9 @@ if ! [ -e zeth-instance.json ] ; then
 fi
 popd # deployer
 
-cp deployer/zeth-instance.json alice
-cp deployer/zeth-instance.json bob
-cp deployer/zeth-instance.json charlie
+copy_deployment_info deployer alice
+copy_deployment_info deployer bob
+copy_deployment_info deployer charlie
 
 # Alice deposits 200 and sends 100 to Bob
 pushd alice

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -4,8 +4,8 @@ export ZETH=`pwd`
 export ZETH_CONTRACTS_DIR=$ZETH/zeth-contracts/contracts
 export ZETH_DEBUG_DIR=$ZETH/debug
 
-mkdir -p $ZETH/coinstore
-export ZETH_COINSTORE=$ZETH/coinstore
+mkdir -p $ZETH/notestore
+export ZETH_NOTESTORE=$ZETH/notestore
 
 mkdir -p $ZETH/trusted_setup
 export ZETH_TRUSTED_SETUP_DIR=$ZETH/trusted_setup

--- a/zeth-contracts/contracts/BaseMerkleTree.sol
+++ b/zeth-contracts/contracts/BaseMerkleTree.sol
@@ -46,7 +46,7 @@ contract BaseMerkleTree {
     }
 
     // Appends a commitment to the tree, and returns its address
-    function insert(bytes32 commitment) public returns (uint) {
+    function insert(bytes32 commitment) public {
 
         // If this require fails => the merkle tree is full, we can't append
         // leaves anymore.
@@ -62,6 +62,5 @@ contract BaseMerkleTree {
         ++num_leaves;
         uint256 next_entry_idx = (MAX_NUM_LEAVES - 1) + next_address;
         nodes[next_entry_idx] = commitment;
-        return next_address;
     }
 }

--- a/zeth-contracts/contracts/BaseMixer.sol
+++ b/zeth-contracts/contracts/BaseMixer.sol
@@ -85,6 +85,9 @@ contract BaseMixer is MerkleTreeMiMC7, ERC223ReceivingContract {
     //   jsOut (commitment per JS output)
     uint256 constant nb_hash_digests = 1 + 2*jsIn;
 
+    // Bit offset of v_out in residual_bits
+    uint256 constant residual_hash_bits = packing_residue_length*nb_hash_digests;
+
     // Total number of residual bits from packing of 256-bit long string into
     // 253-bit long field elements to which are added the public value of size
     // 64 bits
@@ -192,17 +195,11 @@ contract BaseMixer is MerkleTreeMiMC7, ERC223ReceivingContract {
         // We know vpub_in corresponds to the first 64 bits of the first
         // residual field element after padding. We retrieve the public value
         // in and remove any extra bits (due to the padding)
-        uint256 residual_hash_size = packing_residue_length*nb_hash_digests;
 
-        bytes32 vpub_bytes = bytes32(primary_inputs[1 + jsOut + nb_hash_digests])
-            >> (residual_hash_size + public_value_length);
-        vpub_in = uint64(uint(vpub_bytes));
-
-        // We retrieve the public value out and remove any extra bits (due to
-        // the padding)
-        vpub_bytes = bytes32(primary_inputs[1 + jsOut + nb_hash_digests])
-            >> residual_hash_size;
-        vpub_out = uint64(uint(vpub_bytes));
+        uint256 residual_bits = primary_inputs[1 + jsOut + nb_hash_digests];
+        residual_bits = residual_bits >> residual_hash_bits;
+        vpub_out = uint64(residual_bits);
+        vpub_in = uint64(residual_bits >> public_value_length);
     }
 
     // This function is used to reassemble hsig given the the primary_inputs To

--- a/zeth-contracts/contracts/BaseMixer.sol
+++ b/zeth-contracts/contracts/BaseMixer.sol
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0+
 
 pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
 
 import "./MerkleTreeMiMC7.sol";
 
@@ -383,10 +384,10 @@ contract BaseMixer is MerkleTreeMiMC7, ERC223ReceivingContract {
 
     function emit_ciphertexts(
         bytes32 pk_sender,
-        bytes memory ciphertext0,
-        bytes memory ciphertext1)
+        bytes[jsOut] memory ciphertexts)
         internal {
-        emit LogSecretCiphers(pk_sender, ciphertext0);
-        emit LogSecretCiphers(pk_sender, ciphertext1);
+        for (uint256 i = 0 ; i < jsOut ; ++i) {
+            emit LogSecretCiphers(pk_sender, ciphertexts[i]);
+        }
     }
 }

--- a/zeth-contracts/contracts/BaseMixer.sol
+++ b/zeth-contracts/contracts/BaseMixer.sol
@@ -125,7 +125,6 @@ contract BaseMixer is MerkleTreeMiMC7, ERC223ReceivingContract {
     bytes32[jsIn] nullifiers,
     bytes32 pk_sender,
     bytes32[jsOut] commitments,
-    uint256[jsOut] commAddrs,
     bytes[jsOut] ciphertexts);
 
     // Debug only
@@ -315,14 +314,13 @@ contract BaseMixer is MerkleTreeMiMC7, ERC223ReceivingContract {
 
     function assemble_commitments_and_append_to_state(
         uint256[nbInputs] memory primary_inputs,
-        bytes32[jsOut] memory comms,
-        uint256[jsOut] memory commAddrs)
+        bytes32[jsOut] memory comms)
         internal {
         // We re-assemble the commitments (JSOutputs)
         for (uint256 i = 0; i < jsOut; i++) {
             bytes32 current_commitment = bytes32(primary_inputs[1 + i]);
             comms[i] = current_commitment;
-            commAddrs[i] = insert(current_commitment);
+            insert(current_commitment);
         }
     }
 

--- a/zeth-contracts/contracts/Groth16Mixer.sol
+++ b/zeth-contracts/contracts/Groth16Mixer.sol
@@ -115,9 +115,7 @@ contract Groth16Mixer is BaseMixer {
 
         // 3. Append the commitments to the tree
         bytes32[jsOut] memory commitments;
-        uint256[jsOut] memory commitment_addresses;
-        assemble_commitments_and_append_to_state(
-            input, commitments, commitment_addresses);
+        assemble_commitments_and_append_to_state(input, commitments);
 
         // 4. Get the public values in Wei and modify the state depending on
         // their values
@@ -133,7 +131,6 @@ contract Groth16Mixer is BaseMixer {
             nullifiers,
             pk_sender,
             commitments,
-            commitment_addresses,
             ciphertexts);
     }
 

--- a/zeth-contracts/contracts/Pghr13Mixer.sol
+++ b/zeth-contracts/contracts/Pghr13Mixer.sol
@@ -132,9 +132,7 @@ contract Pghr13Mixer is BaseMixer {
 
         // 3. Append the commitments to the tree
         bytes32[jsOut] memory commitments;
-        uint256[jsOut] memory commitment_addresses;
-        assemble_commitments_and_append_to_state(
-            input, commitments, commitment_addresses);
+        assemble_commitments_and_append_to_state(input, commitments);
 
         // 4. get the public values in Wei and modify the state depending on
         // their values
@@ -150,7 +148,6 @@ contract Pghr13Mixer is BaseMixer {
             nullifiers,
             pk_sender,
             commitments,
-            commitment_addresses,
             ciphertexts);
     }
 

--- a/zeth-contracts/contracts/Pghr13Mixer.sol
+++ b/zeth-contracts/contracts/Pghr13Mixer.sol
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0+
 
 pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
 
 import "./OTSchnorrVerifier.sol";
 import "./BaseMixer.sol";
@@ -85,18 +86,21 @@ contract Pghr13Mixer is BaseMixer {
         uint256 sigma,
         uint256[nbInputs] memory input,
         bytes32 pk_sender,
-        bytes memory ciphertext0,
-        bytes memory ciphertext1)
+        bytes[jsOut] memory ciphertexts)
         public payable {
+
         // 1. Check the root and the nullifiers
-        check_mkroot_nullifiers_hsig_append_nullifiers_state(vk, input);
+        bytes32[jsIn] memory nullifiers;
+        check_mkroot_nullifiers_hsig_append_nullifiers_state(
+            vk, input, nullifiers);
 
         // 2.a Verify the signature on the hash of data_to_be_signed
         bytes32 hash_to_be_signed = sha256(
             abi.encodePacked(
                 pk_sender,
-                ciphertext0,
-                ciphertext1,
+                // Must be unrolled for now.
+                ciphertexts[0],
+                ciphertexts[1],
                 a,
                 a_p,
                 b,
@@ -126,20 +130,28 @@ contract Pghr13Mixer is BaseMixer {
             "Invalid proof: Unable to verify the proof correctly"
         );
 
-
         // 3. Append the commitments to the tree
-        append_commitments_to_state(input);
+        bytes32[jsOut] memory commitments;
+        uint256[jsOut] memory commitment_addresses;
+        assemble_commitments_and_append_to_state(
+            input, commitments, commitment_addresses);
 
         // 4. get the public values in Wei and modify the state depending on
         // their values
         process_public_values(input);
 
         // 5. Add the new root to the list of existing roots and emit it
-        add_and_emit_merkle_root(getRoot());
+        bytes32 new_merkle_root = recomputeRoot(jsOut);
+        add_merkle_root(new_merkle_root);
 
-        // Emit the all the coins' secret data encrypted with the recipients'
-        // respective keys
-        emit_ciphertexts(pk_sender, ciphertext0, ciphertext1);
+        // Emit the all Mix data
+        emit LogMix(
+            new_merkle_root,
+            nullifiers,
+            pk_sender,
+            commitments,
+            commitment_addresses,
+            ciphertexts);
     }
 
     function getIC(uint256 i) public view returns (uint) {


### PR DESCRIPTION
Some small changes that help when reusing the pyclient code in external projects.
Some headline changes:
- Mixer events as a single event call (simplify parsing by clients)
- `Wallet` class owns `MerkleTree`
- Remove the "Commit Address" from mixer event
- Basic packaging changes
- Factor out the Mix params as a serializable class
