### PR TITLE
Fix instructions to run custom ganache

### DIFF
--- a/.github/workflows/onpullrequest.yml
+++ b/.github/workflows/onpullrequest.yml
@@ -12,5 +12,8 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
     - name: Execute
       run: CI_EVENT_NAME=pull_request CI_USE_DOCKER=1 CI_CONFIG=Release scripts/ci build

--- a/.github/workflows/onpush.yml
+++ b/.github/workflows/onpush.yml
@@ -12,9 +12,17 @@ jobs:
   check-contracts:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 10
     - name: Check Contracts
-      run: CI_USE_DOCKER=1 scripts/ci check_contracts
+      run: scripts/ci check_contracts
 
   check-client:
     runs-on: ubuntu-20.04
@@ -22,6 +30,9 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
     - name: Execute
       run: scripts/ci check_client
 
@@ -34,6 +45,9 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
     - name: Install Dependencies
       run: brew install ${MACOS_BREW_PACKAGES}
     - name: Execute
@@ -48,6 +62,9 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
     - name: Execute
       run: CI_CHECK_FORMAT=1 CI_USE_DOCKER=1 CI_CONFIG=${{ matrix.config }} scripts/ci build
 
@@ -57,6 +74,9 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
     - name: Execute
       run: CI_USE_DOCKER=1 CI_CONFIG=Release CI_ZKSNARK=PGHR13 scripts/ci build
 
@@ -66,5 +86,8 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
     - name: Execute
       run: CI_CHECK_FORMAT=1 CI_USE_DOCKER=1 scripts/ci check_cpp

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ It follows and extends the design presented in [zerocash-ethereum](https://githu
 
 In order to follow the README below, you will need:
 - [Docker](https://www.docker.com/get-started)
-- [Npm](https://www.npmjs.com/get-npm) (at least version `6.4.1`)
-- [Node](https://nodejs.org/en/) (at least version `v9.5.0`)
+- [Npm](https://www.npmjs.com/get-npm) (at least version `6.9.0`)
+- [Node](https://nodejs.org/en/) (recommended version `v10` to be able to build and use the custom `ganache-cli`)
 - [Python3](https://www.python.org/downloads/) (at least version `3.7`)
 - [Pip](https://pip.pypa.io/en/stable/) (at least version `19.0.2`)
 

--- a/scripts/ci
+++ b/scripts/ci
@@ -24,7 +24,7 @@ function check_format() {
 function check_contracts() {
     pushd zeth_contracts
     npm config set python python2.7
-    npm install
+    npm install --unsafe-perm
     npm run check
     popd
 }
@@ -122,7 +122,6 @@ function ci_setup() {
     if [ "${platform}" == "Darwin" ] ; then
         # Some of these commands can fail (if packages are already installed,
         # etc), hence the `|| echo`.
-        brew unlink python@2 || echo
         brew update || echo
         brew install \
              gmp \
@@ -134,7 +133,6 @@ function ci_setup() {
              libtool \
              autoconf \
              automake \
-             python \
              || echo
     fi
 

--- a/zeth_contracts/package.json
+++ b/zeth_contracts/package.json
@@ -5,7 +5,7 @@
   "main": "truffle.js",
   "scripts": {
     "install": "ln -s ../../depends/ganache-cli node_modules/ganache-cli && cd node_modules/ganache-cli && npm install",
-    "testrpc": "ganache-cli --hardfork istanbul --port 8545 --gasLimit 0x3FFFFFFFFFFFF --gasPrice 1 --defaultBalanceEther 90000000000 --networkId 1234",
+    "testrpc": "cd node_modules/ganache-cli && node cli.js --hardfork istanbul --port 8545 --gasLimit 0x3FFFFFFFFFFFF --gasPrice 1 --defaultBalanceEther 90000000000 --networkId 1234",
     "compile": "truffle compile",
     "deploy": "truffle deploy",
     "test": "truffle test",

--- a/zeth_contracts/package.json
+++ b/zeth_contracts/package.json
@@ -5,7 +5,7 @@
   "main": "truffle.js",
   "scripts": {
     "install": "ln -s ../../depends/ganache-cli node_modules/ganache-cli && cd node_modules/ganache-cli && npm install",
-    "testrpc": "cd node_modules/ganache-cli && node cli.js --hardfork istanbul --port 8545 --gasLimit 0x3FFFFFFFFFFFF --gasPrice 1 --defaultBalanceEther 90000000000 --networkId 1234",
+    "testrpc": "node node_modules/ganache-cli/cli.js --hardfork istanbul --port 8545 --gasLimit 0x3FFFFFFFFFFFF --gasPrice 1 --defaultBalanceEther 90000000000 --networkId 1234",
     "compile": "truffle compile",
     "deploy": "truffle deploy",
     "test": "truffle test",


### PR DESCRIPTION
There were a few annoying traps which required more documentation.
- The version numbers need to be more strict on `node` and `nvm` since the FFI library used does not seem to support node versions > 10 (see: https://github.com/node-ffi/node-ffi#requirements). Furthermore, I got some errors related to dependency syntax (aliases) which according to https://stackoverflow.com/questions/54085943/npm-err-invalid-dependency-type-requested-alias requires a version of `npm` > 6.9 (and not "at least 6.4.1"). Running `nvm use 10 && nvm install-latest-npm` allows to use the right versions. Always making sure to provide a minimal working Dockerfile allows to catch these version mismatch and is a good way to save time going forward
- The `npm install` carried out on the CI server (see here: https://github.com/clearmatics/zeth/blob/develop/scripts/ci#L27) does not seem to be executed (see: https://github.com/clearmatics/zeth/runs/1265491500#step:3:490 for instance) - seems like `npm install --unsafe-perm` fixes this.

For some reason the `dist` doesn't get built for our custom `ethereumjs-vm` package as mentioned in more details in this ticket: https://github.com/clearmatics/ganache-cli/pull/1#issue-511485994