### PR TITLE
Ran codespell and fixed typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # Sets the env vars PROJECT_SOURCE_DIR, and PROJECT_BINARY_DIR
 project(zeth CXX)
 
-# Versionning of the project
+# Versioning of the project
 set(ZETH_VERSION_MAJOR 0)
 set(ZETH_VERSION_MINOR 8)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,14 +12,14 @@ Coding standards are described in full [here](CODING_STANDARDS.md).
 ## Pull Request Process
 
 1. Ensure any install or build dependencies are removed from your branch before opening a Pull Request.
-   Furthermore, please do make sure to extend the [.gitignore](./.gitignore) file to keep unecessary files
+   Furthermore, please do make sure to extend the [.gitignore](./.gitignore) file to keep unnecessary files
    outside of the version control.
 2. Update the README.md files and the relevant code comments with details of changes to the interface.
    This includes: new environment variables, exposed ports, useful file locations and container parameters for instance.
 3. If the Pull Request requires a version change (e.g. a "fix" or new release), increase the version numbers in all relevant files.
    The versioning scheme we use is [SemVer][semver].
 4. All Pull Requests must be reviewed by a code owner. While under review, a code owner may ask the Pull Request author to *rebase*
-   her branch on top of the targetted "base" branch. If so, please be sure to *rebase* on top of the base branch (and *not merge*
+   her branch on top of the targeted "base" branch. If so, please be sure to *rebase* on top of the base branch (and *not merge*
    the base branch in your branch), as we strive to avoid duplicated merge commits in the git history (merging is a unidirectional
    process e.g. `master < develop < feature` or `master < hotfix`).
 5. Once approved, the Pull Request is merged by one of the code owners.

--- a/client/zeth/cli/utils.py
+++ b/client/zeth/cli/utils.py
@@ -422,7 +422,7 @@ def parse_output(output_str: str) -> Tuple[ZethAddressPub, EtherValue]:
     """
     Parse a string of the form "<receiver_pub_address>,<value>" to an output
     specification. <receiver_pub_address> can be a file name containing the
-    address. "<value>" is interpretted as the <default-address-file>,<value>.
+    address. "<value>" is interpreted as the <default-address-file>,<value>.
     """
     parts = output_str.split(",")
     if len(parts) == 1:

--- a/client/zeth/core/mimc.py
+++ b/client/zeth/core/mimc.py
@@ -27,7 +27,7 @@ from typing import List
 
 class MiMCBase(ITreeHash):
     """
-    Base class of MiMC implmentations.
+    Base class of MiMC implementations.
     """
     def __init__(
             self,

--- a/client/zeth/core/mixer_client.py
+++ b/client/zeth/core/mixer_client.py
@@ -515,7 +515,7 @@ class MixerClient:
 
         If for_dispatch_call is set, the parameters are to be passed to the
         Mixer's `dispatch` call in a later operation (in which proof data is
-        not available), hence proof is ommitted from the signature.
+        not available), hence proof is omitted from the signature.
         """
 
         # Encrypt the notes
@@ -559,7 +559,7 @@ class MixerClient:
         Convenience function around creation of MixCallDescription, ProofInputs,
         Proof and MixParameters. If for_dispatch_call is set, the parameters
         are to be passed to the Mixer's `dispatch` call in a later operation
-        (in which proof data is not available), hence proof is ommitted from
+        (in which proof data is not available), hence proof is omitted from
         the signature.
         """
         # Generate prover inputs and signing key
