### PR TITLE
Adjust scanning ci

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches:
       - develop
+      - master
   pull_request:
     branches:
+      - develop
       - master
   # TODO: Consider scheduling code scanning
   #schedule:


### PR DESCRIPTION
As per: https://github.com/clearmatics/zeth/actions/runs/429016459 the following warning was thrown as code scanning should be configured `on push` and `on pull request` for the same branch to track changes:
```
 1 issue was detected with this workflow: Please make sure that every branch in on.pull_request is also in on.push so that Code Scanning can compare pull requests against the state of the base branch
```

This PR makes sure that code scanning run `on: push` and `on: pull-request` on both `develop` and `master` as branches on which code scanning.