### PR TITLE
Prover server flags

### DIFF
--- a/libzeth/serialization/filesystem_util.cpp
+++ b/libzeth/serialization/filesystem_util.cpp
@@ -9,18 +9,20 @@ namespace libzeth
 
 boost::filesystem::path get_path_to_setup_directory()
 {
+    // If the ZETH_TRUSTED_SETUP_DIR env var is not set, check HOME, and
+    // fallback to current directory.
+
     const char *path = std::getenv("ZETH_TRUSTED_SETUP_DIR");
     if (path != nullptr) {
-        return boost::filesystem::path(path);
+        return path;
     }
 
-    // Fallback   destination if the ZETH_TRUSTED_SETUP_DIR env var is not set
-    // We assume below that `std::getenv("HOME")` does not return `nullptr`
-    boost::filesystem::path home_path =
-        boost::filesystem::path(std::getenv("HOME"));
-    boost::filesystem::path zeth_setup("zeth_setup");
-    boost::filesystem::path default_path = home_path / zeth_setup;
-    return default_path;
+    path = std::getenv("HOME");
+    if (path != nullptr) {
+        return boost::filesystem::path(path) / "zeth_setup";
+    }
+
+    return "";
 }
 
 boost::filesystem::path get_path_to_debug_directory()

--- a/libzeth/serialization/filesystem_util.hpp
+++ b/libzeth/serialization/filesystem_util.hpp
@@ -11,9 +11,11 @@ namespace libzeth
 {
 
 /// This function returns the path to the setup directory in which the SRS will
-/// be written. It assumes that the host OS is compliant with the
-/// POSIX specification since it assumes that the HOME environment variable is
-/// set. See: https://pubs.opengroup.org/onlinepubs/9699919799/
+/// be written and/or read from. It uses the ZETH_TRUSTED_SETUP_DIR environment
+/// variable, if available, falling back to ${HOME}/zeth_setup (using the POSIX
+/// HOME environment variable, see:
+/// https://pubs.opengroup.org/onlinepubs/9699919799/), and finally the current
+/// directory.
 boost::filesystem::path get_path_to_setup_directory();
 
 /// This function returns the path to the debug directory used in Zeth. It


### PR DESCRIPTION
Fix up prover server flags and output, so that keypair files can be written / read and debug output controlled fully.
Related to #242 