### PR TITLE
Api group elements refactor

### DIFF
--- a/api/ec_group_messages.proto
+++ b/api/ec_group_messages.proto
@@ -2,9 +2,15 @@ syntax = "proto3";
 
 package zeth_proto;
 
-// Every point coordinate (ie: base field element)
-// is treated as an hexadecimal string.
-// The points in G1 are represented in affine form.
+// Every point coordinate (ie: base field element) is treated as an hexadecimal
+// string. The points in G1 are represented in affine form.
+//
+// e.g. Let A be a `HexPointBaseGroup1Affine` message. Then `A` is of the form:
+// ```
+// A = {
+//    x_coord = "0xa34...ef",
+//    y_coord = "0xae7...dc"
+// }
 message HexPointBaseGroup1Affine {
     // First coordinate of the point
     string x_coord = 1;
@@ -13,6 +19,17 @@ message HexPointBaseGroup1Affine {
 }
 
 // The points in G2 are represented in affine form.
+// We use a "repeated" string field for each coordinates to have flexibility
+// over the degree of the field extension used to define elements of G2.
+// This makes the API generic enough to support pairing groups with various
+// embedding degrees and twist degrees.
+//
+// e.g. Let A be a `HexPointBaseGroup2Affine` message. Then `A` is of the form:
+// ```
+// A = {
+//    x_coord = ["0xa34...ef", ... "0xaef...ab"],
+//    y_coord = ["0xae7...dc", ... "0xbfe...54"]
+// }
 message HexPointBaseGroup2Affine {
     // First coordinate of the point
     repeated string x_coord = 1;

--- a/api/ec_group_messages.proto
+++ b/api/ec_group_messages.proto
@@ -15,9 +15,7 @@ message HexPointBaseGroup1Affine {
 // The points in G2 are represented in affine form.
 message HexPointBaseGroup2Affine {
     // First coordinate of the point
-    string x_c1_coord = 1;
-    string x_c0_coord = 2;
+    repeated string x_coord = 1;
     // Second coordinate of the point
-    string y_c1_coord = 3;
-    string y_c0_coord = 4;
+    repeated string y_coord = 2;
 }

--- a/client/test_commands/test_ether_mixing.py
+++ b/client/test_commands/test_ether_mixing.py
@@ -69,6 +69,7 @@ def main() -> None:
             #   https://docs.python.org/3/library/shutil.html#shutil.rmtree.avoids_symlink_attacks
             shutil.rmtree(wallet_dir)
         return Wallet(mixer_instance, name, wallet_dir, sk)
+
     sk_alice = keystore['Alice'].addr_sk
     sk_bob = keystore['Bob'].addr_sk
     sk_charlie = keystore['Charlie'].addr_sk

--- a/client/zeth/contracts.py
+++ b/client/zeth/contracts.py
@@ -266,7 +266,7 @@ def mix(
     tx_hash = mixer_call.transact({
         'from': sender_address,
         'value': wei_pub_value,
-        'gas': 4000000000
+        'gas': call_gas
     })
     return tx_hash.hex()
 

--- a/client/zeth/contracts.py
+++ b/client/zeth/contracts.py
@@ -266,7 +266,7 @@ def mix(
     tx_hash = mixer_call.transact({
         'from': sender_address,
         'value': wei_pub_value,
-        'gas': call_gas
+        'gas': 4000000000
     })
     return tx_hash.hex()
 

--- a/client/zeth/mixer_client.py
+++ b/client/zeth/mixer_client.py
@@ -480,7 +480,6 @@ class MixerClient:
             signing_keypair.vk,
             signature,
             ciphertexts)
-
         return mix_params, signing_keypair
 
     def create_mix_parameters(

--- a/client/zeth/mixer_client.py
+++ b/client/zeth/mixer_client.py
@@ -480,6 +480,7 @@ class MixerClient:
             signing_keypair.vk,
             signature,
             ciphertexts)
+
         return mix_params, signing_keypair
 
     def create_mix_parameters(

--- a/client/zeth/zksnark.py
+++ b/client/zeth/zksnark.py
@@ -198,7 +198,5 @@ def _parse_hex_point_base_group1_affine(
 
 def _parse_hex_point_base_group2_affine(
         point: HexPointBaseGroup2Affine
-) -> Tuple[Tuple[str, str], Tuple[str, str]]:
-    return (
-        (point.x_c1_coord, point.x_c0_coord),
-        (point.y_c1_coord, point.y_c0_coord))
+) -> Tuple[List[str], List[str]]:
+    return (point.x_coord, point.y_coord)

--- a/client/zeth/zksnark.py
+++ b/client/zeth/zksnark.py
@@ -16,7 +16,7 @@ from api.ec_group_messages_pb2 import HexPointBaseGroup1Affine, \
 
 import json
 from abc import (ABC, abstractmethod)
-from typing import Dict, List, Tuple, Any, cast
+from typing import Dict, List, Tuple, Any
 # pylint: disable=unnecessary-pass
 
 # Dictionary representing a VerificationKey from any supported snark
@@ -90,7 +90,6 @@ class Groth16SnarkProvider(IZKSnarkProvider):
     def parse_verification_key(
             vk_obj: VerificationKey) -> GenericVerificationKey:
         vk = vk_obj.groth16_verification_key
-
         return {
             "alpha_g1": _parse_hex_point_base_group1_affine(vk.alpha_g1),
             "beta_g2": _parse_hex_point_base_group2_affine(vk.beta_g2),

--- a/client/zeth/zksnark.py
+++ b/client/zeth/zksnark.py
@@ -198,5 +198,5 @@ def _parse_hex_point_base_group1_affine(
 
 def _parse_hex_point_base_group2_affine(
         point: HexPointBaseGroup2Affine
-) -> Tuple[Tuple[str], Tuple[str]]:
+) -> Tuple[Tuple[str, ...], Tuple[str, ...]]:
     return (tuple(point.x_coord), tuple(point.y_coord))

--- a/client/zeth/zksnark.py
+++ b/client/zeth/zksnark.py
@@ -16,7 +16,7 @@ from api.ec_group_messages_pb2 import HexPointBaseGroup1Affine, \
 
 import json
 from abc import (ABC, abstractmethod)
-from typing import Dict, List, Tuple, Any
+from typing import Dict, List, Tuple, Any, cast
 # pylint: disable=unnecessary-pass
 
 # Dictionary representing a VerificationKey from any supported snark
@@ -90,6 +90,7 @@ class Groth16SnarkProvider(IZKSnarkProvider):
     def parse_verification_key(
             vk_obj: VerificationKey) -> GenericVerificationKey:
         vk = vk_obj.groth16_verification_key
+
         return {
             "alpha_g1": _parse_hex_point_base_group1_affine(vk.alpha_g1),
             "beta_g2": _parse_hex_point_base_group2_affine(vk.beta_g2),
@@ -198,5 +199,5 @@ def _parse_hex_point_base_group1_affine(
 
 def _parse_hex_point_base_group2_affine(
         point: HexPointBaseGroup2Affine
-) -> Tuple[List[str], List[str]]:
-    return (point.x_coord, point.y_coord)
+) -> Tuple[Tuple[str], Tuple[str]]:
+    return (tuple(point.x_coord), tuple(point.y_coord))

--- a/libzeth/core/field_element_utils.hpp
+++ b/libzeth/core/field_element_utils.hpp
@@ -38,16 +38,27 @@ std::string bigint_to_hex(const libff::bigint<FieldT::num_limbs> &limbs);
 template<typename FieldT>
 libff::bigint<FieldT::num_limbs> bigint_from_hex(const std::string &hex);
 
-/// Convert a field element to an hexadecimal string
-/// The element is assumed to be from an arbitrary field (which can be
-/// an extension). As such the function first checks the degree of the
-/// extension field in order to serialize the element correctly.
+/// Convert a base/ground field element to an hexadecimal string
 template<typename FieldT>
-std::string field_element_to_hex(const FieldT &field_el);
+std::string base_field_element_to_hex(const FieldT &field_el);
 
-/// Convert an hexadecimal string to a field element
+/// Convert an hexadecimal string to a base/ground field element
 template<typename FieldT>
-FieldT field_element_from_hex(const std::string &field_str);
+FieldT base_field_element_from_hex(const std::string &field_str);
+
+/// Convert an extension field element to a vector of hexadecimal strings.
+/// All coefficients necessary to represent the extension field element
+/// are written contiguously in the vector, i.e. this function does not
+/// support extension fields built as "towers".
+template<typename EFieldT>
+std::vector<std::string> ext_field_element_to_hex(const EFieldT &field_el);
+
+/// Convert a vector of hexadecimal strings to an extension field element.
+/// All coefficients necessary to represent the extension field element
+/// are written contiguously in the vector, i.e. this function does not
+/// support extension fields built as "towers".
+template<typename EFieldT>
+EFieldT ext_field_element_from_hex(const std::vector<std::string> &field_str);
 
 } // namespace libzeth
 

--- a/libzeth/core/field_element_utils.hpp
+++ b/libzeth/core/field_element_utils.hpp
@@ -39,6 +39,9 @@ template<typename FieldT>
 libff::bigint<FieldT::num_limbs> bigint_from_hex(const std::string &hex);
 
 /// Convert a field element to an hexadecimal string
+/// The element is assumed to be from an arbitrary field (which can be
+/// an extension). As such the function first checks the degree of the
+/// extension field in order to serialize the element correctly.
 template<typename FieldT>
 std::string field_element_to_hex(const FieldT &field_el);
 

--- a/libzeth/core/field_element_utils.tcc
+++ b/libzeth/core/field_element_utils.tcc
@@ -52,12 +52,11 @@ template<typename EFieldT>
 std::vector<std::string> ext_field_element_to_hex(const EFieldT &field_el)
 {
     const size_t extension_degree = EFieldT::extension_degree();
-    const size_t tower_extension_degree = EFieldT::tower_extension_degree;
 
     // Make sure we process an extension field element
     BOOST_ASSERT(extension_degree > 1);
     // Make sure we process a "non-towered" extension field element
-    BOOST_ASSERT(extension_degree == tower_extension_degree);
+    BOOST_ASSERT(extension_degree == EFieldT::tower_extension_degree);
 
     std::vector<std::string> res;
     for (size_t i = 0; i < extension_degree; i++) {
@@ -72,12 +71,11 @@ template<typename EFieldT>
 EFieldT ext_field_element_from_hex(const std::vector<std::string> &hex_vec)
 {
     const size_t extension_degree = EFieldT::extension_degree();
-    const size_t tower_extension_degree = EFieldT::tower_extension_degree;
 
     // Make sure we process an extension field element
     BOOST_ASSERT(extension_degree > 1);
     // Make sure we process a "non-towered" extension field element
-    BOOST_ASSERT(extension_degree == tower_extension_degree);
+    BOOST_ASSERT(extension_degree == EFieldT::tower_extension_degree);
     // Make sure we process an input in the right form
     BOOST_ASSERT(extension_degree == hex_vec.size());
 

--- a/libzeth/core/field_element_utils.tcc
+++ b/libzeth/core/field_element_utils.tcc
@@ -8,6 +8,8 @@
 #include "libzeth/core/field_element_utils.hpp"
 #include "libzeth/core/utils.hpp"
 
+#include <boost/assert.hpp>
+
 #include <iomanip>
 
 /// This file uses types and preprocessor variables defined in the `gmp.h`
@@ -34,9 +36,33 @@ libff::bigint<FieldT::num_limbs> bigint_from_hex(const std::string &hex)
 }
 
 template<typename FieldT>
-std::string field_element_to_hex(const FieldT &field_el)
+std::string base_field_element_to_hex(const FieldT &field_el)
 {
+    // Serialize a "ground/base" field element
+    //BOOST_ASSERT(FieldT::extension_degree() == 1);
     return bigint_to_hex<FieldT>(field_el.as_bigint());
+}
+
+template<typename EFieldT>
+std::string ext_field_element_to_hex(const EFieldT &field_el)
+{
+    const size_t extension_degree = EFieldT::extension_degree();
+    const size_t tower_extension_degree = EFieldT::tower_extension_degree;
+
+    // Make sure we process an extension field element
+    //BOOST_ASSERT(extension_degree > 1);
+    // Make sure we process a "non-towered" extension field element
+    BOOST_ASSERT(extension_degree == tower_extension_degree);
+
+    std::stringstream ss;
+    for (size_t i = 0; i < extension_degree; i++) {
+        if (i != 0){
+            ss << ", ";
+        }
+        ss << "\"0x" + bigint_to_hex<typename EFieldT::my_Fp>(field_el.coeffs[i].as_bigint()) + "\"";
+    }
+
+    return "[" + ss.str() + "]";
 }
 
 template<typename FieldT> FieldT field_element_from_hex(const std::string &hex)

--- a/libzeth/core/field_element_utils.tcc
+++ b/libzeth/core/field_element_utils.tcc
@@ -39,35 +39,55 @@ template<typename FieldT>
 std::string base_field_element_to_hex(const FieldT &field_el)
 {
     // Serialize a "ground/base" field element
-    //BOOST_ASSERT(FieldT::extension_degree() == 1);
+    BOOST_ASSERT(FieldT::extension_degree() == 1);
     return bigint_to_hex<FieldT>(field_el.as_bigint());
 }
 
+template<typename FieldT> FieldT base_field_element_from_hex(const std::string &hex)
+{
+    return FieldT(bigint_from_hex<FieldT>(hex));
+}
+
 template<typename EFieldT>
-std::string ext_field_element_to_hex(const EFieldT &field_el)
+std::vector<std::string> ext_field_element_to_hex(const EFieldT &field_el)
 {
     const size_t extension_degree = EFieldT::extension_degree();
     const size_t tower_extension_degree = EFieldT::tower_extension_degree;
 
     // Make sure we process an extension field element
-    //BOOST_ASSERT(extension_degree > 1);
+    BOOST_ASSERT(extension_degree > 1);
     // Make sure we process a "non-towered" extension field element
     BOOST_ASSERT(extension_degree == tower_extension_degree);
 
-    std::stringstream ss;
+    std::vector<std::string> res;
     for (size_t i = 0; i < extension_degree; i++) {
-        if (i != 0){
-            ss << ", ";
-        }
-        ss << "\"0x" + bigint_to_hex<typename EFieldT::my_Fp>(field_el.coeffs[i].as_bigint()) + "\"";
+        res.push_back(bigint_to_hex<typename EFieldT::my_Fp>(field_el.coeffs[i].as_bigint()));
     }
 
-    return "[" + ss.str() + "]";
+    return res;
 }
 
-template<typename FieldT> FieldT field_element_from_hex(const std::string &hex)
+template<typename EFieldT>
+EFieldT ext_field_element_from_hex(const std::vector<std::string> &hex_vec)
 {
-    return FieldT(bigint_from_hex<FieldT>(hex));
+    const size_t extension_degree = EFieldT::extension_degree();
+    const size_t tower_extension_degree = EFieldT::tower_extension_degree;
+
+    // Make sure we process an extension field element
+    BOOST_ASSERT(extension_degree > 1);
+    // Make sure we process a "non-towered" extension field element
+    BOOST_ASSERT(extension_degree == tower_extension_degree);
+    // Make sure we process the right input
+    BOOST_ASSERT(extension_degree == hex_vec.size());
+
+    typename EFieldT::my_Fp tmp[extension_degree];
+    for (size_t i = 0; i < extension_degree; i++) {
+        tmp[i] = base_field_element_from_hex<typename EFieldT::my_Fp>(hex_vec[i]);
+    }
+
+    EFieldT el = EFieldT();
+    std::copy(std::begin(tmp), std::end(tmp), std::begin(el.coeffs));
+    return el;
 }
 
 } // namespace libzeth

--- a/libzeth/core/field_element_utils.tcc
+++ b/libzeth/core/field_element_utils.tcc
@@ -9,7 +9,6 @@
 #include "libzeth/core/utils.hpp"
 
 #include <boost/assert.hpp>
-
 #include <iomanip>
 
 /// This file uses types and preprocessor variables defined in the `gmp.h`
@@ -43,7 +42,8 @@ std::string base_field_element_to_hex(const FieldT &field_el)
     return bigint_to_hex<FieldT>(field_el.as_bigint());
 }
 
-template<typename FieldT> FieldT base_field_element_from_hex(const std::string &hex)
+template<typename FieldT>
+FieldT base_field_element_from_hex(const std::string &hex)
 {
     return FieldT(bigint_from_hex<FieldT>(hex));
 }
@@ -61,7 +61,8 @@ std::vector<std::string> ext_field_element_to_hex(const EFieldT &field_el)
 
     std::vector<std::string> res;
     for (size_t i = 0; i < extension_degree; i++) {
-        res.push_back(bigint_to_hex<typename EFieldT::my_Fp>(field_el.coeffs[i].as_bigint()));
+        res.push_back(bigint_to_hex<typename EFieldT::my_Fp>(
+            field_el.coeffs[i].as_bigint()));
     }
 
     return res;
@@ -82,7 +83,8 @@ EFieldT ext_field_element_from_hex(const std::vector<std::string> &hex_vec)
 
     typename EFieldT::my_Fp tmp[extension_degree];
     for (size_t i = 0; i < extension_degree; i++) {
-        tmp[i] = base_field_element_from_hex<typename EFieldT::my_Fp>(hex_vec[i]);
+        tmp[i] =
+            base_field_element_from_hex<typename EFieldT::my_Fp>(hex_vec[i]);
     }
 
     // TODO: Add constructor from array in libff to avoid to extra copy step

--- a/libzeth/core/field_element_utils.tcc
+++ b/libzeth/core/field_element_utils.tcc
@@ -85,11 +85,7 @@ EFieldT ext_field_element_from_hex(const std::vector<std::string> &hex_vec)
             base_field_element_from_hex<typename EFieldT::my_Fp>(hex_vec[i]);
     }
 
-    // TODO: Add constructor from array in libff to avoid to extra copy step
-    // that would be cleaner.
-    EFieldT el = EFieldT();
-    std::copy(std::begin(tmp), std::end(tmp), std::begin(el.coeffs));
-    return el;
+    return EFieldT(tmp);
 }
 
 } // namespace libzeth

--- a/libzeth/core/field_element_utils.tcc
+++ b/libzeth/core/field_element_utils.tcc
@@ -77,7 +77,7 @@ EFieldT ext_field_element_from_hex(const std::vector<std::string> &hex_vec)
     BOOST_ASSERT(extension_degree > 1);
     // Make sure we process a "non-towered" extension field element
     BOOST_ASSERT(extension_degree == tower_extension_degree);
-    // Make sure we process the right input
+    // Make sure we process an input in the right form
     BOOST_ASSERT(extension_degree == hex_vec.size());
 
     typename EFieldT::my_Fp tmp[extension_degree];
@@ -85,6 +85,8 @@ EFieldT ext_field_element_from_hex(const std::vector<std::string> &hex_vec)
         tmp[i] = base_field_element_from_hex<typename EFieldT::my_Fp>(hex_vec[i]);
     }
 
+    // TODO: Add constructor from array in libff to avoid to extra copy step
+    // that would be cleaner.
     EFieldT el = EFieldT();
     std::copy(std::begin(tmp), std::end(tmp), std::begin(el.coeffs));
     return el;

--- a/libzeth/core/group_element_utils.hpp
+++ b/libzeth/core/group_element_utils.hpp
@@ -22,8 +22,10 @@ libff::G1<ppT> point_g1_affine_from_json(const std::string &grp_str);
 
 /// Convert a group element of G2 to a json string (list of hexadecimal
 /// strings). This function assumes that the group element is in affine form,
-/// and that both coordinates (X, Y) are elements of a an extension field of
-/// degree 2.
+/// and that both coordinates (X, Y) are elements of an extension field which
+/// is not built as a tower. Both X and Y are written in "human readable"
+/// order, i.e. the coefficients of the polynomial are written from higher
+/// degree to smaller (e.g. E = [c2, c1, c0], where E = c2 * x^2 + c1 * x + c0)
 template<typename ppT>
 std::string point_g2_affine_to_json(const libff::G2<ppT> &point);
 

--- a/libzeth/core/group_element_utils.tcc
+++ b/libzeth/core/group_element_utils.tcc
@@ -15,8 +15,8 @@ std::string point_g1_affine_to_json(const libff::G1<ppT> &point)
 {
     libff::G1<ppT> affine_p = point;
     affine_p.to_affine_coordinates();
-    return "[\"0x" + bigint_to_hex<libff::Fq<ppT>>(affine_p.X.as_bigint()) +
-           "\", \"0x" + bigint_to_hex<libff::Fq<ppT>>(affine_p.Y.as_bigint()) +
+    return "[\"0x" + field_element_to_hex<libff::Fq<ppT>>(affine_p.X) +
+           "\", \"0x" + field_element_to_hex<libff::Fq<ppT>>(affine_p.Y) +
            "\"]";
 }
 
@@ -47,18 +47,9 @@ std::string point_g2_affine_to_json(const libff::G2<ppT> &point)
 {
     libff::G2<ppT> affine_p = point;
     affine_p.to_affine_coordinates();
-    return "[\n"
-           "[\"0x" +
-           bigint_to_hex<libff::Fq<ppT>>(affine_p.X.c1.as_bigint()) +
-           "\", \"0x" +
-           bigint_to_hex<libff::Fq<ppT>>(affine_p.X.c0.as_bigint()) +
-           "\"],\n"
-           "[\"0x" +
-           bigint_to_hex<libff::Fq<ppT>>(affine_p.Y.c1.as_bigint()) +
-           "\", \"0x" +
-           bigint_to_hex<libff::Fq<ppT>>(affine_p.Y.c0.as_bigint()) +
-           "\"]\n"
-           "]";
+    return "[\"0x" + field_element_to_hex<libff::Fq<ppT>>(affine_p.X) +
+           "\", \"0x" + field_element_to_hex<libff::Fq<ppT>>(affine_p.Y) +
+           "\"]";
 }
 
 } // namespace libzeth

--- a/libzeth/core/group_element_utils.tcc
+++ b/libzeth/core/group_element_utils.tcc
@@ -15,8 +15,8 @@ std::string point_g1_affine_to_json(const libff::G1<ppT> &point)
 {
     libff::G1<ppT> affine_p = point;
     affine_p.to_affine_coordinates();
-    return "[\"0x" + field_element_to_hex<libff::Fq<ppT>>(affine_p.X) +
-           "\", \"0x" + field_element_to_hex<libff::Fq<ppT>>(affine_p.Y) +
+    return "[\"0x" + base_field_element_to_hex<libff::Fq<ppT>>(affine_p.X) +
+           "\", \"0x" + base_field_element_to_hex<libff::Fq<ppT>>(affine_p.Y) +
            "\"]";
 }
 
@@ -29,7 +29,7 @@ libff::G1<ppT> point_g1_affine_from_json(const std::string &grp_str)
         const size_t end_hex = grp_str.find("\"", next_hex_pos);
         const std::string next_hex =
             grp_str.substr(next_hex_pos, end_hex - next_hex_pos);
-        coordinates.push_back(field_element_from_hex<libff::Fq<ppT>>(next_hex));
+        coordinates.push_back(base_field_element_from_hex<libff::Fq<ppT>>(next_hex));
         next_hex_pos = grp_str.find("0x", end_hex);
     }
 
