### PR TITLE
Excluded mpc targets from compilation if wrong curve selected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,7 @@ endif()
 # Add all local subdirecetories
 add_subdirectory(libzeth)
 add_subdirectory(prover_server)
-if(${ZKSNARK} STREQUAL "GROTH16")
+# For now the MPC for Groth16 only is tailored to the alt_bn128 pairing group
+if(${ZKSNARK} STREQUAL "GROTH16" AND ${CURVE} STREQUAL "ALT_BN128")
   add_subdirectory(mpc_tools)
 endif()


### PR DESCRIPTION
In the current config, mpc-related binaries are produced as soon as the snark use is groth16. Nevertheless, if the curve used is different of `alt_bn128` the compilation fails. I modified the condition to compile the targets to additionally check that the curve set is alt_bn128. If not, the mpc binaries aren't produced.

This condition can be relaxed back to a single check on the snark once the mpc code is fully generic (https://github.com/clearmatics/zeth/issues/176).