### PR TITLE
Found boost system to fix linking issues

### DIFF
--- a/mpc_tools/CMakeLists.txt
+++ b/mpc_tools/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Build for mpc utilities
 
-find_package(Boost REQUIRED COMPONENTS program_options)
+find_package(Boost REQUIRED COMPONENTS system program_options)
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
 
 # Add the binary tree to the search path for include files


### PR DESCRIPTION
We link `libboost_system` during the compilation of the pot-process target (see: https://github.com/clearmatics/zeth/blob/develop/mpc_tools/CMakeLists.txt#L16), however, we do not find the package first. I have the following issue when compiling the project:

```bash
[ 92%] Building CXX object mpc_tools/CMakeFiles/pot-process.dir/pot_process/pot_process.cpp.o
[ 92%] Linking CXX executable pot-process
CMakeFiles/pot-process.dir/pot_process/pot_process.cpp.o: In function `boost::system::error_category::std_category::equivalent(std::error_code const&, int) const':
/usr/include/boost/system/error_code.hpp:686: undefined reference to `boost::system::generic_category()'
/usr/include/boost/system/error_code.hpp:689: undefined reference to `boost::system::generic_category()'
/usr/include/boost/system/error_code.hpp:701: undefined reference to `boost::system::generic_category()'
CMakeFiles/pot-process.dir/pot_process/pot_process.cpp.o: In function `boost::system::error_category::std_category::equivalent(int, std::error_condition const&) const':
/usr/include/boost/system/error_code.hpp:656: undefined reference to `boost::system::generic_category()'
/usr/include/boost/system/error_code.hpp:659: undefined reference to `boost::system::generic_category()'
CMakeFiles/pot-process.dir/pot_process/pot_process.cpp.o:/usr/include/boost/system/error_code.hpp:206: more undefined references to `boost::system::generic_category()' follow
CMakeFiles/pot-process.dir/pot_process/pot_process.cpp.o: In function `_GLOBAL__sub_I__ZN11cli_optionsC2Ev':
/usr/include/boost/system/error_code.hpp:210: undefined reference to `boost::system::system_category()'
collect2: error: ld returned 1 exit status
mpc_tools/CMakeFiles/pot-process.dir/build.make:111: recipe for target 'mpc_tools/pot-process' failed
make[2]: *** [mpc_tools/pot-process] Error 1
CMakeFiles/Makefile2:2953: recipe for target 'mpc_tools/CMakeFiles/pot-process.dir/all' failed
make[1]: *** [mpc_tools/CMakeFiles/pot-process.dir/all] Error 2
```

Which is fixed by first finding the boost system package and then linking it. That is what is done in this PR