@@ -47,8 +47,8 @@ std::string point_g2_affine_to_json(const libff::G2<ppT> &point)
 {
     libff::G2<ppT> affine_p = point;
     affine_p.to_affine_coordinates();
-    return "[\"0x" + field_element_to_hex<libff::Fq<ppT>>(affine_p.X) +
-           "\", \"0x" + field_element_to_hex<libff::Fq<ppT>>(affine_p.Y) +
+    return "[\"0x" + ext_field_element_to_hex<libff::Fqe<ppT>>(affine_p.X) +
+           "\", \"0x" + ext_field_element_to_hex<libff::Fqe<ppT>>(affine_p.Y) +
            "\"]";
 }
 

--- a/libzeth/core/group_element_utils.tcc
+++ b/libzeth/core/group_element_utils.tcc
@@ -29,7 +29,8 @@ libff::G1<ppT> point_g1_affine_from_json(const std::string &grp_str)
         const size_t end_hex = grp_str.find("\"", next_hex_pos);
         const std::string next_hex =
             grp_str.substr(next_hex_pos, end_hex - next_hex_pos);
-        coordinates.push_back(base_field_element_from_hex<libff::Fq<ppT>>(next_hex));
+        coordinates.push_back(
+            base_field_element_from_hex<libff::Fq<ppT>>(next_hex));
         next_hex_pos = grp_str.find("0x", end_hex);
     }
 

