### PR TITLE
Client changes to suppot geth-style nodes, such as autonity (depends on #239)

### DIFF
--- a/client/commands/constants.py
+++ b/client/commands/constants.py
@@ -9,6 +9,7 @@ Constants and defaults specific to the CLI interface.
 
 ETH_RPC_ENDPOINT_DEFAULTS = {
     "ganache": "http://localhost:8545",
+    "autonity-helloworld": "http://localhost:8541",
 }
 
 ETH_NETWORK_FILE_DEFAULT = "eth-network"

--- a/client/test_commands/fund_eth_address.py
+++ b/client/test_commands/fund_eth_address.py
@@ -41,6 +41,14 @@ def fund_eth_address(
         # Use the first hosted address.
         source_addr = web3.eth.accounts[0]  # pylint: disable=no-member
 
+        if eth_network.name == "autonity-helloworld":
+            # The Autonity helloworld network supplies hosted accounts, secured
+            # with the password 'test'. Attempt to unlock it.
+            # pylint: disable=import-outside-toplevel, no-member
+            from web3.middleware import geth_poa_middleware  # type: ignore
+            web3.middleware_stack.inject(geth_poa_middleware, layer=0)
+            web3.personal.unlockAccount(source_addr, "test")
+
     print(f"eth_addr = {eth_addr}")
     print(f"source_addr = {source_addr}")
     print(f"amount = {amount}")

--- a/zeth_contracts/truffle.js
+++ b/zeth_contracts/truffle.js
@@ -14,6 +14,11 @@ module.exports = {
       gasprice: 0x1,
       network_id: "*" // Match any network id
     },
+    autonityhelloworld: {
+        host: "localhost",
+        port: 8541,
+        network_id: "*",
+    },
   },
   mocha: {
     useColors: true,


### PR DESCRIPTION
Uses infraastructure in #239 to add a `autonity-helloworld` network configuration.
Support all client operations on `autonity-helloworld`, ensuring that `scripts/test_zeth_cli` and `scripts/test_zeth_cli_token` succeed.