### PR TITLE
Fix ownership key documentation

### DIFF
--- a/client/zeth/core/ownership.py
+++ b/client/zeth/core/ownership.py
@@ -24,8 +24,9 @@ OwnershipPublicKey = NewType('OwnershipPublicKey', bytes)
 
 class OwnershipKeyPair:
     """
-    Key-pair for ownership proof. This represents the public payment address
-    and the private spending key. These are components of ZethAddress, used in
+    Key-pair for ownership proof. This represents the 'payment key' (apk)
+    from the 'payment address' and the 'spending key' (ask) from the
+    'private address'. These are components of ZethAddress, used in
     note commitments in the joinsplit statement.
     """
     def __init__(self, a_sk: OwnershipSecretKey, a_pk: OwnershipPublicKey):


### PR DESCRIPTION
Fix documentation of OwnershipKey to comply with specifications (related to: https://github.com/clearmatics/zeth/pull/293#discussion_r506468183)