### PR TITLE
Switched actions/checkout@v1 to v2

### DIFF
--- a/.github/workflows/onpullrequest-build-ubuntu.yml
+++ b/.github/workflows/onpullrequest-build-ubuntu.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         curve: [ BLS12_377, ALT_BN128 ]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: recursive
     - uses: actions/setup-node@v1
@@ -90,7 +90,7 @@ jobs:
       matrix:
         curve: [ BLS12_377, ALT_BN128 ]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: recursive
     - uses: actions/setup-node@v1

--- a/.github/workflows/onpush-build-ubuntu.yml
+++ b/.github/workflows/onpush-build-ubuntu.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: build-grpc
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: recursive
     - name: Cache grpc

--- a/.github/workflows/onpush-checks.yml
+++ b/.github/workflows/onpush-checks.yml
@@ -35,7 +35,7 @@ jobs:
   check-client:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: recursive
     - name: Cache pip
@@ -49,7 +49,7 @@ jobs:
   check-cpp-linux:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: recursive
     - name: Execute


### PR DESCRIPTION
As per the title, we seem to use `actions/checkout@v1` in some places in our CI scripts. I see no reason to stick to the v1. The v2 offers better perfs (among other) so I switch to `v2` everywhere. @dtebbs let me know if I miss something and you used `v1` at the specified locations for a specific reason!