### PR TITLE
Fix access specifiers in `gadget` inheritance tree

### DIFF
--- a/libzeth/circuits/binary_operation.hpp
+++ b/libzeth/circuits/binary_operation.hpp
@@ -70,7 +70,6 @@ public:
 /// however given the inputs are boolean, the output is automatically boolean
 template<typename FieldT> class xor_rot_gadget : public libsnark::gadget<FieldT>
 {
-
 private:
     const libsnark::pb_variable_array<FieldT> a;
     const libsnark::pb_variable_array<FieldT> b;
@@ -98,7 +97,6 @@ public:
 template<typename FieldT>
 class double_bit32_sum_eq_gadget : public libsnark::gadget<FieldT>
 {
-
 private:
     libsnark::pb_variable_array<FieldT> a;
     libsnark::pb_variable_array<FieldT> b;

--- a/libzeth/circuits/commitments/commitment.hpp
+++ b/libzeth/circuits/commitments/commitment.hpp
@@ -14,7 +14,7 @@ namespace libzeth
 {
 
 template<typename FieldT, typename HashT>
-class COMM_gadget : libsnark::gadget<FieldT>
+class COMM_gadget : public libsnark::gadget<FieldT>
 {
 private:
     // input variable block = {x, y}

--- a/libzeth/circuits/joinsplit.tcc
+++ b/libzeth/circuits/joinsplit.tcc
@@ -23,7 +23,7 @@ template<
     size_t NumInputs,
     size_t NumOutputs,
     size_t TreeDepth>
-class joinsplit_gadget : libsnark::gadget<FieldT>
+class joinsplit_gadget : public libsnark::gadget<FieldT>
 {
 private:
     const size_t digest_len_minus_field_cap =

--- a/libzeth/core/hash_stream.hpp
+++ b/libzeth/core/hash_stream.hpp
@@ -32,7 +32,7 @@ template<typename HashT> class hash_ostream_wrapper;
 template<typename HashT> class hash_istream_wrapper;
 
 /// Internal streambuf for hash_ostream. Hash and discard all written data.
-template<typename HashT> class hash_streambuf : private std::streambuf
+template<typename HashT> class hash_streambuf : public std::streambuf
 {
 protected:
     hash_streambuf();
@@ -44,7 +44,7 @@ protected:
 };
 
 /// Internal streambuf for wrapped streams. Hash data and forward.
-template<typename HashT> class hash_streambuf_wrapper : private std::streambuf
+template<typename HashT> class hash_streambuf_wrapper : public std::streambuf
 {
 protected:
     explicit hash_streambuf_wrapper(std::ostream *inner);

--- a/libzeth/core/hash_stream.hpp
+++ b/libzeth/core/hash_stream.hpp
@@ -32,7 +32,7 @@ template<typename HashT> class hash_ostream_wrapper;
 template<typename HashT> class hash_istream_wrapper;
 
 /// Internal streambuf for hash_ostream. Hash and discard all written data.
-template<typename HashT> class hash_streambuf : std::streambuf
+template<typename HashT> class hash_streambuf : private std::streambuf
 {
 protected:
     hash_streambuf();
@@ -44,7 +44,7 @@ protected:
 };
 
 /// Internal streambuf for wrapped streams. Hash data and forward.
-template<typename HashT> class hash_streambuf_wrapper : std::streambuf
+template<typename HashT> class hash_streambuf_wrapper : private std::streambuf
 {
 protected:
     explicit hash_streambuf_wrapper(std::ostream *inner);


### PR DESCRIPTION
See: #394 

As mentioned in the ticket linked above, the gadgets inheritances were inconsistent. Some gadgets like `joinsplit` or `COMM_gadget` had a private inheritance from `libsnark::gadget` and all others inherited publicly. So far the `libsnark::gadget` class is very small. Only one constructor (public) and 2 `protected` attributes. As such, public inheritance is not an issue. I think that this "public scopes by default" behavior is not desired. Instead, we should be strict with scopes and group attributes/methods by access specifier to control the interface of the classes in order to expose the strict necessary in the public interface of each class, and we should use `private` (or `protected` if needed) scopes by default and should modify this default behavior when using `public` scopes is justified. Likewise, we should specify scopes and access specifiers explicitly to crystalize the implementer's intention, instead of relying on default behavior. This allows to keep a good control over the children classes interfaces and forces to think about interfaces/API.
[EDIT:] Edited message further to discussions below.