### PR TITLE
Added empty constructor for extended_proof class

### DIFF
--- a/libzeth/core/extended_proof.hpp
+++ b/libzeth/core/extended_proof.hpp
@@ -22,9 +22,11 @@ private:
         primary_inputs;
 
 public:
+    extended_proof(){};
     extended_proof(
         typename snarkT::ProofT &in_proof,
         libsnark::r1cs_primary_input<libff::Fr<ppT>> &in_primary_inputs);
+
     const typename snarkT::ProofT &get_proof() const;
 
     const libsnark::r1cs_primary_input<libff::Fr<ppT>> &get_primary_inputs()


### PR DESCRIPTION
In certain context, having an empty constructor for our classes is required (if we have `std::array` of objects of the given class). This PR adds the empty constructor for the `extended_proof` class.