### PR TITLE
Scripts to generate large circuits, keys and assignments

### DIFF
--- a/.github/workflows/onpullrequest-build-ubuntu.yml
+++ b/.github/workflows/onpullrequest-build-ubuntu.yml
@@ -22,7 +22,7 @@ jobs:
         key: grpc-1.31.x-${{ runner.os }}
         path: depends/grpc
     - name: Build grpc
-      run: if ! [ -d depends/grpc ] ; then scripts/install_grpc /usr v1.31.x depends/grpc ; fi
+      run: if ! [ -d depends/grpc ] ; then scripts/install_grpc /usr v1.31.x ; fi
 
   # Extract the commits of submodules for use by cache steps
   onpr-submodules:
@@ -77,7 +77,7 @@ jobs:
         key: prover-tests-npm-${{ hashFiles('**/package-lock.json') }}-${{ runner.os }}
     - name: Install dependencies
       run: |
-        scripts/install_grpc /usr v1.31.x depends/grpc
+        INSTALL_ONLY=1 scripts/install_grpc /usr v1.31.x
         sudo apt install -y ccache
     - name: Execute
       run: CI_CONFIG=Release CI_CURVE=${{ matrix.curve }} CI_PROVER_TESTS=1 scripts/ci build
@@ -124,7 +124,7 @@ jobs:
         key: integration-tests-npm-${{ hashFiles('**/package-lock.json') }}-${{ runner.os }}
     - name: Install dependencies
       run: |
-        scripts/install_grpc /usr v1.31.x depends/grpc
+        INSTALL_ONLY=1 scripts/install_grpc /usr v1.31.x
         sudo apt install -y ccache
     - name: Execute
       run: CI_CONFIG=Release CI_CURVE=${{ matrix.curve }} CI_FULL_TESTS=1 CI_INTEGRATION_TESTS=1 scripts/ci build

--- a/.github/workflows/onpush-build-ubuntu.yml
+++ b/.github/workflows/onpush-build-ubuntu.yml
@@ -22,7 +22,7 @@ jobs:
         key: grpc-1.31.x-${{ runner.os }}
         path: depends/grpc
     - name: Build grpc
-      run: if ! [ -d depends/grpc ] ; then scripts/install_grpc /usr v1.31.x depends/grpc ; fi
+      run: if ! [ -d depends/grpc ] ; then scripts/install_grpc /usr v1.31.x ; fi
 
   build-linux:
     runs-on: ubuntu-20.04
@@ -46,7 +46,7 @@ jobs:
         key: build-linux-pip-${{ hashFiles('**/setup.py') }}-${{ runner.os }}
     - name: Install dependencies
       run: |
-        scripts/install_grpc /usr v1.31.x depends/grpc
+        INSTALL_ONLY=1 scripts/install_grpc /usr v1.31.x
         sudo apt install -y ccache
     - name: Execute
       run: CI_CHECK_FORMAT=1 CI_MPC_TESTS=1 CI_CONFIG=${{ matrix.config }} scripts/ci build
@@ -65,7 +65,7 @@ jobs:
         path: depends/grpc
     - name: Install dependencies
       run: |
-        scripts/install_grpc /usr v1.31.x depends/grpc
+        INSTALL_ONLY=1 scripts/install_grpc /usr v1.31.x
         sudo apt install -y ccache
     - name: Execute
       run: CI_CONFIG=Release CI_ZKSNARK=PGHR13 scripts/ci build
@@ -84,7 +84,7 @@ jobs:
         path: depends/grpc
     - name: Install dependencies
       run: |
-        scripts/install_grpc /usr v1.31.x depends/grpc
+        INSTALL_ONLY=1 scripts/install_grpc /usr v1.31.x
         sudo apt install -y ccache
     - name: Execute
       run: CI_CONFIG=Release CI_CURVE=BLS12_377 scripts/ci build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.13)
 
 # Change the compiler BEFORE the first `project()` command to avoid an infinite loop.
 # See: https://public.kitware.com/pipermail/cmake/2009-November/033133.html

