### PR TITLE
Export data from prover

### DIFF
--- a/libzeth/circuits/circuit_wrapper.hpp
+++ b/libzeth/circuits/circuit_wrapper.hpp
@@ -62,6 +62,8 @@ public:
         const typename snarkT::proving_key &proving_key,
         std::vector<Field> &out_public_data) const;
 
+    const std::vector<Field> &get_last_assignment() const;
+
 private:
     libsnark::protoboard<Field> pb;
     libsnark::pb_variable<Field> public_data_hash;

--- a/libzeth/circuits/circuit_wrapper.tcc
+++ b/libzeth/circuits/circuit_wrapper.tcc
@@ -170,6 +170,26 @@ extended_proof<ppT, snarkT> circuit_wrapper<
         snarkT::generate_proof(proving_key, pb), pb.primary_input());
 }
 
+template<
+    typename HashT,
+    typename HashTreeT,
+    typename ppT,
+    typename snarkT,
+    size_t NumInputs,
+    size_t NumOutputs,
+    size_t TreeDepth>
+const std::vector<libff::Fr<ppT>> &circuit_wrapper<
+    HashT,
+    HashTreeT,
+    ppT,
+    snarkT,
+    NumInputs,
+    NumOutputs,
+    TreeDepth>::get_last_assignment() const
+{
+    return pb.full_variable_assignment();
+}
+
 } // namespace libzeth
 
 #endif // __ZETH_CIRCUITS_CIRCUIT_WRAPPER_TCC__

--- a/libzeth/core/extended_proof.hpp
+++ b/libzeth/core/extended_proof.hpp
@@ -24,6 +24,7 @@ public:
     extended_proof(
         typename snarkT::proof &&in_proof,
         libsnark::r1cs_primary_input<libff::Fr<ppT>> &&in_primary_inputs);
+
     const typename snarkT::proof &get_proof() const;
 
     const libsnark::r1cs_primary_input<libff::Fr<ppT>> &get_primary_inputs()

--- a/libzeth/tests/circuits/simple_test.cpp
+++ b/libzeth/tests/circuits/simple_test.cpp
@@ -14,6 +14,7 @@
 #include <boost/filesystem.hpp>
 #include <gtest/gtest.h>
 #include <libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp>
+#include <libff/algebra/curves/bls12_377/bls12_377_pp.hpp>
 
 using namespace libsnark;
 using namespace libzeth;
