### PR TITLE
Docker image update

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -1,31 +1,33 @@
-FROM ubuntu:19.04
+FROM alpine:3.11.5
 
 ####
-# This Dockerfile builds the base image (installs all the dependencies) for Zeth
+# This Dockerfile builds the base image
+# (installs all the dependencies) for Zeth
 ####
 
 # Install necessary packages
-RUN apt-get update && apt-get install -y \
+RUN apk --update --no-cache add \
+        build-base \
         git \
-        libboost-all-dev \
-        libgmp3-dev \
-        libprocps-dev \
+        boost-dev \
+        gmp-dev \
+        procps-dev \
         g++ \
         gcc \
         libxslt-dev \
         vim \
         cmake \
-        libssl-dev \
-        pkg-config \
+        libressl-dev \
+        pkgconfig \
         curl \
         sudo
 
-# Configue the environment for gRPC
-RUN apt-get install -y \
-        build-essential \
+# Configure the environment for gRPC
+RUN apk --update --no-cache add \
+        automake \
         autoconf \
         libtool
-RUN git clone -b v1.24.x https://github.com/grpc/grpc /var/local/git/grpc
+RUN git clone -b v1.28.x https://github.com/grpc/grpc /var/local/git/grpc
 RUN cd /var/local/git/grpc && git submodule update --init --recursive
 RUN cd /var/local/git/grpc/third_party/protobuf && ./autogen.sh && ./configure --prefix=/usr && make -j12 && make check && make install && make clean
 RUN cd /var/local/git/grpc && make install


### PR DESCRIPTION
Updated the zeth-base docker image.
The image was built from Ubuntu 19.04 which wasn't an LTS and which is not supported anymore (since Jan 2020).

The base image was changed to the last version of Alpine (3.11.5), which docker image is very light, and which will be supported for one year: https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases

We can consider going back to an ubuntu base image if necessary since the new Ubuntu LTS (20.04), is expected to be out at the end of the month (23 April), see: https://ubuntu.com/about/release-cycle

In addition to switching the base image, the version of gRPC was updated to track the latest release (1.28.1), see: https://github.com/grpc/grpc/releases/tag/v1.28.1