--- a/client/.pylintrc
+++ b/client/.pylintrc
@@ -19,7 +19,7 @@ disable=
 #   https://github.com/PyCQA/pylint/issues/3882
 # Re-enable it when the issue is fixed.
 
-good-names=a,b,c,e,g,h,i,k,m,q,r,x,y,z,cm,ic,rc,ek,ex,ct,vk,sk,pk,pp,X,Y,r,el,nf,g1,g2
+good-names=a,b,c,e,g,h,i,k,m,q,r,x,y,z,cm,ic,rc,ek,ex,ct,vk,sk,pk,pp,X,Y,r,el,nf,g1,g2,tx
 
 max-attributes=10
 

--- a/client/zeth/cli/utils.py
+++ b/client/zeth/cli/utils.py
@@ -338,9 +338,13 @@ def do_sync(
     if wait_tx:
         _do_sync()
         tx_receipt = web3.eth.waitForTransactionReceipt(wait_tx, 10000)
+        tx = web3.eth.getTransaction(wait_tx)
         gas_used = tx_receipt.gasUsed
         status = tx_receipt.status
-        print(f"{wait_tx[0:8]}: gasUsed={gas_used}, status={status}")
+        size_bytes = len(tx.input)
+        print(
+            f"{wait_tx[0:8]}: gasUsed={gas_used}, status={status}, "
+            f"input_size={size_bytes}")
 
     return _do_sync()
 

--- a/client/zeth/core/contracts.py
+++ b/client/zeth/core/contracts.py
@@ -153,6 +153,7 @@ def send_contract_call(
         transaction = call.buildTransaction(tx_desc)
         signed_tx = web3.eth.account.signTransaction(
             transaction, sender_eth_private_key)
+        print(f"send_contract_call: size={len(signed_tx.rawTransaction)}")
         return web3.eth.sendRawTransaction(signed_tx.rawTransaction)
 
     # Hosted path

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1,0 +1,68 @@
+# Utility functions for general build tasks.
+#
+# All functions expect to be executed the root directory of the repository, and
+# will exit with this as the current directory.
+
+
+# Init some global variables related to the platform. Some other functions may
+# expect this to be called before they are invoked.
+function init_platform() {
+    platform=`uname`
+    echo platform=${platform}
+}
+
+# Assert that init_platform has been called
+function assert_init_platform() {
+    if [ "${platform}" == "" ] ; then
+        echo init_platform has not been called
+        exit 1
+    fi
+}
+
+# Install dependencies for cpp builds
+function cpp_build_setup() {
+    assert_init_platform
+
+    # Extra deps for native builds
+
+    if [ "${platform}" == "Darwin" ] ; then
+        # Some of these commands can fail (if packages are already installed,
+        # etc), hence the `|| echo`.
+        brew update || echo
+        brew install \
+             gmp \
+             grpc \
+             protobuf \
+             boost \
+             openssl \
+             cmake \
+             libtool \
+             autoconf \
+             automake \
+             || echo
+    fi
+
+    if [ "${platform}" == "Linux" ] ; then
+        if (which apk) ; then
+            # Packages already available in Docker build
+            echo -n             # null op required for syntax
+        elif (which yum) ; then
+            sudo yum groupinstall -y "Development Tools"
+            sudo yum install -y \
+                 openssl openssl-devel \
+                 gmp-devel procps-devel cmake3 \
+                 python3 python3-devel \
+                 boost-devel
+        else
+            sudo apt install \
+                 libboost-dev \
+                 libboost-system-dev \
+                 libboost-filesystem-dev \
+                 libboost-program-options-dev \
+                 libgmp-dev \
+                 libprocps-dev \
+                 libxslt1-dev \
+                 pkg-config
+        fi
+    fi
+}

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 
-platform=`uname`
-echo platform=${platform}
-echo "running against commit: "`git log --oneline --no-decorate -n 1`
-
 # Include the CI utils functions
+. scripts/build_utils.sh
 . scripts/ci_utils.sh
 
 set -x
 set -e
+
+# Init platform variables
+init_platform
+
+echo "running against commit: "`git log --oneline --no-decorate -n 1`
 
 function _setup_client() {
     pushd client

--- a/scripts/ci_utils.sh
+++ b/scripts/ci_utils.sh
@@ -147,6 +147,13 @@ function cpp_build_setup() {
         if (which apk) ; then
             # Packages already available in Docker build
             echo -n             # null op required for syntax
+        elif (which yum) ; then
+            sudo yum groupinstall -y "Development Tools"
+            sudo yum install -y \
+                 openssl openssl-devel \
+                 gmp-devel procps-devel cmake3 \
+                 python3 python3-devel \
+                 boost-devel
         else
             sudo apt install \
                  libboost-dev \

--- a/scripts/ci_utils.sh
+++ b/scripts/ci_utils.sh
@@ -97,13 +97,14 @@ function prover_server_is_active() {
     zeth get-verification-key
 }
 
+# 1 - prover server flags
 function prover_server_start() {
     # Requires the client env (for prover_server_is_active)
     . client/env/bin/activate
     pushd build
 
     server_start \
-        ./prover_server/prover_server \
+        "./prover_server/prover_server $1" \
         prover_server_is_active \
         prover_server.pid \
         prover_server.stdout

--- a/scripts/ci_utils.sh
+++ b/scripts/ci_utils.sh
@@ -3,6 +3,8 @@
 # All functions expect to be executed the root directory of the repository, and
 # will exit with this as the current directory.
 
+./scripts/build_utils.sh
+
 # Launch a server in the background and wait for it to be ready, recording the
 # pid in a file.
 #
@@ -48,6 +50,8 @@ function server_stop() {
 #
 
 function ganache_setup() {
+    assert_init_platform
+
     if [ "${platform}" == "Linux" ] ; then
         if (which apk) ; then
             apk add --update npm
@@ -117,53 +121,4 @@ function prover_server_stop() {
     pushd build
     server_stop prover_server prover_server.pid
     popd # build
-}
-
-#
-# DEPENDENCIES
-#
-
-function cpp_build_setup() {
-    # Extra deps for native builds
-
-    if [ "${platform}" == "Darwin" ] ; then
-        # Some of these commands can fail (if packages are already installed,
-        # etc), hence the `|| echo`.
-        brew update || echo
-        brew install \
-             gmp \
-             grpc \
-             protobuf \
-             boost \
-             openssl \
-             cmake \
-             libtool \
-             autoconf \
-             automake \
-             || echo
-    fi
-
-    if [ "${platform}" == "Linux" ] ; then
-        if (which apk) ; then
-            # Packages already available in Docker build
-            echo -n             # null op required for syntax
-        elif (which yum) ; then
-            sudo yum groupinstall -y "Development Tools"
-            sudo yum install -y \
-                 openssl openssl-devel \
-                 gmp-devel procps-devel cmake3 \
-                 python3 python3-devel \
-                 boost-devel
-        else
-            sudo apt install \
-                 libboost-dev \
-                 libboost-system-dev \
-                 libboost-filesystem-dev \
-                 libboost-program-options-dev \
-                 libgmp-dev \
-                 libprocps-dev \
-                 libxslt1-dev \
-                 pkg-config
-        fi
-    fi
 }

--- a/scripts/ec2_setup.sh
+++ b/scripts/ec2_setup.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# Installs dependencies and runs a build of all components required to execute
+# the zeth pipeline. Specialized for ec2 instances using the 'yum' package
+# manager.
+
+if ! (which yum) ; then
+    echo ERROR: yum package manager not found.
+    exit 1
+fi
+
+set -e
+set -x
+
+#
+# Dependencies
+#
+
+# Packages
+sudo yum groupinstall -y "Development Tools"
+sudo yum install -y \
+     openssl openssl-devel \
+     gmp-devel procps-devel cmake3 \
+     python3 python3-devel \
+     boost-devel \
+     emacs-nox
+sudo ln -sf /usr/bin/cmake3 /usr/local/bin/cmake
+
+# Library directories
+sudo sh -c 'echo /usr/local/lib > /etc/ld.so.conf.d/local-x86_64.conf'
+sudo ldconfig
+
+# Install grpc
+scripts/install_grpc /usr/local v1.31.x
+
+# Install and activate nodejs
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+. ~/.nvm/nvm.sh
+nvm install 10
+
+# Setup ganache
+pushd zeth_contracts
+npm config set python python2.7
+npm config set engine-strict true
+npm config set unsafe-perm true
+npm install --unsafe-perm
+popd
+
+#
+# Zeth-specific setup
+#
+
+# Setup client
+pushd client
+python3 -m venv env
+. env/bin/activate
+make setup
+sudo ln -sf ~/.solcx/solc-* /usr/local/bin/solc
+popd
+
+# Prover server
+mkdir -p build
+pushd build
+    CMAKE_PREFIX_PATH=/usr/local cmake -DCMAKE_BUILD_TYPE=Release ..
+    make -j"$(($(nproc)+1))" prover_server zeth-tool
+popd

--- a/scripts/install_grpc
+++ b/scripts/install_grpc
@@ -3,11 +3,12 @@
 # This script is only intended to run on the CI machines. Not for local
 # development.
 
-# Expect 3 arguments, all non-empty.
-if [ "$#" -ne 3 ] || [ "" == "$1" ] || [ "" == "$2" ] || [ "" == "$3" ] ; then
+# Expect 2 arguments.
+if [ "" == "$1" ] || [ "" == "$2" ] ; then
    echo "error: invalid arguments"
-   echo "Usage: $0 <install-location> <version> <build-dir>"
+   echo "Usage: $0 <install-location> <version>"
    echo ""
+   echo "If env var INSTALL_ONLY=1, only run sudo make install"
    exit 1
 fi
 
@@ -16,62 +17,52 @@ set -x
 
 INSTALL_DIR=$1
 VERSION=$2
-BUILD_DIR=$3
 
-# This script executes in one of 2 modes on the CI:
-#
-# - No pre-existing build directory (DO_BUILD=1).
-#
-# - Pre-existing build directory, cached a previous successful build
-#   (DO_BUILD=0). In this case, installation can be performed directly.
+pushd depends
 
-if [ -d "${BUILD_DIR}" ] ; then
-    DO_BUILD=0
-else
-    DO_BUILD=1
-fi
-
-mkdir -p ${BUILD_DIR}
-pushd ${BUILD_DIR}
-
-    # Clone repo and submodules (if DO_BUILD == 1)
-    if [ "${DO_BUILD}" == "1" ] ; then
-        git clone --depth 1 -b ${VERSION} https://github.com/grpc/grpc .
-        git submodule update --depth 1 --init --recursive
+    if ! [ -d grpc ] ; then
+        git clone --depth 1 -b ${VERSION} https://github.com/grpc/grpc
+        git -C grpc submodule update --depth 1 --init --recursive
+    else
+        echo grpc directory already exists. skipping download.
     fi
 
-    # Install protobuf
-    pushd third_party/protobuf
-        if [ "${DO_BUILD}" == "1" ] ; then
-            [ -e ./configure ] || ./autogen.sh
-            DIST_LANG=cpp ./configure --prefix ${INSTALL_DIR}
-            make -j $(($(nproc)+1))
-        fi
-        sudo make install
-    popd # third_party/protobuf
+    pushd grpc
 
-    # Install grpc
-    mkdir -p build
-    pushd build
-        if [ "${DO_BUILD}" == "1" ] ; then
-            cmake \
-                -DCMAKE_PREFIX_PATH=${INSTALL_DIR}       \
-                -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}    \
-                -DCMAKE_BUILD_TYPE=Release               \
-                -DgRPC_INSTALL=ON                        \
-                -DgRPC_BUILD_TESTS=OFF                   \
-                -DBUILD_TESTING=OFF                      \
-                -DgRPC_SSL_PROVIDER=package              \
-                -DgRPC_PROTOBUF_PROVIDER=package         \
-                -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF      \
-                -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF        \
-                -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF \
-                -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF         \
-                -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF        \
-                ..
-            make -j"$(($(nproc)+1))"
-        fi
-        sudo make install
-    popd # build
+        # Install protobuf
+        pushd third_party/protobuf
+            if [ "${INSTALL_ONLY}" != "1" ] ; then
+                [ -e ./configure ] || ./autogen.sh
+                DIST_LANG=cpp ./configure --prefix ${INSTALL_DIR}
+                make -j $(($(nproc)+1))
+            fi
+            sudo make install
+        popd # third_party/protobuf
 
-popd # ${INSTALL_DEST}
+        # Install grpc
+        mkdir -p build
+        pushd build
+            if [ "${INSTALL_ONLY}" != "1" ] ; then
+                cmake \
+                    -DCMAKE_PREFIX_PATH=${INSTALL_DIR}       \
+                    -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}    \
+                    -DCMAKE_BUILD_TYPE=Release               \
+                    -DgRPC_INSTALL=ON                        \
+                    -DgRPC_BUILD_TESTS=OFF                   \
+                    -DBUILD_TESTING=OFF                      \
+                    -DgRPC_SSL_PROVIDER=package              \
+                    -DgRPC_PROTOBUF_PROVIDER=package         \
+                    -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF      \
+                    -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF        \
+                    -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF \
+                    -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF         \
+                    -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF        \
+                    ..
+                make -j"$(($(nproc)+1))"
+            fi
+            sudo make install
+        popd # build
+
+    popd # grpc
+
+popd # depends

--- a/scripts/install_grpc
+++ b/scripts/install_grpc
@@ -18,6 +18,11 @@ set -x
 INSTALL_DIR=$1
 VERSION=$2
 
+if [ "${INSTALL_ONLY}" != "1" ] ; then
+    . scripts/ci_utils.sh
+    cpp_build_setup
+fi
+
 pushd depends
 
     if ! [ -d grpc ] ; then

--- a/scripts/install_grpc
+++ b/scripts/install_grpc
@@ -4,7 +4,7 @@
 # development.
 
 # Expect 2 arguments.
-if [ "" == "$1" ] || [ "" == "$2" ] ; then
+if [ "$1" == "" ] || [ "$2" == "" ] ; then
    echo "error: invalid arguments"
    echo "Usage: $0 <install-location> <version>"
    echo ""
@@ -15,11 +15,13 @@ fi
 set -e
 set -x
 
+. scripts/build_utils.sh
+init_platform
+
 INSTALL_DIR=$1
 VERSION=$2
 
 if [ "${INSTALL_ONLY}" != "1" ] ; then
-    . scripts/ci_utils.sh
     cpp_build_setup
 fi
 

--- a/scripts/prover_profile.sh
+++ b/scripts/prover_profile.sh
@@ -1,0 +1,53 @@
+
+# Simple script to run the generic prover with some keys and witness data,
+# recording the output (including timing information) to separate files.
+#
+# DATA_DIR and CIRCUIT variables must be set such that the directory
+# ${DATA_DIR} contains the following files:
+#
+#   ${CIRCUIT}_pk.bin
+#   ${CIRCUIT}_vk.bin
+#   ${CIRCUIT}_assignment.bin
+#   ${CIRCUIT}_primary.bin
+#
+# The zeth-tool binary is expected to be in the path, or at ${ZETH_TOOL}.
+
+if [ "${DATA_DIR}" == "" ] ; then
+    echo "DATA_DIR var must be set (see comments in script)"
+    exit 1
+fi
+
+if [ "${CIRCUIT}" == "" ] ; then
+    echo "CIRCUIT var must be set (see comments in script)"
+    exit 1
+fi
+
+# If not given, use any zeth-tool in the path or a default location.
+if [ "${ZETH_TOOL}" == "" ] ; then
+    if (which zeth-tool) ; then
+        ZETH_TOOL=`which zeth-tool`
+    else
+        ZETH_TOOL=./zeth_tool/zeth-tool
+    fi
+fi
+
+PK=${DATA_DIR}/${CIRCUIT}_pk.bin
+VK=${DATA_DIR}/${CIRCUIT}_vk.bin
+ASSIGNMENT=${DATA_DIR}/${CIRCUIT}_assignment.bin
+PRIMARY_INPUT=${DATA_DIR}/${CIRCUIT}_primary.bin
+
+if [ "$1" == "" ] ; then
+    echo Usage: $0 '<tag>'
+    exit 1
+fi
+TAG=$1
+
+set -e
+set -x
+
+${ZETH_TOOL} prove --profile ${PK} ${ASSIGNMENT} proof.bin > ${CIRCUIT}_${TAG}_proof_1.txt
+${ZETH_TOOL} verify ${VK} ${PRIMARY_INPUT} proof.bin
+${ZETH_TOOL} prove --profile ${PK} ${ASSIGNMENT} proof.bin > ${CIRCUIT}_${TAG}_proof_2.txt
+${ZETH_TOOL} verify ${VK} ${PRIMARY_INPUT} proof.bin
+${ZETH_TOOL} prove --profile ${PK} ${ASSIGNMENT} proof.bin > ${CIRCUIT}_${TAG}_proof_3.txt
+${ZETH_TOOL} verify ${VK} ${PRIMARY_INPUT} proof.bin

--- a/scripts/set_jsinout.sh
+++ b/scripts/set_jsinout.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# client/zeth/core/constants.py:JS_INPUTS: int = 2
+# client/zeth/core/constants.py:JS_OUTPUTS: int = 2
+sed -i -e 's/JS_INPUTS: int = 2/JS_INPUTS: int = '$1'/g' client/zeth/core/constants.py
+sed -i -e 's/JS_OUTPUTS: int = 2/JS_OUTPUTS: int = '$1'/g' client/zeth/core/constants.py
+
+# libzeth/zeth_constants.hpp:static const size_t ZETH_NUM_JS_INPUTS = 2;
+# libzeth/zeth_constants.hpp:static const size_t ZETH_NUM_JS_OUTPUTS = 2;
+sed -i -e 's/static const size_t ZETH_NUM_JS_INPUTS = 2/static const size_t ZETH_NUM_JS_INPUTS = '$1'/g' libzeth/zeth_constants.hpp
+sed -i -e 's/static const size_t ZETH_NUM_JS_OUTPUTS = 2/static const size_t ZETH_NUM_JS_OUTPUTS = '$1'/g' libzeth/zeth_constants.hpp

--- a/zeth_tool/main.cpp
+++ b/zeth_tool/main.cpp
@@ -6,6 +6,7 @@
 #include "zeth_tool/dump_proof_cmd.hpp"
 #include "zeth_tool/joinsplit_circuit_cmd.hpp"
 #include "zeth_tool/prove_cmd.hpp"
+#include "zeth_tool/split_keypair_cmd.hpp"
 #include "zeth_tool/tool_common.hpp"
 #include "zeth_tool/verify_cmd.hpp"
 
@@ -39,6 +40,7 @@ int main(int argc, char **argv)
         {"prove", prove_cmd},
         {"dump-proof", dump_proof_cmd},
         {"joinsplit-circuit", joinsplit_circuit_cmd},
+        {"split-keypair", split_keypair_cmd},
     };
 
     zeth_command cmd;

--- a/zeth_tool/split_keypair_cmd.cpp
+++ b/zeth_tool/split_keypair_cmd.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) 2015-2021 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#include "zeth_tool/split_keypair_cmd.hpp"
+
+#include "libtool/tool_util.hpp"
+
+namespace zethtool
+{
+
+namespace commands
+{
+
+class split_keypair_cmd : public generic_subcommand<split_keypair_cmd>
+{
+public:
+    using base_class = generic_subcommand<split_keypair_cmd>;
+
+    split_keypair_cmd(
+        const std::string &subcommand_name, const std::string &description)
+        : base_class(subcommand_name, description)
+    {
+    }
+
+    template<typename ppT, typename snarkT>
+    int execute_generic(const global_options &)
+    {
+        ppT::init_public_params();
+        libff::inhibit_profiling_info = true;
+        libff::inhibit_profiling_counters = true;
+
+        typename snarkT::keypair keypair;
+        {
+            std::ifstream in_s = libtool::open_binary_input_file(keypair_file);
+            snarkT::keypair_read_bytes(keypair, in_s);
+        }
+
+        if (!vk_file.empty()) {
+            std::ofstream out_s = libtool::open_binary_output_file(vk_file);
+            snarkT::verification_key_write_bytes(keypair.vk, out_s);
+        }
+
+        if (!pk_file.empty()) {
+            std::ofstream out_s = libtool::open_binary_output_file(pk_file);
+            snarkT::proving_key_write_bytes(keypair.pk, out_s);
+        }
+
+        return 0;
+    }
+
+protected:
+    void initialize_suboptions(
+        boost::program_options::options_description &options,
+        boost::program_options::options_description &all_options,
+        boost::program_options::positional_options_description &pos) override
+    {
+        base_class::initialize_suboptions(options, all_options, pos);
+
+        options.add_options()(
+            "vk-file,v",
+            po::value<std::string>(),
+            "Verification key file (optional)")(
+            "pk-file,p",
+            po::value<std::string>(),
+            "Proving key file (optional)");
+
+        all_options.add(options).add_options()(
+            "keypair-file,k", po::value<std::string>(), "Keypair file");
+        pos.add("keypair-file", 1);
+    }
+
+    void parse_suboptions(
+        const boost::program_options::variables_map &vm) override
+    {
+        base_class::parse_suboptions(vm);
+
+        if (vm.count("keypair-file") == 0) {
+            throw po::error("keypair file not specified");
+        }
+
+        keypair_file = vm["keypair-file"].as<std::string>();
+        vk_file = vm.count("vk-file") ? vm["vk-file"].as<std::string>() : "";
+        pk_file = vm.count("pk-file") ? vm["pk-file"].as<std::string>() : "";
+
+        if (vk_file.empty() && pk_file.empty()) {
+            throw po::error("no VK or PK file specified");
+        }
+    }
+
+    void subcommand_usage(const char *argv0) override
+    {
+        std::cout << "Usage:\n"
+                     "  "
+                  << argv0 << " split-keypair <options> [keypair_file]\n";
+    }
+
+    std::string keypair_file;
+    std::string vk_file;
+    std::string pk_file;
+};
+
+} // namespace commands
+
+zeth_subcommand *split_keypair_cmd = new commands::split_keypair_cmd(
+    "split-keypair",
+    "Extract the verification key / proving key from a keypair.");
+
+} // namespace zethtool

--- a/zeth_tool/split_keypair_cmd.hpp
+++ b/zeth_tool/split_keypair_cmd.hpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2015-2021 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#ifndef __ZETH_TOOL_SPLIT_KEYPAIR_CMD_HPP__
+#define __ZETH_TOOL_SPLIT_KEYPAIR_CMD_HPP__
+
+#include "zeth_tool/tool_common.hpp"
+
+namespace zethtool
+{
+
+extern zeth_subcommand *split_keypair_cmd;
+
+} // namespace zethtool
+
+#endif // __ZETH_TOOL_SPLIT_KEYPAIR_CMD_HPP__


### PR DESCRIPTION
Scripts and tools related to generating zeth witness data for various JSIN/OUT values, 
- [x] `zeth-tool split-keypair` command
- [x] fixes and scripts for autmating witness data generation
- [x] improvements to some build scripts, support for building on ec2 instances
- [x] some verbose client output related to tx size

(Could potentially drop some of the commits directly related to data generation.  For now, leaving everything for discussion.)