@@ -23,7 +24,8 @@ boost::filesystem::path g_output_dir = boost::filesystem::path("");
 namespace
 {
 
-template<typename ppT, typename snarkT> void test_simple_circuit_proof()
+template<typename ppT, typename snarkT>
+void test_simple_circuit_proof(bool support_output = true)
 {
     using Field = libff::Fr<ppT>;
 
@@ -36,7 +38,7 @@ template<typename ppT, typename snarkT> void test_simple_circuit_proof()
         pb.get_constraint_system();
 
     // Write to file if output directory is given.
-    if (!g_output_dir.empty()) {
+    if (!g_output_dir.empty() && support_output) {
 
         boost::filesystem::path outpath =
             g_output_dir / ("simple_circuit_r1cs_" + pp_name<ppT>() + ".json");
@@ -69,7 +71,7 @@ template<typename ppT, typename snarkT> void test_simple_circuit_proof()
 
     ASSERT_TRUE(snarkT::verify(primary, proof, keypair.vk));
 
-    if (!g_output_dir.empty()) {
+    if (!g_output_dir.empty() && support_output) {
         {
             boost::filesystem::path proving_key_path =
                 g_output_dir / ("simple_proving_key_" + snarkT::name + "_" +
@@ -107,18 +109,25 @@ template<typename ppT, typename snarkT> void test_simple_circuit_proof()
     }
 }
 
-TEST(SimpleTests, SimpleCircuitProofGroth16)
+TEST(SimpleTests, SimpleCircuitProofGroth16AltBN128)
 {
     test_simple_circuit_proof<
         libff::alt_bn128_pp,
         libzeth::groth16_snark<libff::alt_bn128_pp>>();
 }
 
+TEST(SimpleTests, SimpleCircuitProofGroth16BLS12_377)
+{
+    test_simple_circuit_proof<
+        libff::bls12_377_pp,
+        libzeth::groth16_snark<libff::bls12_377_pp>>();
+}
+
 TEST(SimpleTests, SimpleCircuitProofPghr13)
 {
     test_simple_circuit_proof<
         libff::alt_bn128_pp,
-        pghr13_snark<libff::alt_bn128_pp>>();
+        pghr13_snark<libff::alt_bn128_pp>>(false);
 }
 
 TEST(SimpleTests, SimpleCircuitProofPow2Domain)
@@ -149,6 +158,7 @@ int main(int argc, char **argv)
 {
     // WARNING: Do once for all tests. Do not forget to do this.
     libff::alt_bn128_pp::init_public_params();
+    libff::bls12_377_pp::init_public_params();
 
     // Remove stdout noise from libff
     libff::inhibit_profiling_counters = true;

--- a/libzeth/tests/prover/prover_test.cpp
+++ b/libzeth/tests/prover/prover_test.cpp
@@ -156,6 +156,7 @@ void TestValidJS2In2Case1(
         keypair.pk,
         public_data);
     libff::leave_block("Generate proof", true);
+
     std::vector<Field> primary_inputs = ext_proof.get_primary_inputs();
     ASSERT_EQ(1, primary_inputs.size());
     ASSERT_NE(Field::zero(), primary_inputs[0]);
@@ -165,6 +166,12 @@ void TestValidJS2In2Case1(
     ASSERT_EQ(
         input_hasher_type<snarkT>::compute_hash(public_data),
         primary_inputs[0]);
+
+    // The full assignment should be strictly larger than the public data, and
+    // begin with the primary input.
+    const std::vector<Field> &full_assignment = prover.get_last_assignment();
+    ASSERT_GT(full_assignment.size(), public_data.size());
+    ASSERT_EQ(primary_inputs[0], full_assignment[0]);
 
     libff::enter_block("Verify proof", true);
     // Get the verification key

--- a/prover_server/prover_server.cpp
+++ b/prover_server/prover_server.cpp
@@ -7,6 +7,7 @@
 #include "libzeth/core/utils.hpp"
 #include "libzeth/serialization/proto_utils.hpp"
 #include "libzeth/serialization/r1cs_serialization.hpp"
+#include "libzeth/serialization/r1cs_variable_assignment_serialization.hpp"
 #include "libzeth/zeth_constants.hpp"
 #include "zeth_config.h"
 
@@ -70,6 +71,24 @@ static void write_keypair(
     snark::keypair_write_bytes(keypair, out_s);
 }
 
+static void write_proving_key(
+    const typename snark::proving_key &pk,
+    const boost::filesystem::path &pk_file)
+{
+    std::ofstream out_s(
+        pk_file.c_str(), std::ios_base::out | std::ios_base::binary);
+    snark::proving_key_write_bytes(pk, out_s);
+}
+
+static void write_verification_key(
+    const typename snark::verification_key &vk,
+    const boost::filesystem::path &vk_file)
+{
+    std::ofstream out_s(
+        vk_file.c_str(), std::ios_base::out | std::ios_base::binary);
+    snark::verification_key_write_bytes(vk, out_s);
+}
+
 static void write_constraint_system(
     const circuit_wrapper &prover, const boost::filesystem::path &r1cs_file)
 {
@@ -77,12 +96,30 @@ static void write_constraint_system(
     libzeth::r1cs_write_json(prover.get_constraint_system(), r1cs_stream);
 }
 
-static void write_ext_proof_to_file(
+static void write_extproof_to_json_file(
     const libzeth::extended_proof<pp, snark> &ext_proof,
-    boost::filesystem::path proof_path)
+    const boost::filesystem::path &proof_path)
 {
-    std::ofstream os(proof_path.c_str());
-    ext_proof.write_json(os);
+    std::ofstream out_s(proof_path.c_str());
+    ext_proof.write_json(out_s);
+}
+
+static void write_proof_to_file(
+    const typename snark::proof &proof,
+    const boost::filesystem::path &proof_path)
+{
+    std::ofstream out_s(
+        proof_path.c_str(), std::ios_base::out | std::ios_base::binary);
+    snark::proof_write_bytes(proof, out_s);
+}
+
+static void write_assignment_to_file(
+    const std::vector<Field> &assignment,
+    const boost::filesystem::path &assignment_path)
+{
+    std::ofstream out_s(
+        assignment_path.c_str(), std::ios_base::out | std::ios_base::binary);
+    libzeth::r1cs_variable_assignment_write_bytes(assignment, out_s);
 }
 
 /// The prover_server class inherits from the Prover service
@@ -97,14 +134,31 @@ private:
     snark::keypair keypair;
 
     // Optional file to write proofs into (for debugging).
+    boost::filesystem::path extproof_json_output_file;
+
+    // Optional file to write proofs into (for debugging).
     boost::filesystem::path proof_output_file;
+
+    // Optional file to write primary input data into (for debugging).
+    boost::filesystem::path primary_output_file;
+
+    // Optional file to write full assignments into (for debugging).
+    boost::filesystem::path assignment_output_file;
 
 public:
     explicit prover_server(
         circuit_wrapper &prover,
         const snark::keypair &keypair,
-        const boost::filesystem::path &proof_output_file)
-        : prover(prover), keypair(keypair), proof_output_file(proof_output_file)
+        const boost::filesystem::path &extproof_json_output_file,
+        const boost::filesystem::path &proof_output_file,
+        const boost::filesystem::path &primary_output_file,
+        const boost::filesystem::path &assignment_output_file)
+        : prover(prover)
+        , keypair(keypair)
+        , extproof_json_output_file(extproof_json_output_file)
+        , proof_output_file(proof_output_file)
+        , primary_output_file(primary_output_file)
+        , assignment_output_file(assignment_output_file)
     {
     }
 
@@ -229,10 +283,28 @@ public:
             }
 
             // Write a copy of the proof for debugging.
+            if (!extproof_json_output_file.empty()) {
+                std::cout << "[DEBUG] Writing extended proof (JSON) to "
+                          << extproof_json_output_file << "\n";
+                write_extproof_to_json_file(
+                    ext_proof, extproof_json_output_file);
+            }
             if (!proof_output_file.empty()) {
-                std::cout << "[DEBUG] Writing extended proof to "
-                          << proof_output_file << "\n";
-                write_ext_proof_to_file(ext_proof, proof_output_file);
+                std::cout << "[DEBUG] Writing proof to " << proof_output_file
+                          << "\n";
+                write_proof_to_file(ext_proof.get_proof(), proof_output_file);
+            }
+            if (!primary_output_file.empty()) {
+                std::cout << "[DEBUG] Writing primary input to "
+                          << primary_output_file << "\n";
+                write_assignment_to_file(
+                    ext_proof.get_primary_inputs(), primary_output_file);
+            }
+            if (!assignment_output_file.empty()) {
+                std::cout << "[DEBUG] WARNING! Writing assignment to "
+                          << assignment_output_file << "\n";
+                write_assignment_to_file(
+                    prover.get_last_assignment(), assignment_output_file);
             }
 
             std::cout << "[DEBUG] Preparing response..." << std::endl;
@@ -294,12 +366,21 @@ void display_server_start_message()
 static void RunServer(
     circuit_wrapper &prover,
     const typename snark::keypair &keypair,
-    const boost::filesystem::path &proof_output_file)
+    const boost::filesystem::path &extproof_json_output_file,
+    const boost::filesystem::path &proof_output_file,
+    const boost::filesystem::path &primary_output_file,
+    const boost::filesystem::path &assignment_output_file)
 {
     // Listen for incoming connections on 0.0.0.0:50051
     std::string server_address("0.0.0.0:50051");
 
-    prover_server service(prover, keypair, proof_output_file);
+    prover_server service(
+        prover,
+        keypair,
+        extproof_json_output_file,
+        proof_output_file,
+        primary_output_file,
+        assignment_output_file);
 
     grpc::ServerBuilder builder;
 
@@ -335,9 +416,29 @@ int main(int argc, char **argv)
         po::value<boost::filesystem::path>(),
         "file in which to export the r1cs (in json format)");
     options.add_options()(
-        "proof-output,p",
+        "proving-key-output",
         po::value<boost::filesystem::path>(),
-        "(DEBUG) file to write generated proofs into");
+        "write proving key to file (if generated)");
+    options.add_options()(
+        "verification-key-output",
+        po::value<boost::filesystem::path>(),
+        "write verification key to file (if generated)");
+    options.add_options()(
+        "extproof-json-output",
+        po::value<boost::filesystem::path>(),
+        "(DEBUG) write generated extended proofs (JSON) to file");
+    options.add_options()(
+        "proof-output",
+        po::value<boost::filesystem::path>(),
+        "(DEBUG) write generated proofs to file");
+    options.add_options()(
+        "primary-output",
+        po::value<boost::filesystem::path>(),
+        "(DEBUG) write primary input to file");
+    options.add_options()(
+        "assignment-output",
+        po::value<boost::filesystem::path>(),
+        "(DEBUG) write full assignment to file (INSECURE!)");
 
     auto usage = [&]() {
         std::cout << "Usage:"
@@ -350,7 +451,12 @@ int main(int argc, char **argv)
 
     boost::filesystem::path keypair_file;
     boost::filesystem::path r1cs_file;
+    boost::filesystem::path proving_key_output_file;
+    boost::filesystem::path verification_key_output_file;
+    boost::filesystem::path extproof_json_output_file;
     boost::filesystem::path proof_output_file;
+    boost::filesystem::path primary_output_file;
+    boost::filesystem::path assignment_output_file;
     try {
         po::variables_map vm;
         po::store(
@@ -365,9 +471,29 @@ int main(int argc, char **argv)
         if (vm.count("r1cs")) {
             r1cs_file = vm["r1cs"].as<boost::filesystem::path>();
         }
+        if (vm.count("proving-key-output")) {
+            proving_key_output_file =
+                vm["proving-key-output"].as<boost::filesystem::path>();
+        }
+        if (vm.count("verification-key-output")) {
+            verification_key_output_file =
+                vm["verification-key-output"].as<boost::filesystem::path>();
+        }
+        if (vm.count("extproof-json-output")) {
+            extproof_json_output_file =
+                vm["extproof-json-output"].as<boost::filesystem::path>();
+        }
         if (vm.count("proof-output")) {
             proof_output_file =
                 vm["proof-output"].as<boost::filesystem::path>();
+        }
+        if (vm.count("primary-output")) {
+            primary_output_file =
+                vm["primary-output"].as<boost::filesystem::path>();
+        }
+        if (vm.count("assignment-output")) {
+            assignment_output_file =
+                vm["assignment-output"].as<boost::filesystem::path>();
         }
     } catch (po::error &error) {
         std::cerr << " ERROR: " << error.what() << std::endl;
@@ -392,7 +518,10 @@ int main(int argc, char **argv)
     // If the keypair file exists, load and use it, otherwise generate a new
     // keypair and write it to the file.
     circuit_wrapper prover;
-    snark::keypair keypair = [&keypair_file, &prover]() {
+    snark::keypair keypair = [&keypair_file,
+                              &proving_key_output_file,
+                              &verification_key_output_file,
+                              &prover]() {
         if (boost::filesystem::exists(keypair_file)) {
             std::cout << "[INFO] Loading keypair: " << keypair_file << "\n";
             return load_keypair(keypair_file);
@@ -403,6 +532,18 @@ int main(int argc, char **argv)
         const snark::keypair keypair = prover.generate_trusted_setup();
         std::cout << "[INFO] Writing new keypair to " << keypair_file << "\n";
         write_keypair(keypair, keypair_file);
+
+        if (!proving_key_output_file.empty()) {
+            std::cout << "[DEBUG] Writing separate proving key to "
+                      << proving_key_output_file << "\n";
+            write_proving_key(keypair.pk, proving_key_output_file);
+        }
+        if (!verification_key_output_file.empty()) {
+            std::cout << "[DEBUG] Writing separate verification key to "
+                      << verification_key_output_file << "\n";
+            write_verification_key(keypair.vk, verification_key_output_file);
+        }
+
         return keypair;
     }();
 
@@ -414,6 +555,12 @@ int main(int argc, char **argv)
     }
 
     std::cout << "[INFO] Setup successful, starting the server..." << std::endl;
-    RunServer(prover, keypair, proof_output_file);
+    RunServer(
+        prover,
+        keypair,
+        extproof_json_output_file,
+        proof_output_file,
+        primary_output_file,
+        assignment_output_file);
     return 0;
 }


### PR DESCRIPTION
Changes to support extracting binary key and assignment data from zeth prover (for debug purposes)