### PR TITLE
Build fix

### DIFF
--- a/libzeth/tests/circuits/simple_test.cpp
+++ b/libzeth/tests/circuits/simple_test.cpp
@@ -12,6 +12,7 @@
 #include "serialization/r1cs_variable_assignment_serialization.hpp"
 
 #include <boost/filesystem.hpp>
+#include <fstream>
 #include <gtest/gtest.h>
 #include <libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp>
 #include <libff/algebra/curves/bls12_377/bls12_377_pp.hpp>

--- a/libzeth/tests/core/ec_operation_data_test.cpp
+++ b/libzeth/tests/core/ec_operation_data_test.cpp
@@ -7,6 +7,7 @@
 #include "libzeth/serialization/proto_utils.hpp"
 
 #include <boost/filesystem.hpp>
+#include <fstream>
 #include <gtest/gtest.h>
 #include <libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp>
 #include <libff/algebra/curves/bls12_377/bls12_377_pp.hpp>

--- a/libzeth/tests/snarks/groth16/groth16_snark_test.cpp
+++ b/libzeth/tests/snarks/groth16/groth16_snark_test.cpp
@@ -8,6 +8,7 @@
 #include "libzeth/tests/snarks/common_snark_tests.tcc"
 
 #include <boost/filesystem.hpp>
+#include <fstream>
 #include <gtest/gtest.h>
 #include <libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp>
 #include <libff/algebra/curves/bls12_377/bls12_377_pp.hpp>


### PR DESCRIPTION
Fixes a build error related to clang-14, which is now the default for mac CI builds.
Fixes #428