### PR TITLE
Full support for BLS12-377 (depends on #302)

### DIFF
--- a/.github/workflows/onpush.yml
+++ b/.github/workflows/onpush.yml
@@ -65,6 +65,15 @@ jobs:
     - name: Execute
       run: CI_USE_DOCKER=1 CI_CONFIG=Release CI_ZKSNARK=PGHR13 scripts/ci build
 
+  build-linux-bls12-377:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+    - name: Execute
+      run: CI_USE_DOCKER=1 CI_CONFIG=Release CI_CURVE=BLS12_377 scripts/ci build
+
   check-cpp-linux:
     runs-on: ubuntu-20.04
     steps:

--- a/mpc_tools/CMakeLists.txt
+++ b/mpc_tools/CMakeLists.txt
@@ -7,8 +7,8 @@ include_directories(SYSTEM ${Boost_INCLUDE_DIR})
 # so that we will find zethConfig.h
 include_directories(${PROJECT_BINARY_DIR})
 
-# Compile the pot-process utility (GROTH16 only)
-if(${ZETH_SNARK} STREQUAL "GROTH16")
+# Compile the pot-process utility (GROTH16 ALT-BN128 only)
+if(${ZETH_SNARK} STREQUAL "GROTH16" AND ${ZETH_CURVE} STREQUAL "ALT_BN128")
   add_executable(
     pot-process
     pot_process/pot_process.cpp
@@ -21,4 +21,6 @@ if(${ZETH_SNARK} STREQUAL "GROTH16")
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
   )
   add_subdirectory(mpc_phase2)
+else()
+  message("Disabling MPC tools (only available in GROTH16 ALT-BN128 config)")
 endif()

--- a/scripts/ci
+++ b/scripts/ci
@@ -56,10 +56,13 @@ function check_cpp() {
     popd
 }
 
-function command_tests() {
+function mpc_tests() {
 
     # These commands are only for the GROTH16 config
     if ! [ "${CI_ZKSNARK}" == "GROTH16" ] ; then
+        return
+    fi
+    if ! [ "${CI_CURVE}" == "ALT_BN128" ] ; then
         return
     fi
 
@@ -97,6 +100,7 @@ function build() {
     fi
 
     cmake_flags="-DCMAKE_BUILD_TYPE=${CI_CONFIG} -DZETH_SNARK=${CI_ZKSNARK}"
+    cmake_flags="${cmake_flags} -DZETH_CURVE=${CI_CURVE}"
     if ! [ "${full_build}" == "1" ] ; then
         cmake_flags="${cmake_flags} -DFAST_TESTS_ONLY=ON"
     fi
@@ -114,7 +118,7 @@ function build() {
     CTEST_OUTPUT_ON_FAILURE=1 make -j 2 check
     cd ..
 
-    command_tests
+    mpc_tests
 }
 
 function ci_setup() {
@@ -175,6 +179,7 @@ echo ci_task = ${ci_task}
 echo full_build=${full_build}
 echo CI_CONFIG=${CI_CONFIG}
 echo CI_ZKSNARK=${CI_ZKSNARK}
+echo CI_CURVE=${CI_CURVE}
 echo CI_CHECK_FORMAT=${CI_CHECK_FORMAT}
 echo CI_EVENT_NAME=${CI_EVENT_NAME}
 
@@ -184,6 +189,10 @@ fi
 
 if [ "${CI_ZKSNARK}" == "" ] ; then
     CI_ZKSNARK="GROTH16"
+fi
+
+if [ "${CI_CURVE}" == "" ] ; then
+   CI_CURVE="ALT_BN128"
 fi
 
 # The CI_USE_DOCKER variable determines whether we should
@@ -197,6 +206,7 @@ if [ "${CI_USE_DOCKER}" == "1" ] ; then
            --name zeth \
            --env CI_CONFIG=${CI_CONFIG} \
            --env CI_ZKSNARK=${CI_ZKSNARK} \
+           --env CI_CURVE=${CI_CURVE} \
            zeth-dev:latest $0 ${ci_task} ${full_build}
 else
     ci_setup

--- a/zeth_contracts/contracts/BLS12_377MixerBase.sol
+++ b/zeth_contracts/contracts/BLS12_377MixerBase.sol
@@ -1,0 +1,80 @@
+// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import "./MixerBase.sol";
+import "./MiMC31.sol";
+
+// Partial implementation of abstract MixerBase which implements the
+// curve-specific methods to use the BLS12-377 pairing.
+contract BLS12_377MixerBase is MixerBase
+{
+    // TODO: Code here is very similar to AltBN128MixerBase, with only the
+    // constants changed. Look into sharing more code (possibly by making some
+    // of these constants dynamic).
+
+    // Constants regarding the hash digest length, the prime number used and
+    // its associated length in bits and the max values (v_in and v_out)
+
+    // Number of bits that can be reliably represented by a single field element.
+    // FIELD_CAPACITY = floor( log_2(r) )
+    // Denoted FIELDCAP in Zeth specifications.
+    uint256 constant FIELD_CAPACITY = 252;
+
+    // Number of residual bits per bytes32
+    uint256 constant NUM_RESIDUAL_BITS = digest_length - FIELD_CAPACITY;
+
+    // Shift to move residual bits from lowest order to highest order
+    uint256 constant RESIDUAL_BITS_SHIFT = 256 - NUM_RESIDUAL_BITS;
+
+    // Mask to extract the residual bits in the high-order position
+    uint256 constant RESIDUAL_BITS_MASK =
+    ((1 << NUM_RESIDUAL_BITS) - 1) << RESIDUAL_BITS_SHIFT;
+
+    // Total number of bits required to hold all residual bits from, including
+    // the public vin and vout values (each 64 bits long). Denoted RSDBLEN in
+    // Zeth specifications.
+    uint256 constant RESIDUAL_BITS_LENGTH =
+    2 * public_value_bits + NUM_RESIDUAL_BITS * num_hash_digests;
+
+    constructor(
+        uint256 mk_depth,
+        address token,
+        uint256[] memory vk)
+        MixerBase(mk_depth, token, vk)
+        public
+    {
+    }
+
+    // Extract a full uint256 from a field element and the n-th set of residual
+    // bits from `residual`.
+    function extract_bytes32(
+        uint256 field_element, uint256 residual, uint256 residual_bits_set_idx)
+        internal pure
+        returns(bytes32)
+    {
+        // The residual_bits_set_idx-th set of residual bits (denoted r_i
+        // below) start at bit:
+        //   (2 * public_value_bits) + (residual_bits_set_idx * num_residual_bits)
+        //
+        // Shift r_i to occupy the highest order bits:
+        // 255                                         128        64           0
+        //  | bits_to_shift |       | residual_bits_idx |          |           |
+        //  | <------------ | <r_i> |                   |<v_pub_in>|<v_pub_out>|
+
+        // Number of bits AFTER public values
+        uint256 residual_bits_idx = residual_bits_set_idx * NUM_RESIDUAL_BITS;
+        uint256 bits_to_shift =
+        RESIDUAL_BITS_SHIFT - total_public_value_bits - residual_bits_idx;
+        uint256 residual_bits = (residual << bits_to_shift) & RESIDUAL_BITS_MASK;
+        return bytes32(field_element | residual_bits);
+    }
+
+    function hash(bytes32 left, bytes32 right) internal returns(bytes32)
+    {
+        return MiMC31.hash(left, right);
+    }
+}

--- a/zeth_contracts/contracts/Groth16BLS12_377Mixer.sol
+++ b/zeth_contracts/contracts/Groth16BLS12_377Mixer.sol
@@ -1,0 +1,43 @@
+// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import "./Groth16BLS12_377.sol";
+import "./BLS12_377MixerBase.sol";
+
+// Instance of BLS12_377MixerBase implementing the Groth16 verifier for the
+// bls12-377 pairing.
+contract Groth16BLS12_377Mixer is BLS12_377MixerBase
+{
+    constructor(
+        uint256 mk_depth,
+        address token,
+        uint256[] memory vk)
+        BLS12_377MixerBase(mk_depth, token, vk)
+        public
+    {
+    }
+
+    function verify_zk_proof(
+        uint256[] memory proof,
+        uint256[num_inputs] memory inputs)
+        internal
+        returns (bool)
+    {
+        // Convert the statically sized inputs to a dynamic array
+        // expected by the verifyer.
+
+        // TODO: mechanism to pass static-sized input arrays to generic
+        // verifier functions to avoid this copy.
+
+        // solium-disable-next-line
+        uint256[] memory input_values = new uint256[](num_inputs);
+        for (uint256 i = 0 ; i < num_inputs; i++) {
+            input_values[i] = inputs[i];
+        }
+        return Groth16BLS12_377.verify(_vk, proof, input_values);
+    }
+}


### PR DESCRIPTION
Changes required to execute zeth using BLS12-377 in zk-proofs.
- [x] Contracts: `BLS12_377MixerBase` and `Groth16BLS12_377Mixer`
- [x] Enable BLS curve for all mixing tests
- [x] Curve configuration handling in mpc tools

Related spec changes: clearmatics/zeth-specifications#1 clearmatics/zeth-specifications#4