### PR TITLE
Extend contribution interval in MPC tests

### DIFF
--- a/testdata/mpc_phase1_server_config.json
+++ b/testdata/mpc_phase1_server_config.json
@@ -8,7 +8,7 @@
         "start_time": "TIME",
 
         "_contribution_interval_description": "Interval time in seconds",
-        "contribution_interval": "10.0",
+        "contribution_interval": "60.0",
 
         "_email_description": "Optional email server and credentials",
         "_email_server": "smtp.myorg.com:465",

--- a/testdata/mpc_phase2_server_config.json
+++ b/testdata/mpc_phase2_server_config.json
@@ -5,7 +5,7 @@
 
         "contributors_file": "../testdata/mpc_contributors.json",
         "start_time": "TIME",
-        "contribution_interval": "10.0",
+        "contribution_interval": "60.0",
         "_email_server": "smtp.myorg.com:465",
         "_email_address": "mpc.coordinator@myorg.com",
         "_email_password_file": "file containing password for email account",


### PR DESCRIPTION
To fix timing issue on CI servers