### PR TITLE
Util script fix

### DIFF
--- a/scripts/ci_utils.sh
+++ b/scripts/ci_utils.sh
@@ -3,7 +3,7 @@
 # All functions expect to be executed the root directory of the repository, and
 # will exit with this as the current directory.
 
-./scripts/build_utils.sh
+. scripts/build_utils.sh
 
 # Launch a server in the background and wait for it to be ready, recording the
 # pid in a file.


### PR DESCRIPTION
Issue in ci util scripts (ci_utils.sh executes instead of sourcing build_utils.sh, which should not work).  This issue was shown up when trying to update zeth in zecale.  It's not clear to me why this works in this repo, but not in zecale.