### PR TITLE
Ci fix

### DIFF
--- a/.github/workflows/dev-docs.yml
+++ b/.github/workflows/dev-docs.yml
@@ -12,10 +12,10 @@ jobs:
     - name: Cache grpc
       uses: actions/cache@v2
       with:
-        key: grpc-1.31.x-${{ runner.os }}
+        key: grpc-1.32.x-${{ runner.os }}
         path: depends/grpc
     - name: Build grpc
-      run: if ! [ -d depends/grpc ] ; then scripts/install-grpc /usr v1.31.x ; fi
+      run: if ! [ -d depends/grpc ] ; then scripts/install-grpc /usr v1.32.x ; fi
 
   build-documentation:
     runs-on: ubuntu-20.04
@@ -28,7 +28,7 @@ jobs:
     - name: Cache grpc
       uses: actions/cache@v2
       with:
-        key: grpc-1.31.x-${{ runner.os }}
+        key: grpc-1.32.x-${{ runner.os }}
         path: depends/grpc
     - name: Install dependencies
       run: |
@@ -36,7 +36,7 @@ jobs:
         source scripts/build_utils.sh
         init_platform
         cpp_build_setup
-        INSTALL_ONLY=1 scripts/install-grpc /usr v1.31.x
+        INSTALL_ONLY=1 scripts/install-grpc /usr v1.32.x
         sudo apt install -y doxygen graphviz
     - name: Generate documentation
       run: |

--- a/.github/workflows/onpullrequest-build-ubuntu.yml
+++ b/.github/workflows/onpullrequest-build-ubuntu.yml
@@ -19,10 +19,10 @@ jobs:
     - name: Cache grpc
       uses: actions/cache@v2
       with:
-        key: grpc-1.31.x-${{ runner.os }}
+        key: grpc-1.32.x-${{ runner.os }}
         path: depends/grpc
     - name: Build grpc
-      run: if ! [ -d depends/grpc ] ; then scripts/install-grpc /usr v1.31.x ; fi
+      run: if ! [ -d depends/grpc ] ; then scripts/install-grpc /usr v1.32.x ; fi
 
   # Extract the commits of submodules for use by cache steps
   onpr-submodules:
@@ -51,7 +51,7 @@ jobs:
     - name: Cache grpc
       uses: actions/cache@v2
       with:
-        key: grpc-1.31.x-${{ runner.os }}
+        key: grpc-1.32.x-${{ runner.os }}
         path: depends/grpc
     - name: Cache pip
       uses: actions/cache@v2
@@ -62,7 +62,7 @@ jobs:
         key: prover-tests-pip-${{ hashFiles('**/setup.py') }}-${{ runner.os }}
     - name: Install dependencies
       run: |
-        INSTALL_ONLY=1 scripts/install-grpc /usr v1.31.x
+        INSTALL_ONLY=1 scripts/install-grpc /usr v1.32.x
         sudo apt install -y ccache
     - name: Execute
       run: CI_CONFIG=Release CI_CURVE=${{ matrix.curve }} CI_PROVER_TESTS=1 scripts/ci build
@@ -81,7 +81,7 @@ jobs:
     - name: Cache grpc
       uses: actions/cache@v2
       with:
-        key: grpc-1.31.x-${{ runner.os }}
+        key: grpc-1.32.x-${{ runner.os }}
         path: depends/grpc
     - name: Cache pip
       uses: actions/cache@v2
@@ -92,7 +92,7 @@ jobs:
         key: integration-tests-pip-${{ hashFiles('**/setup.py') }}-${{ runner.os }}
     - name: Install dependencies
       run: |
-        INSTALL_ONLY=1 scripts/install-grpc /usr v1.31.x
+        INSTALL_ONLY=1 scripts/install-grpc /usr v1.32.x
         sudo apt install -y ccache
     - name: Execute
       run: CI_CONFIG=Release CI_CURVE=${{ matrix.curve }} CI_FULL_TESTS=1 CI_INTEGRATION_TESTS=1 scripts/ci build

--- a/.github/workflows/onpush-build-ubuntu.yml
+++ b/.github/workflows/onpush-build-ubuntu.yml
@@ -19,10 +19,10 @@ jobs:
     - name: Cache grpc
       uses: actions/cache@v2
       with:
-        key: grpc-1.31.x-${{ runner.os }}
+        key: grpc-1.32.x-${{ runner.os }}
         path: depends/grpc
     - name: Build grpc