@@ -671,7 +671,7 @@ def joinsplit_sign(
     the hash of the ciphers and inputs for consistency. If for_dispatch_call is
     set, the parameters are to be passed to the Mixer's `dispatch` call in a
     later operation (in which proof data is not available), hence proof is
-    ommitted from the signature.
+    omitted from the signature.
     """
     assert len(ciphertexts) == constants.JS_INPUTS
 

--- a/debug/analyzer/parse_r1cs.py
+++ b/debug/analyzer/parse_r1cs.py
@@ -76,7 +76,7 @@ def get_constraints(constraints_set, annotation_index):
 
 def get_constraints_from_annotation_pattern(constraints_set, annotation_pattern):
     """
-    Returns a set fo constraints which annotation matches the given pattern.
+    Returns a set of constraints which annotation matches the given pattern.
     The regex is given by the user (which can be quite dangerous but
     the goal of this script is not to be robust anyway)
     """
@@ -120,7 +120,7 @@ if __name__ == "__main__":
     r1cs_variables_nb = r1cs_obj["num_variables"]
     r1cs_constraints_nb = r1cs_obj["num_constraints"]
 
-    print("R1CS succesfully loaded, vars: {}, constraints: {}"
+    print("R1CS successfully loaded, vars: {}, constraints: {}"
             .format(r1cs_variables_nb, r1cs_variables_nb))
 
     variables_annotations_set = r1cs_obj["variables_annotations"]

--- a/libzeth/circuits/blake2s/blake2s_comp.tcc
+++ b/libzeth/circuits/blake2s/blake2s_comp.tcc
@@ -138,7 +138,7 @@ void BLAKE2s_256_comp<FieldT>::generate_r1cs_witness(
         gadget.generate_r1cs_witness();
     }
 
-    // Retrieve values, swap endiannes of each bit32 and append them to get
+    // Retrieve values, swap endianness of each bit32 and append them to get
     // final output
     std::vector<FieldT> output_conversion;
     for (size_t i = 0; i < 8; i++) {

--- a/libzeth/circuits/joinsplit.tcc
+++ b/libzeth/circuits/joinsplit.tcc
@@ -88,7 +88,7 @@ private:
     // inputs above are allocated first, so only the first
     // get_num_public_elements allocated by this gadget are "public").
 
-    // Total amount transfered in the transaction
+    // Total amount transferred in the transaction
     libsnark::pb_variable_array<FieldT> zk_total_uint64;
     // List of all spending keys
     std::array<std::shared_ptr<libsnark::digest_variable<FieldT>>, NumInputs>
@@ -356,7 +356,7 @@ public:
                 pb, ZERO, a_sks[i]->bits, h_sig->bits, i, h_is[i]));
         }
 
-        // Ouput note gadgets for commitments as well as PRF gadgets for the
+        // Output note gadgets for commitments as well as PRF gadgets for the
         // rho_is
         for (size_t i = 0; i < NumOutputs; i++) {
             rho_i_gadgets[i].reset(new PRF_rho_gadget<FieldT, HashT>(

--- a/libzeth/circuits/mimc/mimc_permutation.hpp
+++ b/libzeth/circuits/mimc/mimc_permutation.hpp
@@ -12,7 +12,7 @@ namespace libzeth
 
 /// MiMC_permutation_gadget enforces correct computation of the MiMC
 /// permutation, denoted MiMC_r(k, m) in the Zeth specifications
-/// (https://github.com/clearmatics/zeth-specifications), by peforming
+/// (https://github.com/clearmatics/zeth-specifications), by performing
 /// NumRounds MiMC rounds with the given Exponent. An optional `add_to_result`
 /// value can be passed in to be added to the result of the regular MiMC
 /// permutation (without requiring extra constraints).
@@ -23,7 +23,8 @@ private:
     // Round constants only available up to some maximum number of rounds. Note
     // that the instantiations used in this library do not use all 93 round
     // constants, but other instantiations may (in particular, see
-    // instantations for other curves in https://github.com/clearmatics/zecale).
+    // instantiations for other curves in
+    // https://github.com/clearmatics/zecale).
     static const size_t MaxRounds = 93;
     static_assert(
         NumRounds <= MaxRounds, "NumRounds must be less than MaxRounds");

--- a/libzeth/circuits/notes/note.hpp
+++ b/libzeth/circuits/notes/note.hpp
@@ -64,7 +64,7 @@ private:
     std::shared_ptr<merkle_path_authenticator<FieldT, HashTreeT>>
         check_membership;
 
-    // Makes sure the a_pk is computed corectly from a_sk
+    // Makes sure the a_pk is computed correctly from a_sk
     std::shared_ptr<PRF_addr_a_pk_gadget<FieldT, HashT>> spend_authority;
     // Makes sure the nullifiers are computed correctly from rho and a_sk
     std::shared_ptr<PRF_nf_gadget<FieldT, HashT>> expose_nullifiers;

--- a/libzeth/core/chacha_rng.cpp
+++ b/libzeth/core/chacha_rng.cpp
@@ -21,7 +21,7 @@ chacha_rng::chacha_rng(const void *seed, size_t seed_size)
     : data_used(sizeof(block))
 {
     // Copies behaviour of ChaChaRng::from_seed() from the referenced code.
-    // Use the first 8 words of seed(padding with 0 if necessary), as the key.
+    // Use the first 8 words of seed (padding with 0 if necessary) as the key.
     seed_size = std::min(seed_size, sizeof(key));
     memcpy(key, seed, seed_size);
     if (seed_size < sizeof(key)) {

--- a/libzeth/core/chacha_rng.cpp
+++ b/libzeth/core/chacha_rng.cpp
@@ -21,7 +21,7 @@ chacha_rng::chacha_rng(const void *seed, size_t seed_size)
     : data_used(sizeof(block))
 {
     // Copies behaviour of ChaChaRng::from_seed() from the referenced code.
-    // Use the first 8 words of seed(padding with 0 if necesary), as the key.
+    // Use the first 8 words of seed(padding with 0 if necessary), as the key.
     seed_size = std::min(seed_size, sizeof(key));
     memcpy(key, seed, seed_size);
     if (seed_size < sizeof(key)) {

--- a/libzeth/core/utils.hpp
+++ b/libzeth/core/utils.hpp
@@ -49,7 +49,7 @@ void hex_to_bytes(const std::string &hex, void *dest, size_t bytes);
 /// numbers, etc)
 void hex_to_bytes_reversed(const std::string &hex, void *dest, size_t bytes);
 
-/// Decode hexidecimal string to an std::string of bytes.
+/// Decode hexadecimal string to an std::string of bytes.
 std::string hex_to_bytes(const std::string &s);
 
 /// Encode bytes as a hex string. If `prefix` is true, the string is prepended

--- a/libzeth/mpc/groth16/mpc_hash.cpp
+++ b/libzeth/mpc/groth16/mpc_hash.cpp
@@ -9,7 +9,7 @@
 namespace libzeth
 {
 
-// In the text representation, use 16 x 4-byte words, (each representated as 8
+// In the text representation, use 16 x 4-byte words, (each represented as 8
 // digits + separator).
 using hash_repr_word = uint32_t;
 static const size_t HASH_REPR_WORD_SIZE = sizeof(hash_repr_word);

--- a/libzeth/mpc/groth16/mpc_utils.tcc
+++ b/libzeth/mpc/groth16/mpc_utils.tcc
@@ -142,7 +142,7 @@ srs_mpc_layer_L1<ppT> mpc_compute_linearcombination(
     // n = number of constraints in r1cs, or equivalently, n = deg(t(x))
     // t(x) being the target polynomial of the QAP
     // Note: In the code-base the target polynomial is also denoted Z
-    // as refered to as "the vanishing polynomial", and t is also used
+    // as referred to as "the vanishing polynomial", and t is also used
     // to represent the query point (aka "tau").
     const size_t n = qap.degree();
     const size_t num_variables = qap.num_variables();

--- a/libzeth/mpc/groth16/phase2.hpp
+++ b/libzeth/mpc/groth16/phase2.hpp
@@ -123,7 +123,7 @@ public:
     static srs_mpc_phase2_challenge<ppT> read(std::istream &in);
 };
 
-/// Reponse produced by participant in Phase2 of the SRS generation MPC.
+/// Response produced by participant in Phase2 of the SRS generation MPC.
 /// Implements the interfaces of StructuredT and ReadableT templates.
 template<typename ppT> class srs_mpc_phase2_response
 {
@@ -159,8 +159,8 @@ srs_mpc_phase2_accumulator<ppT> srs_mpc_phase2_begin(
     const srs_mpc_layer_L1<ppT> &layer_L1,
     size_t num_inputs);
 
-/// Outputs the public key (which includes the POK) for our secret. Correponds
-/// to steps 1 and 2 in "Computation", section 7.3 of [BoweGM17]
+/// Outputs the public key (which includes the POK) for our secret.
+/// Corresponds to steps 1 and 2 in "Computation", section 7.3 of [BoweGM17]
 template<typename ppT>
 srs_mpc_phase2_publickey<ppT> srs_mpc_phase2_compute_public_key(
     const mpc_hash_t transcript_digest,
@@ -254,7 +254,7 @@ srs_mpc_phase2_challenge<ppT> srs_mpc_phase2_compute_challenge(
 ///   accumulator, based on the final delta
 ///
 /// This function validates the transcript as a stream of publickey objects,
-/// outputing the encoding of the final delta in G1.
+/// outputting the encoding of the final delta in G1.
 template<typename ppT, bool enable_contribution_check = true>
 bool srs_mpc_phase2_verify_transcript(
     const mpc_hash_t initial_transcript_digest,

--- a/libzeth/serialization/stream_utils.hpp
+++ b/libzeth/serialization/stream_utils.hpp
@@ -57,7 +57,7 @@ template<
     void(WriterT)(const MemberT<CollectionT> &, std::ostream &)>
 void collection_write_bytes(const CollectionT &collection, std::ostream &out_s);
 
-/// Read a collection of group elements as bytes, usinng
+/// Read a collection of group elements as bytes, using
 /// group_elements_read_bytes.
 template<
     typename CollectionT,

--- a/libzeth/tests/circuits/blake2s_test.cpp
+++ b/libzeth/tests/circuits/blake2s_test.cpp
@@ -158,7 +158,7 @@ TEST(TestG, TestTrue)
     ASSERT_EQ(d2_expected.get_bits(pb), d2.get_bits(pb));
 }
 
-// The test correponds to blake2s(b"hello world")
+// The test corresponds to blake2s(b"hello world")
 // The test vectors were computed with hashlib's blake2s function
 TEST(TestBlake2sComp, TestTrue)
 {
@@ -268,7 +268,7 @@ TEST(TestBlake2sComp, TestTrue)
     ASSERT_EQ(expected.get_bits(pb), output.bits.get_bits(pb));
 }
 
-// The test correponds to blake2s(b"hello world")
+// The test corresponds to blake2s(b"hello world")
 // The test vectors were computed with hashlib's blake2s function
 TEST(TestBlake2s, TestTrue)
 {
@@ -349,7 +349,7 @@ TEST(TestBlake2s, TestTrue)
     ASSERT_EQ(expected.get_bits(pb), output.bits.get_bits(pb));
 }
 
-// The test correponds to blake2s(b"hello world")
+// The test corresponds to blake2s(b"hello world")
 // The test vectors were computed with hashlib's blake2s function
 TEST(TestBlake2s, TestTrue2)
 {

--- a/libzeth/tests/mpc/groth16/mpc_test.cpp
+++ b/libzeth/tests/mpc/groth16/mpc_test.cpp
@@ -866,7 +866,7 @@ TEST(MPCTests, Phase2TranscriptVerification)
         ASSERT_TRUE(contribution_found);
     }
 
-    // Verify and check for non-existant contribution
+    // Verify and check for non-existent contribution
     {
         mpc_hash_t no_such_contribution;
         memset(no_such_contribution, 0, sizeof(mpc_hash_t));

--- a/libzeth/tests/prover/prover_test.cpp
+++ b/libzeth/tests/prover/prover_test.cpp
@@ -17,7 +17,7 @@
 
 // Use the default ppT and other options from the circuit code, but force the
 // Merkle tree depth to 4. Parameterize the test code on the snark, so that
-// this code can test all available snark schemes, indepedent of the build
+// this code can test all available snark schemes, independent of the build
 // configuration.
 
 static const size_t TreeDepth = 4;
@@ -436,7 +436,7 @@ void TestValidJS2In2Case3(
     typename snarkT::verification_key vk = keypair.vk;
     bool res = snarkT::verify(
         ext_proof.get_primary_inputs(), ext_proof.get_proof(), vk);
-    std::cout << "Does the proof verfy? " << res << std::endl;
+    std::cout << "Does the proof verify? " << res << std::endl;
     libff::leave_block("Verify proof", true);
 
     std::cout << "[DEBUG] Displaying the extended proof" << std::endl;

--- a/mpc_tools/mpc_phase2/cli/README.md
+++ b/mpc_tools/mpc_phase2/cli/README.md
@@ -6,12 +6,12 @@ and pre-computed Lagrange polynomials evaluations, as computed by the
 `powersoftau` command.
 
 cli executables can be implemented as `main` functions which call into the code
-in this library, passing in the set of commands ot make available, and a
+in this library, passing in the set of commands to make available, and a
 function to generate the circuit for the MPC.
 
 Commands are provided to:
   - generate initial "challenge" of the Phase 2 MPC
-  - compute participants' resonses to a given challenge
+  - compute participants' responses to a given challenge
   - verify a response and create a subsequent challeng
   - verify the auditable transcript of contributions
   - create a final keypair from the MPC output

--- a/mpc_tools/mpc_phase2/cli/mpc_linear_combination.cpp
+++ b/mpc_tools/mpc_phase2/cli/mpc_linear_combination.cpp
@@ -57,7 +57,7 @@ private:
             "pot-degree",
             po::value<size_t>(),
             "powersoftau degree (assumed equal to lagrange file)")(
-            "verify", "Skip compuation. Load and verify input data");
+            "verify", "Skip computation. Load and verify input data");
         all_options.add(options).add_options()(
             "powersoftau_file", po::value<std::string>(), "powersoftau file")(
             "lagrange_file", po::value<std::string>(), "lagrange file")(

--- a/mpc_tools/mpc_phase2/cli/mpc_phase2_verify_transcript.cpp
+++ b/mpc_tools/mpc_phase2/cli/mpc_phase2_verify_transcript.cpp
@@ -192,10 +192,11 @@ private:
                      final_transcript_digest,
                      sizeof(mpc_hash_t))) {
             throw std::invalid_argument(
-                "invalid transcript digest in final accumlator");
+                "invalid transcript digest in final accumulator");
         }
         if (final_challenge.accumulator.delta_g1 != final_delta) {
-            throw std::invalid_argument("invalid delta_g1 in final accumlator");
+            throw std::invalid_argument(
+                "invalid delta_g1 in final accumulator");
         }
         if (!srs_mpc_phase2_update_is_consistent(
                 challenge_0.accumulator, final_challenge.accumulator)) {

--- a/proto/zeth/api/ec_group_messages.proto
+++ b/proto/zeth/api/ec_group_messages.proto
@@ -23,7 +23,7 @@ message Group1Point {
 // The points in G2 are represented in affine form. Coordinates are encoded as
 // JSON objects containing hexadecimal strings. Depending on the pairing,
 // coordinates may be in the base field (simple strings, as for G1) or in
-// extension fields (JSON arrays of stings).
+// extension fields (JSON arrays of strings).
 //
 // e.g. Let A be a `Group2Point` message. Then `A` is of the form:
 // ```

--- a/scripts/mimc_constraints.sage
+++ b/scripts/mimc_constraints.sage
@@ -44,7 +44,7 @@ def output_valid_config_and_constraints(r, log_2_r, e):
         mults = compute_mults(e)
         rounds = ceil(log_2_r / log(e, 2))
         constraints = mults * rounds + 1
-        print(f"  e={e}, rounds={rounds}, mults={mults}, contraints={constraints}")
+        print(f"  e={e}, rounds={rounds}, mults={mults}, constraints={constraints}")
 
 
 def output_valid_configs_and_constraints(r):

--- a/scripts/test-zeth-cli
+++ b/scripts/test-zeth-cli
@@ -4,7 +4,7 @@ set -e
 set -x
 
 if ! [ "$1" == "" ] ; then
-    echo == RUNING ON NETWORK: $1 ==
+    echo == RUNNING ON NETWORK: $1 ==
     eth_network=$1
 else
     eth_network=

--- a/scripts/test-zeth-cli-token
+++ b/scripts/test-zeth-cli-token
@@ -18,7 +18,7 @@ ALICE_DIR=${BASE_DIR}/alice
 BOB_DIR=${BASE_DIR}/bob
 CHARLIE_DIR=${BASE_DIR}/charlie
 
-# Setup addresss
+# Setup address
 
 mkdir -p ${BASE_DIR}
 pushd ${BASE_DIR}

--- a/zeth_contracts/contracts/LibGroth16AltBN128.sol
+++ b/zeth_contracts/contracts/LibGroth16AltBN128.sol
@@ -103,7 +103,7 @@ library LibGroth16AltBN128
         //  ready to call bn256Add(in: 0x00, out: 0x00) to update accum_x,
         //  accum_y in place.
 
-        // Memory scratch pad, large enough to accomodate the above layout.
+        // Memory scratch pad, large enough to accommodate the above layout.
         uint256[24] memory pad;
         bool success = true;
         uint256 vk_slot_num;

--- a/zeth_contracts/contracts/LibGroth16BLS12_377.sol
+++ b/zeth_contracts/contracts/LibGroth16BLS12_377.sol
@@ -90,7 +90,7 @@ library LibGroth16BLS12_377
         //   0x000    accum_x                         --    --
 
         assembly {
-            // Copied from bn implemenation in zeth.
+            // Copied from bn implementation in zeth.
             let g := sub(gas(), 2000)
 
             // Compute starting slot of the vk data and abc data.

--- a/zeth_tool/README.md
+++ b/zeth_tool/README.md
@@ -4,6 +4,6 @@ Primarily designed for performing fine-grained operations, either outside of the
 
 Examples include, generation of arbitrary proofs (given a proving key and full assignment), verification of arbitrary proofs (given a proof, verification key and primary input), re-serialization of objects (e.g. conversion to/from binary, JSON etc).
 
-Since the tool is more development / administration focussed, not all functionality is necessarily complete, and may be extended as required in the future (possibly including operations that are specific to the zeth circuit).
+Since the tool is more development / administration focused, not all functionality is necessarily complete, and may be extended as required in the future (possibly including operations that are specific to the zeth circuit).
 
 To build, run `make zeth-tool` in the `build` directory (see the [main README](../README.md)) to build to executable at `build/zeth_tool/zeth-tool`. Run `zeth-tool help` (with the appropriate path to the executable) to see the up-to-date list of supported commands.


### PR DESCRIPTION
Related to: https://github.com/clearmatics/zeth/issues/405

Ran:
```
codespell --skip ./client/env/*,./zeth_contracts/node_modules/*,./build/*,./zeth_contracts/env/*,./client/.mypy_cache/*,./.git/*,./depends/*,./mpc/.mypy_cache/* --ignore-words-list GroupT,keypair
```

and fixed detected typos.