### PR TITLE
libzeth: fix segfault in filesystem_util

### DIFF
--- a/libzeth/serialization/filesystem_util.cpp
+++ b/libzeth/serialization/filesystem_util.cpp
@@ -10,33 +10,33 @@ namespace libzeth
 boost::filesystem::path get_path_to_setup_directory()
 {
     const char *path = std::getenv("ZETH_TRUSTED_SETUP_DIR");
-    if (nullptr == path) {
-        // Fallback destination if the ZETH_TRUSTED_SETUP_DIR env var is not set
-        // We assume below that `std::getenv("HOME")` does not return `nullptr`
-        boost::filesystem::path home_path =
-            boost::filesystem::path(std::getenv("HOME"));
-        boost::filesystem::path zeth_setup("zeth_setup");
-        boost::filesystem::path default_path = home_path / zeth_setup;
-
-        return default_path;
+    if (path != nullptr) {
+        return boost::filesystem::path(path);
     }
 
-    return boost::filesystem::path(path);
+    // Fallback   destination if the ZETH_TRUSTED_SETUP_DIR env var is not set
+    // We assume below that `std::getenv("HOME")` does not return `nullptr`
+    boost::filesystem::path home_path =
+        boost::filesystem::path(std::getenv("HOME"));
+    boost::filesystem::path zeth_setup("zeth_setup");
+    boost::filesystem::path default_path = home_path / zeth_setup;
+    return default_path;
 }
 
 boost::filesystem::path get_path_to_debug_directory()
 {
     const char *path = std::getenv("ZETH_DEBUG_DIR");
-    if (nullptr == path) {
-        // Fallback destination if the ZETH_DEBUG_DIR env var is not set
-        // We assume below that `std::getenv("HOME")` does not return `nullptr`
-        boost::filesystem::path home_path =
-            boost::filesystem::path(std::getenv("HOME"));
-        boost::filesystem::path zeth_debug("zeth_debug");
-        boost::filesystem::path default_path = home_path / zeth_debug;
+    if (path != nullptr) {
+        return boost::filesystem::path(path);
     }
 
-    return boost::filesystem::path(path);
+    // Fallback destination if the ZETH_DEBUG_DIR env var is not set
+    // We assume below that `std::getenv("HOME")` does not return `nullptr`
+    boost::filesystem::path home_path =
+        boost::filesystem::path(std::getenv("HOME"));
+    boost::filesystem::path zeth_debug("zeth_debug");
+    boost::filesystem::path default_path = home_path / zeth_debug;
+    return default_path;
 }
 
 } // namespace libzeth


### PR DESCRIPTION
fix segfault under some circumstances
rearranged code slightly so potentially null var is only handled in confined set of lines.