### PR TITLE
Hash joinsplit public inputs (depends on #344)

### DIFF
--- a/client/tests/test_mixer_client.py
+++ b/client/tests/test_mixer_client.py
@@ -28,6 +28,7 @@ class TestMixerClient(TestCase):
                 "bcde",
                 "cdef",
             ])
+        public_data = [1234, 4321, 9876, 6789]
         sig_keypair = gen_signing_keypair()
         sig_vk = sig_keypair.vk
         sig = sign(sig_keypair.sk, bytes.fromhex("00112233"))
@@ -37,7 +38,8 @@ class TestMixerClient(TestCase):
             encrypt(token_bytes(NOTE_LENGTH_BYTES), receiver_enc_keypair.k_pk),
         ]
 
-        mix_params = MixParameters(ext_proof, sig_vk, sig, ciphertexts)
+        mix_params = MixParameters(
+            ext_proof, public_data, sig_vk, sig, ciphertexts)
 
         mix_params_json = mix_params.to_json()
         mix_params_2 = MixParameters.from_json(zksnark, mix_params_json)

--- a/libzeth/circuits/circuit_wrapper.hpp
+++ b/libzeth/circuits/circuit_wrapper.hpp
@@ -6,6 +6,7 @@
 #define __ZETH_CIRCUITS_CIRCUIT_WRAPPER_HPP__
 
 #include "libzeth/circuits/joinsplit.tcc"
+#include "libzeth/circuits/mimc/mimc_input_hasher.hpp"
 #include "libzeth/core/extended_proof.hpp"
 #include "libzeth/core/note.hpp"
 #include "libzeth/zeth_constants.hpp"
@@ -36,6 +37,7 @@ public:
         NumInputs,
         NumOutputs,
         TreeDepth>;
+    using input_hasher_type = mimc_input_hasher<Field, HashTreeT>;
 
     circuit_wrapper();
     circuit_wrapper(const circuit_wrapper &) = delete;
@@ -56,11 +58,15 @@ public:
         const bits64 &vpub_out,
         const bits256 &h_sig_in,
         const bits256 &phi_in,
-        const typename snarkT::proving_key &proving_key) const;
+        const typename snarkT::proving_key &proving_key,
+        std::vector<Field> &out_public_data) const;
 
 private:
     libsnark::protoboard<Field> pb;
+    libsnark::pb_variable<Field> public_data_hash;
+    libsnark::pb_variable_array<Field> public_data;
     std::shared_ptr<joinsplit_type> joinsplit;
+    std::shared_ptr<input_hasher_type> input_hasher;
 };
 
 } // namespace libzeth