--- a/libzeth/core/group_element_utils.tcc
+++ b/libzeth/core/group_element_utils.tcc
@@ -48,9 +48,25 @@ std::string point_g2_affine_to_json(const libff::G2<ppT> &point)
 {
     libff::G2<ppT> affine_p = point;
     affine_p.to_affine_coordinates();
-    return "[\"0x" + ext_field_element_to_hex<libff::Fqe<ppT>>(affine_p.X) +
-           "\", \"0x" + ext_field_element_to_hex<libff::Fqe<ppT>>(affine_p.Y) +
-           "\"]";
+    const std::vector<std::string> x_coord = ext_field_element_to_hex<libff::Fqe<ppT>>(affine_p.X);
+    const std::vector<std::string> y_coord = ext_field_element_to_hex<libff::Fqe<ppT>>(affine_p.Y);
+
+    const size_t extension_degree = libff::Fqe<ppT>::extension_degree();
+    BOOST_ASSERT(extension_degree >= 2);
+
+    std::stringstream ss;
+    // Write the coordinates in reverse order to match the previous implementation
+    ss << "[\n[\"0x" <<  x_coord[extension_degree - 1];
+    for (size_t i = extension_degree - 1; i >= 1; --i) {
+        ss << "\", \"0x" << x_coord[i-1];
+    }
+    ss << "\"],\n[\"0x" << y_coord[extension_degree - 1];
+    for (size_t i = extension_degree - 1; i >= 1; --i) {
+        ss << "\", \"0x" << y_coord[i-1];
+    }
+    ss << "\"]\n]";
+
+    return ss.str();
 }
 
 } // namespace libzeth

