### PR TITLE
Fix tests namespace

### DIFF
--- a/libzeth/tests/circuits/simple_test.cpp
+++ b/libzeth/tests/circuits/simple_test.cpp
@@ -22,7 +22,7 @@ TEST(SimpleTests, SimpleCircuitProof)
 {
     // Simple circuit
     protoboard<Field> pb;
-    libzeth::test::simple_circuit<Field>(pb);
+    libzeth::tests::simple_circuit<Field>(pb);
 
     // Constraint system
     const r1cs_constraint_system<Field> constraint_system =
@@ -59,7 +59,7 @@ TEST(SimpleTests, SimpleCircuitProofPow2Domain)
 {
     // Simple circuit
     protoboard<Field> pb;
-    test::simple_circuit<Field>(pb);
+    libzeth::tests::simple_circuit<Field>(pb);
 
     const r1cs_constraint_system<Field> constraint_system =
         pb.get_constraint_system();

--- a/libzeth/tests/circuits/simple_test.hpp
+++ b/libzeth/tests/circuits/simple_test.hpp
@@ -9,7 +9,7 @@
 
 namespace libzeth
 {
-namespace test
+namespace tests
 {
 
 // Generate a simple test circuit with 1 public input 'y' and auxiliary
@@ -24,7 +24,7 @@ namespace test
 //   g2 = g1 * x
 template<typename FieldT> void simple_circuit(libsnark::protoboard<FieldT> &pb);
 
-} // namespace test
+} // namespace tests
 } // namespace libzeth
 
 #include "simple_test.tcc"

--- a/libzeth/tests/circuits/simple_test.tcc
+++ b/libzeth/tests/circuits/simple_test.tcc
@@ -9,7 +9,7 @@
 
 namespace libzeth
 {
-namespace test
+namespace tests
 {
 
 template<typename FieldT> void simple_circuit(libsnark::protoboard<FieldT> &pb)
@@ -46,7 +46,7 @@ template<typename FieldT> void simple_circuit(libsnark::protoboard<FieldT> &pb)
         r1cs_constraint<FieldT>(g2 + (4 * g1) + (2 * x) + 5, 1, y), "y");
 }
 
-} // namespace test
+} // namespace tests
 } // namespace libzeth
 
 #endif // __ZETH_TEST_SIMPLE_TEST_TCC__

--- a/libzeth/tests/mpc/groth16/mpc_test.cpp
+++ b/libzeth/tests/mpc/groth16/mpc_test.cpp
@@ -38,7 +38,7 @@ namespace
 r1cs_constraint_system<Fr> get_simple_constraint_system()
 {
     protoboard<Fr> pb;
-    libzeth::test::simple_circuit<Fr>(pb);
+    libzeth::tests::simple_circuit<Fr>(pb);
     r1cs_constraint_system<Fr> cs = pb.get_constraint_system();
     cs.swap_AB_if_beneficial();
     return cs;
@@ -159,7 +159,7 @@ TEST(MPCTests, LinearCombination)
     {
         const qap_instance_evaluation<Fr> qap_evaluation = ([&tau] {
             protoboard<Fr> pb;
-            libzeth::test::simple_circuit<Fr>(pb);
+            libzeth::tests::simple_circuit<Fr>(pb);
             r1cs_constraint_system<Fr> constraint_system =
                 pb.get_constraint_system();
             constraint_system.swap_AB_if_beneficial();
@@ -226,7 +226,7 @@ TEST(MPCTests, Layer2)
 {
     // Small test circuit and QAP
     protoboard<Fr> pb;
-    libzeth::test::simple_circuit<Fr>(pb);
+    libzeth::tests::simple_circuit<Fr>(pb);
     r1cs_constraint_system<Fr> constraint_system = pb.get_constraint_system();
     constraint_system.swap_AB_if_beneficial();
     qap_instance<Fr> qap = r1cs_to_qap_instance_map(constraint_system, true);
@@ -268,7 +268,7 @@ TEST(MPCTests, Layer2)
     {
         const qap_instance_evaluation<Fr> qap_evaluation = ([&tau] {
             protoboard<Fr> pb;
-            libzeth::test::simple_circuit<Fr>(pb);
+            libzeth::tests::simple_circuit<Fr>(pb);
             r1cs_constraint_system<Fr> constraint_system =
                 pb.get_constraint_system();
             constraint_system.swap_AB_if_beneficial();
@@ -334,7 +334,7 @@ TEST(MPCTests, Layer2)
     {
         const r1cs_constraint_system<Fr> constraint_system = ([&] {
             protoboard<Fr> pb;
-            libzeth::test::simple_circuit<Fr>(pb);
+            libzeth::tests::simple_circuit<Fr>(pb);
             r1cs_constraint_system<Fr> cs = pb.get_constraint_system();
             cs.swap_AB_if_beneficial();
             return cs;

--- a/mpc_tools/mpc_phase2/test/mpc_test_cli.cpp
+++ b/mpc_tools/mpc_phase2/test/mpc_test_cli.cpp
@@ -7,7 +7,7 @@
 
 void simple_protoboard(libsnark::protoboard<libzeth::defaults::Field> &pb)
 {
-    libzeth::test::simple_circuit<libzeth::defaults::Field>(pb);
+    libzeth::tests::simple_circuit<libzeth::defaults::Field>(pb);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
After generating the Doxygen documentation of the project, I saw the rendered namespace list was:
```
Namespace List
   |_ libzeth
   |        |_ test
   |        |_ tests
```

In fact, in the simple gadget files, we used a namespace called `libzeth::test`, while the other tests, written in `libzeth/tests` use anonymous namespaces, i.e. `namespace {` which is documented as `libzeth::tests`.

This PR renames the namespace `libzeth::test` as `libzeth::tests` to fix this inconsistency.