--- a/libzeth/circuits/mimc/mimc.tcc
+++ b/libzeth/circuits/mimc/mimc.tcc
@@ -79,7 +79,7 @@ void MiMC_permutation_gadget<FieldT, Exponent, NumRounds>::
     generate_r1cs_constraints()
 {
     // For each round, generates the constraints for the corresponding round
-    // gadget
+    // gadget.
     for (auto &gadget : round_gadgets) {
         gadget.generate_r1cs_constraints();
     }
@@ -89,7 +89,8 @@ template<typename FieldT, size_t Exponent, size_t NumRounds>
 void MiMC_permutation_gadget<FieldT, Exponent, NumRounds>::
     generate_r1cs_witness() const
 {
-    // For each round, generates the witness for the corresponding round gadget
+    // For each round, generates the witness for the corresponding round
+    // gadget.
     for (auto &gadget : round_gadgets) {
         gadget.generate_r1cs_witness();
     }

--- a/proto/zeth/api/prover.proto
+++ b/proto/zeth/api/prover.proto
@@ -27,5 +27,5 @@ service Prover {
     rpc GetVerificationKey(google.protobuf.Empty) returns (VerificationKey) {}
 
     // Request a proof generation on the given inputs
-    rpc Prove(ProofInputs) returns (ExtendedProof) {}
+    rpc Prove(ProofInputs) returns (ExtendedProofAndPublicData) {}
 }

--- a/proto/zeth/api/zeth_messages.proto
+++ b/proto/zeth/api/zeth_messages.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package zeth_proto;
 
+import "zeth/api/snark_messages.proto";
+
 message ZethNote {
     string apk = 1;
     // Hex string representing a int64 value
@@ -33,4 +35,15 @@ message ProofInputs {
     string pub_out_value = 5;
     string h_sig = 6;
     string phi = 7;
+}
+
+// The extended proof and related public data for the Zeth statement using ProofInputs data
+message ExtendedProofAndPublicData {
+    // The extended proof (with single public input - the hash of public_data).
+    ExtendedProof extended_proof = 1;
+
+    // The public data (public inputs to the Zeth statement). Each element in
+    // the array is a hex-encoded member of the scalar field for the pairing
+    // being used.
+    repeated string public_data = 2;
 }

--- a/scripts/mimc_constraints.sage
+++ b/scripts/mimc_constraints.sage
@@ -52,6 +52,8 @@ def output_valid_configs_and_constraints(r):
     for t in range(2, 22):
         e = (1 << t) - 1
         output_valid_config_and_constraints(r, log_2_r, e)
+        e = (1 << t) + 1
+        output_valid_config_and_constraints(r, log_2_r, e)
 
     # TODO: determine if these value are valid
     # output_valid_config_and_constraints(r, log_2_r, 11)
@@ -60,6 +62,21 @@ def output_valid_configs_and_constraints(r):
     # output_valid_config_and_constraints(r, log_2_r, 19)
     # output_valid_config_and_constraints(r, log_2_r, 23)
 
+
+# BW6-761
+print("BW6-761:")
+output_valid_configs_and_constraints(
+    r=258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177)
+
+# MNT4
+print("MNT4:")
+output_valid_configs_and_constraints(
+    r=475922286169261325753349249653048451545124878552823515553267735739164647307408490559963137)
+
+# MNT6
+print("MNT6:")
+output_valid_configs_and_constraints(
+    r=475922286169261325753349249653048451545124879242694725395555128576210262817955800483758081)
 
 # BLS12-377
 print("BLS12-377:")

--- a/zeth_contracts/contracts/Groth16AltBN128Mixer.sol
+++ b/zeth_contracts/contracts/Groth16AltBN128Mixer.sol
@@ -26,21 +26,15 @@ contract Groth16AltBN128Mixer is AltBN128MixerBase
 
     function verify_zk_proof(
         uint256[] memory proof,
-        uint256[NUM_INPUTS] memory inputs
+        uint256 public_inputs_hash
     )
         internal
         returns (bool)
     {
-        // Convert the statically sized primaryInputs to a dynamic array
+        // Convert the single primary input to a dynamic array
         // expected by the verifier.
-
-        // TODO: mechanism to pass static-sized input arrays to generic
-        // verifier functions to avoid this copy.
-
-        uint256[] memory input_values = new uint256[](NUM_INPUTS);
-        for (uint256 i = 0 ; i < NUM_INPUTS; i++) {
-            input_values[i] = inputs[i];
-        }
+        uint256[] memory input_values = new uint256[](1);
+        input_values[0] = public_inputs_hash;
         return Groth16AltBN128.verify(_vk, proof, input_values);
     }
 }

--- a/zeth_contracts/contracts/Groth16AltBN128MixerBase_test.sol
+++ b/zeth_contracts/contracts/Groth16AltBN128MixerBase_test.sol
@@ -5,12 +5,12 @@
 pragma solidity ^0.5.0;
 pragma experimental ABIEncoderV2;
 
-import "./AltBN128MixerBase.sol";
+import "./Groth16AltBN128Mixer.sol";
 
 
-// Implementation of abstract AltBN128MixerBase contract, to allow testing
+// Implementation of Groth16AltBN128MixerBase contract, to allow testing
 // specific methods.
-contract AltBN128MixerBase_test is AltBN128MixerBase
+contract Groth16AltBN128MixerBase_test is Groth16AltBN128Mixer
 {
     constructor(
         uint256 mk_depth,
@@ -18,13 +18,22 @@ contract AltBN128MixerBase_test is AltBN128MixerBase
         uint256 vk_hash
     )
         public
-        AltBN128MixerBase(
+        Groth16AltBN128Mixer(
             mk_depth,
             address(0),
             new uint256[](0),
             permitted_dispatcher,
             vk_hash)
     {
+    }
+
+    function hash_public_proof_data_test(
+        uint256[NUM_INPUTS] memory public_data
+    )
+        public
+        returns (uint256)
+    {
+        return hash_public_proof_data(public_data);
     }
 
     function assemble_public_values_test(uint256 residual_bits)

--- a/zeth_contracts/contracts/Groth16BLS12_377Mixer.sol
+++ b/zeth_contracts/contracts/Groth16BLS12_377Mixer.sol
@@ -26,21 +26,15 @@ contract Groth16BLS12_377Mixer is BLS12_377MixerBase
 
     function verify_zk_proof(
         uint256[] memory proof,
-        uint256[NUM_INPUTS] memory inputs
+        uint256 public_inputs_hash
     )
         internal
         returns (bool)
     {
-        // Convert the statically sized inputs to a dynamic array
-        // expected by the verifyer.
-
-        // TODO: mechanism to pass static-sized input arrays to generic
-        // verifier functions to avoid this copy.
-
-        uint256[] memory input_values = new uint256[](NUM_INPUTS);
-        for (uint256 i = 0 ; i < NUM_INPUTS; i++) {
-            input_values[i] = inputs[i];
-        }
+        // Convert the single primary input to a dynamic array
+        // expected by the verifier.
+        uint256[] memory input_values = new uint256[](1);
+        input_values[0] = public_inputs_hash;
         return Groth16BLS12_377.verify(_vk, proof, input_values);
     }
 }

--- a/zeth_contracts/contracts/Pghr13AltBN128Mixer.sol
+++ b/zeth_contracts/contracts/Pghr13AltBN128Mixer.sol
@@ -47,7 +47,7 @@ contract Pghr13AltBN128Mixer is AltBN128MixerBase
     }
 
     function verify(
-        uint256[NUM_INPUTS] memory input,
+        uint256[] memory inputs,
         Proof memory proof
     )
         internal
@@ -75,7 +75,7 @@ contract Pghr13AltBN128Mixer is AltBN128MixerBase
         // |I_{in}| == input.length, and vk.IC also contains A_0(s). Thus
         // ||vk.IC| == input.length + 1
         require(
-            input.length + 1 == vk.IC.length,
+            inputs.length + 1 == vk.IC.length,
             "Using strong input consistency, and the input length differs from"
             " expected"
         );
@@ -90,8 +90,8 @@ contract Pghr13AltBN128Mixer is AltBN128MixerBase
         // |I_{in}| = n here as we assume that we have a vector x of inputs of
         // size n.
         Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
-        for (uint256 i = 0; i < input.length; i++) {
-            vk_x = Pairing.add(vk_x, Pairing.mul(vk.IC[i + 1], input[i]));
+        for (uint256 i = 0; i < inputs.length; i++) {
+            vk_x = Pairing.add(vk_x, Pairing.mul(vk.IC[i + 1], inputs[i]));
         }
         vk_x = Pairing.add(vk_x, vk.IC[0]);
 
@@ -150,7 +150,7 @@ contract Pghr13AltBN128Mixer is AltBN128MixerBase
 
     function verify_zk_proof(
         uint256[] memory proof_data,
-        uint256[NUM_INPUTS] memory inputs
+        uint256 public_inputs_hash
     )
         internal
         returns (bool)
@@ -171,14 +171,13 @@ contract Pghr13AltBN128Mixer is AltBN128MixerBase
         proof.H = Pairing.G1Point(proof_data[14], proof_data[15]);
         proof.K = Pairing.G1Point(proof_data[16], proof_data[17]);
 
-        for(uint256 i = 0; i < inputs.length; i++){
-            // Make sure that all primary inputs lie in the scalar field
-            require(
-                inputs[i] < r,
-                "Input is not is scalar field"
-            );
-        }
+        require(
+            public_inputs_hash < r,
+            "Input is not is scalar field"
+        );
 
+        uint256[] memory inputs = new uint256[](1);
+        inputs[0] = public_inputs_hash;
         uint256 verification_result = verify(inputs, proof);
         if (verification_result != 0) {
             return false;


### PR DESCRIPTION
Reduce primary inputs to zk-proof by hashing public inputs to joinsplit.

Quite a large single commit, unfortunately, involving the prover, client and contract.  It would be difficult to divide it into smaller pieces which didn't temporarily break the system.