### PR TITLE
Fix zeth helper

### DIFF
--- a/client/zeth/helper/eth_fund.py
+++ b/client/zeth/helper/eth_fund.py
@@ -30,7 +30,8 @@ def eth_fund(
         amount: int) -> None:
     """
     Fund an address. If no source address is given, the first hosted account on
-    the RPC host is used.
+    the RPC host is used. This command should only be used in test environments
+    such as ganache or autonity-helloworld.
     """
     eth_addr = load_eth_address(eth_addr)
     eth_network = get_eth_network(ctx.obj["eth_network"])


### PR DESCRIPTION
- Fixed missing conversion to checksum for flag value in `zeth-helper eth-fund`
- The `eth-fund` command fails with the following error:
```
  File "<path-to-zeth>/zeth/client/env/lib/python3.7/site-packages/web3/middleware/validation.py", line 77, in check_extradata_length
    len(result), MAX_EXTRADATA_LENGTH, result
web3.exceptions.ExtraDataLengthError: The field extraData is 495 bytes, but should be 32. It is quite likely that you are connected to a POA chain. Refer to http://web3py.readthedocs.io/en/stable/middleware.html#geth-style-proof-of-authority for more details. The full extraData is: HexBytes('0xf901ecf896d89411345428e41
```