--- a/libzeth/core/group_element_utils.tcc
+++ b/libzeth/core/group_element_utils.tcc
@@ -48,21 +48,24 @@ std::string point_g2_affine_to_json(const libff::G2<ppT> &point)
 {
     libff::G2<ppT> affine_p = point;
     affine_p.to_affine_coordinates();
-    const std::vector<std::string> x_coord = ext_field_element_to_hex<libff::Fqe<ppT>>(affine_p.X);
-    const std::vector<std::string> y_coord = ext_field_element_to_hex<libff::Fqe<ppT>>(affine_p.Y);
+    const std::vector<std::string> x_coord =
+        ext_field_element_to_hex<libff::Fqe<ppT>>(affine_p.X);
+    const std::vector<std::string> y_coord =
+        ext_field_element_to_hex<libff::Fqe<ppT>>(affine_p.Y);
 
     const size_t extension_degree = libff::Fqe<ppT>::extension_degree();
     BOOST_ASSERT(extension_degree >= 2);
 
     std::stringstream ss;
-    // Write the coordinates in reverse order to match the previous implementation
-    ss << "[\n[\"0x" <<  x_coord[extension_degree - 1];
+    // Write the coordinates in reverse order to match the previous
+    // implementation
+    ss << "[\n[\"0x" << x_coord[extension_degree - 1];
     for (size_t i = extension_degree - 1; i >= 1; --i) {
-        ss << "\", \"0x" << x_coord[i-1];
+        ss << "\", \"0x" << x_coord[i - 1];
     }
     ss << "\"],\n[\"0x" << y_coord[extension_degree - 1];
     for (size_t i = extension_degree - 1; i >= 1; --i) {
-        ss << "\", \"0x" << y_coord[i-1];
+        ss << "\", \"0x" << y_coord[i - 1];
     }
     ss << "\"]\n]";
 

--- a/libzeth/mpc/groth16/powersoftau_utils.tcc
+++ b/libzeth/mpc/groth16/powersoftau_utils.tcc
@@ -70,7 +70,7 @@ std::istream &read_powersoftau_fp2(
     libff::bigint<n + 1> c1;
 
     mpn_tdiv_qr(
-        c1.data,              // quotient
+        c1.data,                     // quotient
         el.coeffs[0].mont_repr.data, // remainder
         0,
         packed.data,

--- a/libzeth/mpc/groth16/powersoftau_utils.tcc
+++ b/libzeth/mpc/groth16/powersoftau_utils.tcc
@@ -71,7 +71,7 @@ std::istream &read_powersoftau_fp2(
 
     mpn_tdiv_qr(
         c1.data,              // quotient
-        el.c0.mont_repr.data, // remainder
+        el.coeffs[0].mont_repr.data, // remainder
         0,
         packed.data,
         n * 2,
@@ -79,11 +79,11 @@ std::istream &read_powersoftau_fp2(
         n);
 
     for (size_t i = 0; i < n; ++i) {
-        el.c1.mont_repr.data[i] = c1.data[i];
+        el.coeffs[1].mont_repr.data[i] = c1.data[i];
     }
 
-    to_montgomery_repr(el.c0);
-    to_montgomery_repr(el.c1);
+    to_montgomery_repr(el.coeffs[0]);
+    to_montgomery_repr(el.coeffs[1]);
 
     return in;
 }
@@ -95,8 +95,8 @@ void write_powersoftau_fp2(
     // Fq2 data is packed into a single 512 bit integer as:
     //
     //   c1 * modulus + c0
-    libff::Fp_model<n, modulus> c0 = from_montgomery_repr(fp2.c0);
-    libff::Fp_model<n, modulus> c1 = from_montgomery_repr(fp2.c1);
+    libff::Fp_model<n, modulus> c0 = from_montgomery_repr(fp2.coeffs[0]);
+    libff::Fp_model<n, modulus> c1 = from_montgomery_repr(fp2.coeffs[1]);
 
     libff::bigint<2 * n> packed;
     packed.clear();

--- a/libzeth/serialization/proto_utils.tcc
+++ b/libzeth/serialization/proto_utils.tcc
@@ -22,8 +22,8 @@ zeth_proto::HexPointBaseGroup1Affine point_g1_affine_to_proto(
     aff.to_affine_coordinates();
 
     zeth_proto::HexPointBaseGroup1Affine res;
-    res.set_x_coord("0x" + field_element_to_hex<Fq>(aff.X));
-    res.set_y_coord("0x" + field_element_to_hex<Fq>(aff.Y));
+    res.set_x_coord("0x" + base_field_element_to_hex<Fq>(aff.X));
+    res.set_y_coord("0x" + base_field_element_to_hex<Fq>(aff.Y));
     return res;
 }
 
@@ -33,8 +33,8 @@ libff::G1<ppT> point_g1_affine_from_proto(
 {
     using Fq = libff::Fq<ppT>;
 
-    Fq x_coordinate = field_element_from_hex<Fq>(point.x_coord());
-    Fq y_coordinate = field_element_from_hex<Fq>(point.y_coord());
+    Fq x_coordinate = base_field_element_from_hex<Fq>(point.x_coord());
+    Fq y_coordinate = base_field_element_from_hex<Fq>(point.y_coord());
     return libff::G1<ppT>(x_coordinate, y_coordinate, Fq::one());
 }
 
@@ -42,14 +42,15 @@ template<typename ppT>
 zeth_proto::HexPointBaseGroup2Affine point_g2_affine_to_proto(
     const libff::G2<ppT> &point)
 {
+    using Fqe = libff::Fqe<ppT>;
+    
     assert(!point.is_zero());
-    using Fq = libff::Fq<ppT>;
     libff::G2<ppT> aff = point;
     aff.to_affine_coordinates();
 
     zeth_proto::HexPointBaseGroup2Affine res;
-    res.set_x_coord(field_element_to_hex<Fq>(aff.X));
-    res.set_y_coord(field_element_to_hex<Fq>(aff.Y));
+    res.set_x_coord(ext_field_element_to_hex<Fqe>(aff.X));
+    res.set_y_coord(ext_field_element_to_hex<Fqe>(aff.Y));
 
     return res;
 }
@@ -70,11 +71,9 @@ libff::G2<ppT> point_g2_affine_from_proto(
     // lying in the base field
 
     // TODO
-    Fq x_c0 = field_element_from_hex<Fq>(point.x_coord());
-    Fq x_c1 = field_element_from_hex<Fq>(point.x_coord());
-    Fq y_c0 = field_element_from_hex<Fq>(point.y_coord());
-    Fq y_c1 = field_element_from_hex<Fq>(point.y_coord());
-    return libff::G2<ppT>(Fqe(x_c0, x_c1), Fqe(y_c0, y_c1), Fqe::one());
+    Fqe x = ext_field_element_from_hex<Fqe>(point.x_coord());
+    Fqe y = ext_field_element_from_hex<Fqe>(point.y_coord());
+    return libff::G2<ppT>(x, y, Fqe::one());
 }
 
 template<typename FieldT, size_t TreeDepth>
@@ -87,7 +86,7 @@ joinsplit_input<FieldT, TreeDepth> joinsplit_input_from_proto(
 
     std::vector<FieldT> input_merkle_path;
     for (size_t i = 0; i < TreeDepth; i++) {
-        FieldT mk_node = field_element_from_hex<FieldT>(input.merkle_path(i));
+        FieldT mk_node = base_field_element_from_hex<FieldT>(input.merkle_path(i));
         input_merkle_path.push_back(mk_node);
     }
 
@@ -131,7 +130,7 @@ std::vector<libff::Fr<ppT>> primary_inputs_from_string(
         const size_t end_hex = input_str.find("\"", next_hex_pos);
         const std::string next_hex =
             input_str.substr(next_hex_pos, end_hex - next_hex_pos);
-        res.push_back(field_element_from_hex<libff::Fr<ppT>>(next_hex));
+        res.push_back(base_field_element_from_hex<libff::Fr<ppT>>(next_hex));
         next_hex_pos = input_str.find("0x", end_hex);
     }
     return res;

--- a/libzeth/serialization/proto_utils.tcc
+++ b/libzeth/serialization/proto_utils.tcc
@@ -47,10 +47,16 @@ zeth_proto::HexPointBaseGroup2Affine point_g2_affine_to_proto(
     assert(!point.is_zero());
     libff::G2<ppT> aff = point;
     aff.to_affine_coordinates();
+    const std::vector<std::string> x_coord = ext_field_element_to_hex<libff::Fqe<ppT>>(aff.X);
+    const std::vector<std::string> y_coord = ext_field_element_to_hex<libff::Fqe<ppT>>(aff.Y);
+
+    BOOST_ASSERT(x_coord.size() == y_coord.size());
 
     zeth_proto::HexPointBaseGroup2Affine res;
-    res.set_x_coord(ext_field_element_to_hex<Fqe>(aff.X));
-    res.set_y_coord(ext_field_element_to_hex<Fqe>(aff.Y));
+    for (size_t i = 0; i < x_coord.size(); i++) {
+        res.add_x_coord(x_coord[i]);
+        res.add_y_coord(y_coord[i]);
+    }
 
     return res;
 }
@@ -59,7 +65,6 @@ template<typename ppT>
 libff::G2<ppT> point_g2_affine_from_proto(
     const zeth_proto::HexPointBaseGroup2Affine &point)
 {
-    using Fq = libff::Fq<ppT>;
     using Fqe = libff::Fqe<ppT>;
 
     // See:
@@ -70,9 +75,14 @@ libff::G2<ppT> point_g2_affine_from_proto(
     // As such, each element of Fqe is assumed to be a vector of 2 coefficients
     // lying in the base field
 
-    // TODO
-    Fqe x = ext_field_element_from_hex<Fqe>(point.x_coord());
-    Fqe y = ext_field_element_from_hex<Fqe>(point.y_coord());
+    auto protobuf_x_coord = point.x_coord();
+    std::vector<std::string> x_coord(protobuf_x_coord.begin(), protobuf_x_coord.end());
+
+    auto protobuf_y_coord = point.y_coord();
+    std::vector<std::string> y_coord(protobuf_y_coord.begin(), protobuf_y_coord.end());
+
+    Fqe x = ext_field_element_from_hex<Fqe>(x_coord);
+    Fqe y = ext_field_element_from_hex<Fqe>(y_coord);
     return libff::G2<ppT>(x, y, Fqe::one());
 }
 

--- a/libzeth/serialization/proto_utils.tcc
+++ b/libzeth/serialization/proto_utils.tcc
@@ -42,13 +42,13 @@ template<typename ppT>
 zeth_proto::HexPointBaseGroup2Affine point_g2_affine_to_proto(
     const libff::G2<ppT> &point)
 {
-    using Fqe = libff::Fqe<ppT>;
-
     assert(!point.is_zero());
     libff::G2<ppT> aff = point;
     aff.to_affine_coordinates();
-    const std::vector<std::string> x_coord = ext_field_element_to_hex<libff::Fqe<ppT>>(aff.X);
-    const std::vector<std::string> y_coord = ext_field_element_to_hex<libff::Fqe<ppT>>(aff.Y);
+    const std::vector<std::string> x_coord =
+        ext_field_element_to_hex<libff::Fqe<ppT>>(aff.X);
+    const std::vector<std::string> y_coord =
+        ext_field_element_to_hex<libff::Fqe<ppT>>(aff.Y);
 
     BOOST_ASSERT(x_coord.size() == y_coord.size());
 
@@ -65,8 +65,6 @@ template<typename ppT>
 libff::G2<ppT> point_g2_affine_from_proto(
     const zeth_proto::HexPointBaseGroup2Affine &point)
 {
-    using Fqe = libff::Fqe<ppT>;
-
     // See:
     // https://github.com/scipr-lab/libff/blob/master/libff/algebra/curves/public_params.hpp#L88
     // and:
@@ -76,14 +74,16 @@ libff::G2<ppT> point_g2_affine_from_proto(
     // lying in the base field
 
     auto protobuf_x_coord = point.x_coord();
-    std::vector<std::string> x_coord(protobuf_x_coord.begin(), protobuf_x_coord.end());
+    std::vector<std::string> x_coord(
+        protobuf_x_coord.begin(), protobuf_x_coord.end());
 
     auto protobuf_y_coord = point.y_coord();
-    std::vector<std::string> y_coord(protobuf_y_coord.begin(), protobuf_y_coord.end());
+    std::vector<std::string> y_coord(
+        protobuf_y_coord.begin(), protobuf_y_coord.end());
 
-    Fqe x = ext_field_element_from_hex<Fqe>(x_coord);
-    Fqe y = ext_field_element_from_hex<Fqe>(y_coord);
-    return libff::G2<ppT>(x, y, Fqe::one());
+    libff::Fqe<ppT> x = ext_field_element_from_hex<libff::Fqe<ppT>>(x_coord);
+    libff::Fqe<ppT> y = ext_field_element_from_hex<libff::Fqe<ppT>>(y_coord);
+    return libff::G2<ppT>(x, y, libff::Fqe<ppT>::one());
 }
 
 template<typename FieldT, size_t TreeDepth>

--- a/libzeth/serialization/proto_utils.tcc
+++ b/libzeth/serialization/proto_utils.tcc
@@ -48,10 +48,8 @@ zeth_proto::HexPointBaseGroup2Affine point_g2_affine_to_proto(
     aff.to_affine_coordinates();
 
     zeth_proto::HexPointBaseGroup2Affine res;
-    res.set_x_c0_coord("0x" + field_element_to_hex<Fq>(aff.X.c0));
-    res.set_x_c1_coord("0x" + field_element_to_hex<Fq>(aff.X.c1));
-    res.set_y_c0_coord("0x" + field_element_to_hex<Fq>(aff.Y.c0));
-    res.set_y_c1_coord("0x" + field_element_to_hex<Fq>(aff.Y.c1));
+    res.set_x_coord(field_element_to_hex<Fq>(aff.X));
+    res.set_y_coord(field_element_to_hex<Fq>(aff.Y));
 
     return res;
 }
@@ -71,10 +69,11 @@ libff::G2<ppT> point_g2_affine_from_proto(
     // As such, each element of Fqe is assumed to be a vector of 2 coefficients
     // lying in the base field
 
-    Fq x_c0 = field_element_from_hex<Fq>(point.x_c0_coord());
-    Fq x_c1 = field_element_from_hex<Fq>(point.x_c1_coord());
-    Fq y_c0 = field_element_from_hex<Fq>(point.y_c0_coord());
-    Fq y_c1 = field_element_from_hex<Fq>(point.y_c1_coord());
+    // TODO
+    Fq x_c0 = field_element_from_hex<Fq>(point.x_coord());
+    Fq x_c1 = field_element_from_hex<Fq>(point.x_coord());
+    Fq y_c0 = field_element_from_hex<Fq>(point.y_coord());
+    Fq y_c1 = field_element_from_hex<Fq>(point.y_coord());
     return libff::G2<ppT>(Fqe(x_c0, x_c1), Fqe(y_c0, y_c1), Fqe::one());
 }
 

--- a/libzeth/serialization/proto_utils.tcc
+++ b/libzeth/serialization/proto_utils.tcc
@@ -54,12 +54,12 @@ zeth_proto::HexPointBaseGroup2Affine point_g2_affine_to_proto(
     BOOST_ASSERT(extension_degree >= 2);
 
     zeth_proto::HexPointBaseGroup2Affine res;
-    res.add_x_coord("0x" +  x_coord[extension_degree - 1]);
-    res.add_y_coord("0x" +  y_coord[extension_degree - 1]);
+    res.add_x_coord("0x" + x_coord[extension_degree - 1]);
+    res.add_y_coord("0x" + y_coord[extension_degree - 1]);
 
     for (size_t i = extension_degree - 1; i >= 1; --i) {
-        res.add_x_coord("0x" +  x_coord[i - 1]);
-        res.add_y_coord("0x" +  y_coord[i - 1]);
+        res.add_x_coord("0x" + x_coord[i - 1]);
+        res.add_y_coord("0x" + y_coord[i - 1]);
     }
 
     return res;
@@ -77,13 +77,15 @@ libff::G2<ppT> point_g2_affine_from_proto(
     // As such, each element of Fqe is assumed to be a vector of 2 coefficients
     // lying in the base field
 
+    // We invert the list of coefficients representing the extension field
+    /// elements as they are inverted in the `point_g2_affine_to_proto` function
     auto protobuf_x_coord = point.x_coord();
     std::vector<std::string> x_coord(
-        protobuf_x_coord.begin(), protobuf_x_coord.end());
+        protobuf_x_coord.rbegin(), protobuf_x_coord.rend());
 
     auto protobuf_y_coord = point.y_coord();
     std::vector<std::string> y_coord(
-        protobuf_y_coord.begin(), protobuf_y_coord.end());
+        protobuf_y_coord.rbegin(), protobuf_y_coord.rend());
 
     libff::Fqe<ppT> x = ext_field_element_from_hex<libff::Fqe<ppT>>(x_coord);
     libff::Fqe<ppT> y = ext_field_element_from_hex<libff::Fqe<ppT>>(y_coord);

--- a/libzeth/serialization/proto_utils.tcc
+++ b/libzeth/serialization/proto_utils.tcc
@@ -43,7 +43,7 @@ zeth_proto::HexPointBaseGroup2Affine point_g2_affine_to_proto(
     const libff::G2<ppT> &point)
 {
     using Fqe = libff::Fqe<ppT>;
-    
+
     assert(!point.is_zero());
     libff::G2<ppT> aff = point;
     aff.to_affine_coordinates();
@@ -86,7 +86,8 @@ joinsplit_input<FieldT, TreeDepth> joinsplit_input_from_proto(
 
     std::vector<FieldT> input_merkle_path;
     for (size_t i = 0; i < TreeDepth; i++) {
-        FieldT mk_node = base_field_element_from_hex<FieldT>(input.merkle_path(i));
+        FieldT mk_node =
+            base_field_element_from_hex<FieldT>(input.merkle_path(i));
         input_merkle_path.push_back(mk_node);
     }
 

--- a/libzeth/serialization/proto_utils.tcc
+++ b/libzeth/serialization/proto_utils.tcc
@@ -50,12 +50,16 @@ zeth_proto::HexPointBaseGroup2Affine point_g2_affine_to_proto(
     const std::vector<std::string> y_coord =
         ext_field_element_to_hex<libff::Fqe<ppT>>(aff.Y);
 
-    BOOST_ASSERT(x_coord.size() == y_coord.size());
+    const size_t extension_degree = libff::Fqe<ppT>::extension_degree();
+    BOOST_ASSERT(extension_degree >= 2);
 
     zeth_proto::HexPointBaseGroup2Affine res;
-    for (size_t i = 0; i < x_coord.size(); i++) {
-        res.add_x_coord(x_coord[i]);
-        res.add_y_coord(y_coord[i]);
+    res.add_x_coord("0x" +  x_coord[extension_degree - 1]);
+    res.add_y_coord("0x" +  y_coord[extension_degree - 1]);
+
+    for (size_t i = extension_degree - 1; i >= 1; --i) {
+        res.add_x_coord("0x" +  x_coord[i - 1]);
+        res.add_y_coord("0x" +  y_coord[i - 1]);
     }
 
     return res;

--- a/libzeth/tests/core/field_element_utils_test.cpp
+++ b/libzeth/tests/core/field_element_utils_test.cpp
@@ -10,7 +10,6 @@
 using ppT = libzeth::ppT;
 using Fr = libzeth::FieldT;
 using Fqe = libff::Fqe<ppT>;
-using Fqk = libff::Fqk<ppT>;
 
 using bigint_t = libff::bigint<libzeth::FieldT::num_limbs>;
 
@@ -38,31 +37,33 @@ TEST(FieldElementUtilsTest, BigIntEncodeDecode)
     ASSERT_EQ(bi, bi_decoded);
 }
 
-TEST(FieldElementUtilsTest, FieldElementEncodeDecode)
+TEST(FieldElementUtilsTest, BaseFieldElementEncodeDecode)
 {
     Fr fe = dummy_field_element();
     std::string fe_hex = libzeth::base_field_element_to_hex<Fr>(fe);
     std::cout << "fe_hex: " << fe_hex << std::endl;
-    Fr fe_decoded = libzeth::field_element_from_hex<Fr>(fe_hex);
+    Fr fe_decoded = libzeth::base_field_element_from_hex<Fr>(fe_hex);
     ASSERT_EQ(fe, fe_decoded);
 }
 
-TEST(FieldElementUtilsTest, FieldElementEncode)
+TEST(FieldElementUtilsTest, ExtFieldElementEncodeDecode)
 {
-    Fr fe = dummy_field_element();
-    std::string fe_hex = libzeth::base_field_element_to_hex<Fr>(fe);
-    std::cout << "fe_hex: " << fe_hex << std::endl;
+    Fqe fe = Fqe::random_element();
+    std::vector<std::string> fe_hex = libzeth::ext_field_element_to_hex<Fqe>(fe);
 
-    Fqe el = Fqe::random_element();
-    std::string el_hex = libzeth::ext_field_element_to_hex<Fqe>(el);
-    std::cout << "el_hex: " << el_hex << std::endl;
+    std::string str;
+    for (const auto &entry : fe_hex) str += ("," + entry);
+    std::cout << "fe_hex: " << str << std::endl;
+
+    Fqe fe_decoded = libzeth::ext_field_element_from_hex<Fqe>(fe_hex);
+    ASSERT_EQ(fe, fe_decoded);
 }
 
 TEST(FieldElementUtilsTest, FieldElementDecodeBadString)
 {
     std::string invalid_hex = "xxx";
     ASSERT_THROW(
-        libzeth::field_element_from_hex<Fr>(invalid_hex), std::exception);
+        libzeth::base_field_element_from_hex<Fr>(invalid_hex), std::exception);
 };
 
 } // namespace

--- a/libzeth/tests/core/field_element_utils_test.cpp
+++ b/libzeth/tests/core/field_element_utils_test.cpp
@@ -9,6 +9,9 @@
 
 using ppT = libzeth::ppT;
 using Fr = libzeth::FieldT;
+using Fqe = libff::Fqe<ppT>;
+using Fqk = libff::Fqk<ppT>;
+
 using bigint_t = libff::bigint<libzeth::FieldT::num_limbs>;
 
 namespace
@@ -38,10 +41,21 @@ TEST(FieldElementUtilsTest, BigIntEncodeDecode)
 TEST(FieldElementUtilsTest, FieldElementEncodeDecode)
 {
     Fr fe = dummy_field_element();
-    std::string fe_hex = libzeth::field_element_to_hex<Fr>(fe);
+    std::string fe_hex = libzeth::base_field_element_to_hex<Fr>(fe);
     std::cout << "fe_hex: " << fe_hex << std::endl;
     Fr fe_decoded = libzeth::field_element_from_hex<Fr>(fe_hex);
     ASSERT_EQ(fe, fe_decoded);
+}
+
+TEST(FieldElementUtilsTest, FieldElementEncode)
+{
+    Fr fe = dummy_field_element();
+    std::string fe_hex = libzeth::base_field_element_to_hex<Fr>(fe);
+    std::cout << "fe_hex: " << fe_hex << std::endl;
+
+    Fqe el = Fqe::random_element();
+    std::string el_hex = libzeth::ext_field_element_to_hex<Fqe>(el);
+    std::cout << "el_hex: " << el_hex << std::endl;
 }
 
 TEST(FieldElementUtilsTest, FieldElementDecodeBadString)

--- a/libzeth/tests/core/field_element_utils_test.cpp
+++ b/libzeth/tests/core/field_element_utils_test.cpp
@@ -49,10 +49,12 @@ TEST(FieldElementUtilsTest, BaseFieldElementEncodeDecode)
 TEST(FieldElementUtilsTest, ExtFieldElementEncodeDecode)
 {
     Fqe fe = Fqe::random_element();
-    std::vector<std::string> fe_hex = libzeth::ext_field_element_to_hex<Fqe>(fe);
+    std::vector<std::string> fe_hex =
+        libzeth::ext_field_element_to_hex<Fqe>(fe);
 
     std::string str;
-    for (const auto &entry : fe_hex) str += ("," + entry);
+    for (const auto &entry : fe_hex)
+        str += ("," + entry);
     std::cout << "fe_hex: " << str << std::endl;
 
     Fqe fe_decoded = libzeth::ext_field_element_from_hex<Fqe>(fe_hex);

--- a/prover_server/prover_server.cpp
+++ b/prover_server/prover_server.cpp
@@ -150,7 +150,7 @@ public:
         // Parse received message to feed to the prover
         try {
             libzeth::FieldT root =
-                libzeth::field_element_from_hex<libzeth::FieldT>(
+                libzeth::base_field_element_from_hex<libzeth::FieldT>(
                     proof_inputs->mk_root());
             libzeth::bits64 vpub_in =
                 libzeth::bits64::from_hex(proof_inputs->pub_in_value());


### PR DESCRIPTION
The current proto message for elements of G2 is tailored for a very specific pairing group (bn254) in which elements of G2 have coordinates in F_{q^2}. This is not very flexible and does not allow to use the API for other pairing groups, where elements of G2 can have coordinates in F_{q^m}, m =/= 2.

This PR fixes that.