-      run: if ! [ -d depends/grpc ] ; then scripts/install-grpc /usr v1.31.x ; fi
+      run: if ! [ -d depends/grpc ] ; then scripts/install-grpc /usr v1.32.x ; fi
 
   build-linux:
     runs-on: ubuntu-20.04
@@ -37,7 +37,7 @@ jobs:
     - name: Cache grpc
       uses: actions/cache@v2
       with:
-        key: grpc-1.31.x-${{ runner.os }}
+        key: grpc-1.32.x-${{ runner.os }}
         path: depends/grpc
     - name: Cache pip (for mpc tests)
       uses: actions/cache@v2
@@ -46,7 +46,7 @@ jobs:
         key: build-linux-pip-${{ hashFiles('**/setup.py') }}-${{ runner.os }}
     - name: Install dependencies
       run: |
-        INSTALL_ONLY=1 scripts/install-grpc /usr v1.31.x
+        INSTALL_ONLY=1 scripts/install-grpc /usr v1.32.x
         sudo apt install -y ccache
     - name: Execute
       run: CI_CHECK_FORMAT=1 CI_MPC_TESTS=1 CI_CONFIG=${{ matrix.config }} scripts/ci build
@@ -61,11 +61,11 @@ jobs:
     - name: Cache grpc
       uses: actions/cache@v2
       with:
-        key: grpc-1.31.x-${{ runner.os }}
+        key: grpc-1.32.x-${{ runner.os }}
         path: depends/grpc
     - name: Install dependencies
       run: |
-        INSTALL_ONLY=1 scripts/install-grpc /usr v1.31.x
+        INSTALL_ONLY=1 scripts/install-grpc /usr v1.32.x
         sudo apt install -y ccache
     - name: Execute
       run: CI_CONFIG=Release CI_ZKSNARK=PGHR13 scripts/ci build
@@ -80,11 +80,11 @@ jobs:
     - name: Cache grpc
       uses: actions/cache@v2
       with:
-        key: grpc-1.31.x-${{ runner.os }}
+        key: grpc-1.32.x-${{ runner.os }}
         path: depends/grpc
     - name: Install dependencies
       run: |
-        INSTALL_ONLY=1 scripts/install-grpc /usr v1.31.x
+        INSTALL_ONLY=1 scripts/install-grpc /usr v1.32.x
         sudo apt install -y ccache
     - name: Execute
       run: CI_CONFIG=Release CI_CURVE=BLS12_377 scripts/ci build

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -31,7 +31,7 @@ RUN apk --update --no-cache add \
         vim \
         curl
 
-RUN git clone -b v1.31.x https://github.com/grpc/grpc /var/local/git/grpc
+RUN git clone -b v1.32.x https://github.com/grpc/grpc /var/local/git/grpc
 RUN cd /var/local/git/grpc && git submodule update --init --recursive
 
 # Build protobuf independently and install libraries in /usr/lib

--- a/mpc/setup.py
+++ b/mpc/setup.py
@@ -33,6 +33,11 @@ setup(
         "ecdsa==0.13.3",
         "click==7.0",
         "requests==2.22.0",
+        # flask constraints on dependencies are too loose. Constrain the
+        # versions here to avoid CI failures.
+        "Jinja2==3.0.3",
+        "itsdangerous==2.0.1",
+        "Werkzeug==2.0.2",
     ],
     scripts=[
         "commands/phase1_server",

--- a/scripts/ec2-setup
+++ b/scripts/ec2-setup
@@ -31,7 +31,7 @@ sudo sh -c 'echo /usr/local/lib > /etc/ld.so.conf.d/local-x86_64.conf'
 sudo ldconfig
 
 # Install grpc
-scripts/install-grpc /usr/local v1.31.x
+scripts/install-grpc /usr/local v1.32.x
 
 # Install and activate nodejs
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash


### PR DESCRIPTION
Fix some sudden CI breakages:
- [x] grpc repo uses `git://` references for submodules (no longer supported by public github access)
- [x] flask has loose dependency specifications, and pulls in new incompatible versions of several dependencies.  (Note, I tried upgrading to a later minor version, but this resulted in similar dependency issues.  For simplicity I've added package restrictions in the mpc `setup.py`, whcih can be removed if we upgrade the flask dependency in the future.)