### PR TITLE
Fix build rule scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,21 +266,23 @@ add_compile_options(-Wall -Wextra)
 #
 # Import configuration to run dev tools on the code
 # Generate the compile database needed for some of the tools we invoke below
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-include(cmake/gcc_dev_tools.cmake)
-include(cmake/clang_dev_tools.cmake)
+if ("${IS_ZETH_PARENT}")
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+  include(cmake/gcc_dev_tools.cmake)
+  include(cmake/clang_dev_tools.cmake)
 
-# Import configuration to compile targets with sanitizers
-include(cmake/sanitizers.cmake)
+  # Import configuration to compile targets with sanitizers
+  include(cmake/sanitizers.cmake)
 
-# Import configuration to generate the code documentation if option is set
-if("${GEN_DOC}")
-    include(cmake/documentation.cmake)
-endif()
+  # Import configuration to generate the code documentation if option is set
+  if("${GEN_DOC}")
+      include(cmake/documentation.cmake)
+  endif()
 
-# Import configuration to generate the coverage report if option is set
-if("${CODE_COVERAGE}")
-    include(cmake/code_coverage.cmake)
+  # Import configuration to generate the coverage report if option is set
+  if("${CODE_COVERAGE}")
+      include(cmake/code_coverage.cmake)
+  endif()
 endif()
 
 # Add all local subdirecetories

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ You can select the sanitizer of your choice (one of the sanitizers listed [here]
 Example:
 ```bash
 cd build
-cmake -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DSANITIZER=Address ..
+cmake -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DSANITIZER=Address -DCMAKE_BUILD_TYPE=Debug ..
 make check
 ```
 
@@ -171,7 +171,7 @@ make clang-tidy
 1. Make sure to enable the `CODE_COVERAGE` option in the CMake configuration.
 2. Compile the tests
 ```bash
-cd build && cmake .. && make check
+cd build && cmake -DCODE_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug .. && make check
 ```
 3. Generate the coverage report:
 ```bash

--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ Note: The `clang-tidy` target runs a clang-tidy python script that should be fet
 
 Example:
 ```bash
+# run-clang-tidy.py needs to be in the PATH to be found
+PATH=$PATH:${PWD}
+chmod +x run-clang-tidy.py
+
 cmake -DUSE_CLANG_FORMAT=ON -DUSE_CPP_CHECK=ON -DUSE_CLANG_TIDY=ON ..
 make cppcheck
 make clang-format

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The following libraries are also required to build:
 To generate the documentation of Zeth:
 ```bash
 cd build
-cmake .. && make docs
+cmake .. -DGEN_DOC=ON && make docs
 ```
 
 ## Compile the project using 'sanitizers'


### PR DESCRIPTION
- Added conditional in cmake config to only create make rules if Zeth is the parent project
- Added missing flags and instructions to the README